### PR TITLE
[Java][Datetime] Port SpanishDurationExtractorConfiguration from C# to Java

### DIFF
--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/extractors/SpanishDurationExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/extractors/SpanishDurationExtractorConfiguration.java
@@ -1,0 +1,139 @@
+package com.microsoft.recognizers.text.datetime.spanish.extractors;
+
+import com.google.common.collect.ImmutableMap;
+import com.microsoft.recognizers.text.IExtractor;
+import com.microsoft.recognizers.text.datetime.DateTimeOptions;
+import com.microsoft.recognizers.text.datetime.config.BaseOptionsConfiguration;
+import com.microsoft.recognizers.text.datetime.extractors.config.IDurationExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.resources.SpanishDateTime;
+import com.microsoft.recognizers.text.number.spanish.extractors.CardinalExtractor;
+import com.microsoft.recognizers.text.utilities.RegExpUtility;
+
+import java.util.regex.Pattern;
+
+public class SpanishDurationExtractorConfiguration extends BaseOptionsConfiguration implements IDurationExtractorConfiguration {
+
+    //public static final Pattern UnitRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.UnitRegex);
+    public static final Pattern SuffixAndRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.SuffixAndRegex);
+    public static final Pattern FollowedUnit = RegExpUtility.getSafeRegExp(SpanishDateTime.FollowedUnit);
+    public static final Pattern NumberCombinedWithUnit = RegExpUtility.getSafeRegExp(SpanishDateTime.DurationNumberCombinedWithUnit);
+    public static final Pattern AnUnitRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.AnUnitRegex);
+    public static final Pattern DuringRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.DuringRegex);
+    public static final Pattern AllRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.AllRegex);
+    public static final Pattern HalfRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.HalfRegex);
+    public static final Pattern ConjunctionRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.ConjunctionRegex);
+    public static final Pattern InexactNumberRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.InexactNumberRegex);
+    public static final Pattern InexactNumberUnitRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.InexactNumberUnitRegex);
+    public static final Pattern RelativeDurationUnitRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.RelativeDurationUnitRegex);
+    public static final Pattern DurationUnitRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.DurationUnitRegex);
+    public static final Pattern DurationConnectorRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.DurationConnectorRegex);
+    public static final Pattern MoreThanRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.MoreThanRegex);
+    public static final Pattern LessThanRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.LessThanRegex);
+
+    private final IExtractor cardinalExtractor;
+    private final ImmutableMap<String, String> unitMap;
+    private final ImmutableMap<String, Long> unitValueMap;
+
+    public SpanishDurationExtractorConfiguration() {
+        this(DateTimeOptions.None);
+    }
+
+    public SpanishDurationExtractorConfiguration(DateTimeOptions options) {
+
+        super(options);
+
+        cardinalExtractor = CardinalExtractor.getInstance();
+        unitMap = SpanishDateTime.UnitMap;
+        unitValueMap = SpanishDateTime.UnitValueMap;
+    }
+
+    @Override
+    public Pattern getFollowedUnit() {
+        return FollowedUnit;
+    }
+
+    @Override
+    public Pattern getNumberCombinedWithUnit() {
+        return NumberCombinedWithUnit;
+    }
+
+    @Override
+    public Pattern getAnUnitRegex() {
+        return AnUnitRegex;
+    }
+
+    @Override
+    public Pattern getDuringRegex() {
+        return DuringRegex;
+    }
+
+    @Override
+    public Pattern getAllRegex() {
+        return AllRegex;
+    }
+
+    @Override
+    public Pattern getHalfRegex() {
+        return HalfRegex;
+    }
+
+    @Override
+    public Pattern getSuffixAndRegex() {
+        return SuffixAndRegex;
+    }
+
+    @Override
+    public Pattern getConjunctionRegex() {
+        return ConjunctionRegex;
+    }
+
+    @Override
+    public Pattern getInexactNumberRegex() {
+        return InexactNumberRegex;
+    }
+
+    @Override
+    public Pattern getInexactNumberUnitRegex() {
+        return InexactNumberUnitRegex;
+    }
+
+    @Override
+    public Pattern getRelativeDurationUnitRegex() {
+        return RelativeDurationUnitRegex;
+    }
+
+    @Override
+    public Pattern getDurationUnitRegex() {
+        return DurationUnitRegex;
+    }
+
+    @Override
+    public Pattern getDurationConnectorRegex() {
+        return DurationConnectorRegex;
+    }
+
+    @Override
+    public Pattern getLessThanRegex() {
+        return LessThanRegex;
+    }
+
+    @Override
+    public Pattern getMoreThanRegex() {
+        return MoreThanRegex;
+    }
+
+    @Override
+    public IExtractor getCardinalExtractor() {
+        return cardinalExtractor;
+    }
+
+    @Override
+    public ImmutableMap<String, String> getUnitMap() {
+        return unitMap;
+    }
+
+    @Override
+    public ImmutableMap<String, Long> getUnitValueMap() {
+        return unitValueMap;
+    }
+}

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/utilities/SpanishDatetimeUtilityConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/utilities/SpanishDatetimeUtilityConfiguration.java
@@ -30,68 +30,57 @@ public class SpanishDatetimeUtilityConfiguration implements IDateTimeUtilityConf
     public static final Pattern CommonDatePrefixRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.CommonDatePrefixRegex);
 
     @Override
-    public final Pattern getLaterRegex()
-    {
+    public final Pattern getLaterRegex() {
         return LaterRegex;
     }
 
     @Override
-    public final Pattern getAgoRegex()
-    {
+    public final Pattern getAgoRegex() {
         return AgoRegex;
     }
 
     @Override
-    public final Pattern getInConnectorRegex()
-    {
+    public final Pattern getInConnectorRegex() {
         return InConnectorRegex;
     }
 
     @Override
-    public final Pattern getWithinNextPrefixRegex()
-    {
+    public final Pattern getWithinNextPrefixRegex() {
         return WithinNextPrefixRegex;
     }
 
     @Override
-    public final Pattern getAmDescRegex()
-    {
+    public final Pattern getAmDescRegex() {
         return AmDescRegex;
     }
 
     @Override
-    public final Pattern getPmDescRegex()
-    {
+    public final Pattern getPmDescRegex() {
         return PmDescRegex;
     }
 
     @Override
-    public final Pattern getAmPmDescRegex()
-    {
+    public final Pattern getAmPmDescRegex() {
         return AmPmDescRegex;
     }
 
     @Override
-    public final Pattern getRangeUnitRegex()
-    {
+    public final Pattern getRangeUnitRegex() {
         return RangeUnitRegex;
     }
 
     @Override
-    public final Pattern getTimeUnitRegex()
-    {
+    public final Pattern getTimeUnitRegex() {
         return TimeUnitRegex;
     }
 
     @Override
-    public final Pattern getDateUnitRegex()
-    {
+    public final Pattern getDateUnitRegex() {
         return DateUnitRegex;
     }
 
     @Override
-    public final Pattern getCommonDatePrefixRegex()
-    {
+    public final Pattern getCommonDatePrefixRegex() {
         return CommonDatePrefixRegex;
     }
 }

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/utilities/SpanishDatetimeUtilityConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/utilities/SpanishDatetimeUtilityConfiguration.java
@@ -1,0 +1,97 @@
+package com.microsoft.recognizers.text.datetime.spanish.utilities;
+
+import com.microsoft.recognizers.text.datetime.resources.SpanishDateTime;
+import com.microsoft.recognizers.text.datetime.utilities.IDateTimeUtilityConfiguration;
+import com.microsoft.recognizers.text.utilities.RegExpUtility;
+
+import java.util.regex.Pattern;
+
+public class SpanishDatetimeUtilityConfiguration implements IDateTimeUtilityConfiguration {
+    public static final Pattern AgoRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.AgoRegex);
+
+    public static final Pattern LaterRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.LaterRegex);
+
+    public static final Pattern InConnectorRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.InConnectorRegex);
+
+    public static final Pattern WithinNextPrefixRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.WithinNextPrefixRegex);
+
+    public static final Pattern AmDescRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.AmDescRegex);
+
+    public static final Pattern PmDescRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.PmDescRegex);
+
+    public static final Pattern AmPmDescRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.AmPmDescRegex);
+
+    public static final Pattern RangeUnitRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.RangeUnitRegex);
+
+    public static final Pattern TimeUnitRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.TimeUnitRegex);
+
+    public static final Pattern DateUnitRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.DateUnitRegex);
+
+    public static final Pattern CommonDatePrefixRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.CommonDatePrefixRegex);
+
+    @Override
+    public final Pattern getLaterRegex()
+    {
+        return LaterRegex;
+    }
+
+    @Override
+    public final Pattern getAgoRegex()
+    {
+        return AgoRegex;
+    }
+
+    @Override
+    public final Pattern getInConnectorRegex()
+    {
+        return InConnectorRegex;
+    }
+
+    @Override
+    public final Pattern getWithinNextPrefixRegex()
+    {
+        return WithinNextPrefixRegex;
+    }
+
+    @Override
+    public final Pattern getAmDescRegex()
+    {
+        return AmDescRegex;
+    }
+
+    @Override
+    public final Pattern getPmDescRegex()
+    {
+        return PmDescRegex;
+    }
+
+    @Override
+    public final Pattern getAmPmDescRegex()
+    {
+        return AmPmDescRegex;
+    }
+
+    @Override
+    public final Pattern getRangeUnitRegex()
+    {
+        return RangeUnitRegex;
+    }
+
+    @Override
+    public final Pattern getTimeUnitRegex()
+    {
+        return TimeUnitRegex;
+    }
+
+    @Override
+    public final Pattern getDateUnitRegex()
+    {
+        return DateUnitRegex;
+    }
+
+    @Override
+    public final Pattern getCommonDatePrefixRegex()
+    {
+        return CommonDatePrefixRegex;
+    }
+}

--- a/Java/tests/src/test/java/com/microsoft/recognizers/text/tests/datetime/DateTimeExtractorTest.java
+++ b/Java/tests/src/test/java/com/microsoft/recognizers/text/tests/datetime/DateTimeExtractorTest.java
@@ -12,6 +12,7 @@ import com.microsoft.recognizers.text.datetime.config.BaseOptionsConfiguration;
 import com.microsoft.recognizers.text.datetime.config.IOptionsConfiguration;
 import com.microsoft.recognizers.text.datetime.english.extractors.*;
 import com.microsoft.recognizers.text.datetime.extractors.*;
+import com.microsoft.recognizers.text.datetime.spanish.extractors.SpanishDurationExtractorConfiguration;
 import com.microsoft.recognizers.text.tests.AbstractTest;
 import com.microsoft.recognizers.text.tests.TestCase;
 
@@ -78,6 +79,8 @@ public class DateTimeExtractorTest extends AbstractTest {
             switch (culture) {
                 case Culture.English:
                     return getEnglishExtractor(modelName);
+                case Culture.Spanish:
+                    return getSpanishExtractor(modelName);
                 default:
                     throw new AssumptionViolatedException("Extractor Type/Name not supported.");
             }
@@ -116,6 +119,42 @@ public class DateTimeExtractorTest extends AbstractTest {
                 return new BaseTimePeriodExtractor(new EnglishTimePeriodExtractorConfiguration());
             case "TimeZoneExtractor":
                 return new BaseTimeZoneExtractor(new EnglishTimeZoneExtractorConfiguration(DateTimeOptions.EnablePreview));
+
+            default:
+                throw new AssumptionViolatedException("Extractor Type/Name not supported.");
+        }
+    }
+
+    private static IDateTimeExtractor getSpanishExtractor(String name) {
+
+        IOptionsConfiguration config = new BaseOptionsConfiguration();
+        switch (name) {
+            //case "DateExtractor":
+            //    return new BaseDateExtractor(new SpanishDateExtractorConfiguration(config));
+            //case "DatePeriodExtractor":
+            //    return new BaseDatePeriodExtractor(new SpanishDatePeriodExtractorConfiguration());
+            //case "DateTimeAltExtractor":
+            //    return new BaseDateTimeAltExtractor(new SpanishDateTimeAltExtractorConfiguration());
+            //case "DateTimeExtractor":
+            //    return new BaseDateTimeExtractor(new SpanishDateTimeExtractorConfiguration());
+            //case "DateTimePeriodExtractor":
+            //    return new BaseDateTimePeriodExtractor(new SpanishDateTimePeriodExtractorConfiguration());
+            case "DurationExtractor":
+                return new BaseDurationExtractor(new SpanishDurationExtractorConfiguration());
+            //case "HolidayExtractor":
+            //    return new BaseHolidayExtractor(new SpanishHolidayExtractorConfiguration());
+            //case "MergedExtractor":
+            //   return new BaseMergedDateTimeExtractor(new SpanishMergedExtractorConfiguration(DateTimeOptions.None));
+            //case "MergedExtractorSkipFromTo":
+            //    return new BaseMergedDateTimeExtractor(new SpanishMergedExtractorConfiguration(DateTimeOptions.SkipFromToMerge));
+            //case "SetExtractor":
+            //    return new BaseSetExtractor(new SpanishSetExtractorConfiguration());
+            //case "TimeExtractor":
+            //    return new BaseTimeExtractor(new SpanishTimeExtractorConfiguration());
+            //case "TimePeriodExtractor":
+            //    return new BaseTimePeriodExtractor(new SpanishTimePeriodExtractorConfiguration());
+            //case "TimeZoneExtractor":
+            //    return new BaseTimeZoneExtractor(new SpanishTimeZoneExtractorConfiguration(DateTimeOptions.EnablePreview));
 
             default:
                 throw new AssumptionViolatedException("Extractor Type/Name not supported.");


### PR DESCRIPTION
**NOTE**: This PR is related to the [PR #1117](https://github.com/Microsoft/Recognizers-Text/pull/1117) and must be merged after it.

## Description
* Port SpanishDurationExtractorConfiguration from [C#](https://github.com/Microsoft/Recognizers-Text/blob/master/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishDurationExtractorConfiguration.cs) to Java
* Add SpanishExtractor's tests placeholder in DateTimeExtractorTest
* Enable SpanishDurationExtractor's tests

## Evidence
![image](https://user-images.githubusercontent.com/42191764/50652346-0b776b80-0f65-11e9-99bb-0ae3f1fe5583.png)
