### PR TITLE
[Recognizers-Text] [Java] Fix LocalDateTime with TimeZone exception

### DIFF
--- a/Java/tests/src/test/java/com/microsoft/recognizers/text/tests/TestCase.java
+++ b/Java/tests/src/test/java/com/microsoft/recognizers/text/tests/TestCase.java
@@ -3,6 +3,8 @@ package com.microsoft.recognizers.text.tests;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;

--- a/Java/tests/src/test/java/com/microsoft/recognizers/text/tests/TestCase.java
+++ b/Java/tests/src/test/java/com/microsoft/recognizers/text/tests/TestCase.java
@@ -6,6 +6,8 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class TestCase {
@@ -25,7 +27,9 @@ public class TestCase {
     public LocalDateTime getReferenceDateTime() {
         if (context != null && context.containsKey("ReferenceDateTime")) {
             Object objectDateTime = context.get("ReferenceDateTime");
-            return LocalDateTime.parse(objectDateTime.toString(), DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+            String formatPattern = getDateTimePattern(objectDateTime.toString());
+            DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern(formatPattern);
+            return ZonedDateTime.parse(objectDateTime.toString(), FORMATTER.withZone(ZoneId.systemDefault())).toLocalDateTime();
         }
 
         return LocalDateTime.now();
@@ -33,5 +37,45 @@ public class TestCase {
 
     public String toString() {
         return String.format("%sRecognizer - %s - %s - \"%s\"", this.recognizerName, this.language, this.modelName, this.input);
+    }
+
+    private String getDateTimePattern(String datetime) {
+        StringBuilder stringBuilder = new StringBuilder();
+        stringBuilder.append("yyyy-MM-dd'T'HH:mm:ss");
+        stringBuilder.append(getMillisecondsPatten(datetime, ".", "+"));
+        stringBuilder.append(getTimeZonePattern(datetime));
+
+        return stringBuilder.toString();
+    }
+
+    private String getMillisecondsPatten(String text, String leftBound, String rightBound) {
+        if (text.contains(leftBound)) {
+            String milliseconds = text.substring(text.indexOf(leftBound) + 1 , text.contains(rightBound) ? text.indexOf(rightBound) : text.length());
+            return leftBound + IntStream.range(0, milliseconds.length()).mapToObj(i -> "S").collect(Collectors.joining(""));
+        }
+
+        return "";
+    }
+
+    private String getTimeZonePattern(String text) {
+        if (text.contains("+")) {
+            String timezone = text.substring(text.indexOf("+") + 1);
+            switch (timezone.length()) {
+                case 2:
+                    return "X";
+                case 4:
+                    return "XX";
+                case 5:
+                    return "XXX";
+                case 6:
+                    return "XXXX";
+                case 8:
+                    return "XXXXX";
+                default:
+                    throw new Error("Time Zone format not supported.");
+            }
+        }
+
+        return "";
     }
 }


### PR DESCRIPTION
## Modifications
Fix an exception when `LocalDateTime` tries to parse a date with time zone.
Additionally, support for milliseconds was added. This was needed since one of the test cases uses milliseconds.
## Testing
A comparition was made before and after the modifications.
Before the modifications:
![image](https://user-images.githubusercontent.com/39467613/48861524-849a7500-eda2-11e8-92e7-86f336793d3b.png)

After the modifications:
![image](https://user-images.githubusercontent.com/39467613/48861545-8feda080-eda2-11e8-9c84-15c1b51bbdfa.png)
