### PR TITLE
[Java][DateTime] Port SpanishTime/SpanishTimeZoneExtractorConfiguration from C# to Java

### DIFF
--- a/Java/libraries/recognizers-text-choice/src/main/java/com/microsoft/recognizers/text/choice/extractors/ChoiceExtractor.java
+++ b/Java/libraries/recognizers-text-choice/src/main/java/com/microsoft/recognizers/text/choice/extractors/ChoiceExtractor.java
@@ -71,7 +71,7 @@ public class ChoiceExtractor implements IExtractor {
             return results;
         }
 
-        partialResults.sort(Comparator.comparingInt(er -> er.start));
+        partialResults.sort(Comparator.comparingInt(er -> er.getStart()));
 
         if (this.config.getOnlyTopMatch()) {
 
@@ -80,7 +80,7 @@ public class ChoiceExtractor implements IExtractor {
 
             for (int i = 0; i < partialResults.size(); i++) {
 
-                ChoiceExtractDataResult data = (ChoiceExtractDataResult)partialResults.get(i).data;
+                ChoiceExtractDataResult data = (ChoiceExtractDataResult)partialResults.get(i).getData();
                 if (data.score > topScore) {
                     topScore = data.score;
                     topResultIndex = i;

--- a/Java/libraries/recognizers-text-choice/src/main/java/com/microsoft/recognizers/text/choice/models/BooleanModel.java
+++ b/Java/libraries/recognizers-text-choice/src/main/java/com/microsoft/recognizers/text/choice/models/BooleanModel.java
@@ -23,11 +23,11 @@ public class BooleanModel extends ChoiceModel {
     @Override
     protected SortedMap<String, Object> getResolution(ParseResult parseResult) {
 
-        OptionsParseDataResult parseResultData = (OptionsParseDataResult)parseResult.data;
+        OptionsParseDataResult parseResultData = (OptionsParseDataResult)parseResult.getData();
         SortedMap<String, Object> results = new TreeMap<String, Object>();
         SortedMap<String, Object> otherMatchesMap = new TreeMap<String, Object>();
 
-        results.put("value", parseResult.value);
+        results.put("value", parseResult.getValue());
         results.put("score", parseResultData.score);
 
         for (OptionsOtherMatchParseResult otherMatchParseRes : parseResultData.otherMatches) {

--- a/Java/libraries/recognizers-text-choice/src/main/java/com/microsoft/recognizers/text/choice/models/ChoiceModel.java
+++ b/Java/libraries/recognizers-text-choice/src/main/java/com/microsoft/recognizers/text/choice/models/ChoiceModel.java
@@ -33,7 +33,7 @@ public abstract class ChoiceModel implements IModel {
         List<ParseResult> parseResults = extractResults.stream().map(exRes -> parser.parse(exRes)).collect(Collectors.toList());
         
         List<ModelResult> modelResults = parseResults.stream().map(
-            parseRes -> new ModelResult(parseRes.text, parseRes.start, parseRes.start + parseRes.length - 1, getModelTypeName(), getResolution(parseRes))
+            parseRes -> new ModelResult(parseRes.getText(), parseRes.getStart(), parseRes.getStart() + parseRes.getLength() - 1, getModelTypeName(), getResolution(parseRes))
         ).collect(Collectors.toList());
          
         return modelResults;

--- a/Java/libraries/recognizers-text-choice/src/main/java/com/microsoft/recognizers/text/choice/parsers/ChoiceParser.java
+++ b/Java/libraries/recognizers-text-choice/src/main/java/com/microsoft/recognizers/text/choice/parsers/ChoiceParser.java
@@ -21,12 +21,12 @@ public class ChoiceParser<T> implements IParser {
     public ParseResult parse(ExtractResult extractResult) {
 
         ParseResult parseResult = new ParseResult(extractResult);
-        ChoiceExtractDataResult data = (ChoiceExtractDataResult)extractResult.data;
+        ChoiceExtractDataResult data = (ChoiceExtractDataResult)extractResult.getData();
         Map<String, Boolean> resolutions = this.config.getResolutions();
         List<OptionsOtherMatchParseResult> matches = data.otherMatches.stream().map(match -> getOptionsOtherMatchResult(match)).collect(Collectors.toList());
 
-        parseResult = parseResult.withData(new OptionsParseDataResult(data.score, matches));
-        parseResult = parseResult.withValue(resolutions.getOrDefault(parseResult.type, false));
+        parseResult.setData(new OptionsParseDataResult(data.score, matches));
+        parseResult.setValue(resolutions.getOrDefault(parseResult.getType(), false));
 
         return parseResult;
     }
@@ -34,9 +34,9 @@ public class ChoiceParser<T> implements IParser {
     private OptionsOtherMatchParseResult getOptionsOtherMatchResult(ExtractResult extractResult) {
 
         ParseResult parseResult = new ParseResult(extractResult);
-        ChoiceExtractDataResult data = (ChoiceExtractDataResult)extractResult.data;
+        ChoiceExtractDataResult data = (ChoiceExtractDataResult)extractResult.getData();
         Map<String, Boolean> resolutions = this.config.getResolutions();
-        OptionsOtherMatchParseResult result = new OptionsOtherMatchParseResult(parseResult.text, resolutions.get(parseResult.type), data.score);
+        OptionsOtherMatchParseResult result = new OptionsOtherMatchParseResult(parseResult.getText(), resolutions.get(parseResult.getType()), data.score);
 
         return result;
     }

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/english/extractors/EnglishDateExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/english/extractors/EnglishDateExtractorConfiguration.java
@@ -25,45 +25,45 @@ import java.util.regex.Pattern;
 
 public class EnglishDateExtractorConfiguration extends BaseOptionsConfiguration implements IDateExtractorConfiguration {
 
-    public static final Pattern MonthRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.MonthRegex, Pattern.CASE_INSENSITIVE);
-    public static final Pattern DayRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.ImplicitDayRegex, Pattern.CASE_INSENSITIVE);
-    public static final Pattern MonthNumRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.MonthNumRegex, Pattern.CASE_INSENSITIVE);
-    public static final Pattern YearRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.YearRegex, Pattern.CASE_INSENSITIVE);
-    public static final Pattern WeekDayRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.WeekDayRegex, Pattern.CASE_INSENSITIVE);
-    public static final Pattern SingleWeekDayRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.SingleWeekDayRegex, Pattern.CASE_INSENSITIVE);
-    public static final Pattern OnRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.OnRegex, Pattern.CASE_INSENSITIVE);
+    public static final Pattern MonthRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.MonthRegex);
+    public static final Pattern DayRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.ImplicitDayRegex);
+    public static final Pattern MonthNumRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.MonthNumRegex);
+    public static final Pattern YearRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.YearRegex);
+    public static final Pattern WeekDayRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.WeekDayRegex);
+    public static final Pattern SingleWeekDayRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.SingleWeekDayRegex);
+    public static final Pattern OnRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.OnRegex);
     public static final Pattern RelaxedOnRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.RelaxedOnRegex);
-    public static final Pattern ThisRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.ThisRegex, Pattern.CASE_INSENSITIVE);
-    public static final Pattern LastDateRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.LastDateRegex, Pattern.CASE_INSENSITIVE);
-    public static final Pattern NextDateRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.NextDateRegex, Pattern.CASE_INSENSITIVE);
-    public static final Pattern DateUnitRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.DateUnitRegex, Pattern.CASE_INSENSITIVE);
-    public static final Pattern SpecialDayRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.SpecialDayRegex, Pattern.CASE_INSENSITIVE);
-    public static final Pattern WeekDayOfMonthRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.WeekDayOfMonthRegex, Pattern.CASE_INSENSITIVE);
-    public static final Pattern RelativeWeekDayRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.RelativeWeekDayRegex, Pattern.CASE_INSENSITIVE);
-    public static final Pattern SpecialDate = RegExpUtility.getSafeRegExp(EnglishDateTime.SpecialDate, Pattern.CASE_INSENSITIVE);
-    public static final Pattern SpecialDayWithNumRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.SpecialDayWithNumRegex, Pattern.CASE_INSENSITIVE);
-    public static final Pattern ForTheRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.ForTheRegex, Pattern.CASE_INSENSITIVE);
-    public static final Pattern WeekDayAndDayOfMonthRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.WeekDayAndDayOfMonthRegex, Pattern.CASE_INSENSITIVE);
-    public static final Pattern RelativeMonthRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.RelativeMonthRegex, Pattern.CASE_INSENSITIVE);
-    public static final Pattern PrefixArticleRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.PrefixArticleRegex, Pattern.CASE_INSENSITIVE);
-    public static final Pattern InConnectorRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.InConnectorRegex, Pattern.CASE_INSENSITIVE);
-    public static final Pattern RangeUnitRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.RangeUnitRegex, Pattern.CASE_INSENSITIVE);
-    public static final Pattern RangeConnectorSymbolRegex = RegExpUtility.getSafeRegExp(BaseDateTime.RangeConnectorSymbolRegex, Pattern.CASE_INSENSITIVE);
+    public static final Pattern ThisRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.ThisRegex);
+    public static final Pattern LastDateRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.LastDateRegex);
+    public static final Pattern NextDateRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.NextDateRegex);
+    public static final Pattern DateUnitRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.DateUnitRegex);
+    public static final Pattern SpecialDayRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.SpecialDayRegex);
+    public static final Pattern WeekDayOfMonthRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.WeekDayOfMonthRegex);
+    public static final Pattern RelativeWeekDayRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.RelativeWeekDayRegex);
+    public static final Pattern SpecialDate = RegExpUtility.getSafeRegExp(EnglishDateTime.SpecialDate);
+    public static final Pattern SpecialDayWithNumRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.SpecialDayWithNumRegex);
+    public static final Pattern ForTheRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.ForTheRegex);
+    public static final Pattern WeekDayAndDayOfMonthRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.WeekDayAndDayOfMonthRegex);
+    public static final Pattern RelativeMonthRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.RelativeMonthRegex);
+    public static final Pattern PrefixArticleRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.PrefixArticleRegex);
+    public static final Pattern InConnectorRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.InConnectorRegex);
+    public static final Pattern RangeUnitRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.RangeUnitRegex);
+    public static final Pattern RangeConnectorSymbolRegex = RegExpUtility.getSafeRegExp(BaseDateTime.RangeConnectorSymbolRegex);
 
     public static final List<Pattern> DateRegexList = new ArrayList<Pattern>() {
         {
-            add(RegExpUtility.getSafeRegExp(EnglishDateTime.DateExtractor1, Pattern.CASE_INSENSITIVE));
-            add(RegExpUtility.getSafeRegExp(EnglishDateTime.DateExtractor2, Pattern.CASE_INSENSITIVE));
-            add(RegExpUtility.getSafeRegExp(EnglishDateTime.DateExtractor3, Pattern.CASE_INSENSITIVE));
-            add(RegExpUtility.getSafeRegExp(EnglishDateTime.DateExtractor4, Pattern.CASE_INSENSITIVE));
-            add(RegExpUtility.getSafeRegExp(EnglishDateTime.DateExtractor5, Pattern.CASE_INSENSITIVE));
-            add(RegExpUtility.getSafeRegExp(EnglishDateTime.DateExtractor6, Pattern.CASE_INSENSITIVE));
-            add(RegExpUtility.getSafeRegExp(EnglishDateTime.DateExtractor7L, Pattern.CASE_INSENSITIVE));
-            add(RegExpUtility.getSafeRegExp(EnglishDateTime.DateExtractor7S, Pattern.CASE_INSENSITIVE));
-            add(RegExpUtility.getSafeRegExp(EnglishDateTime.DateExtractor8, Pattern.CASE_INSENSITIVE));
-            add(RegExpUtility.getSafeRegExp(EnglishDateTime.DateExtractor9L, Pattern.CASE_INSENSITIVE));
-            add(RegExpUtility.getSafeRegExp(EnglishDateTime.DateExtractor9S, Pattern.CASE_INSENSITIVE));
-            add(RegExpUtility.getSafeRegExp(EnglishDateTime.DateExtractorA, Pattern.CASE_INSENSITIVE));
+            add(RegExpUtility.getSafeRegExp(EnglishDateTime.DateExtractor1));
+            add(RegExpUtility.getSafeRegExp(EnglishDateTime.DateExtractor2));
+            add(RegExpUtility.getSafeRegExp(EnglishDateTime.DateExtractor3));
+            add(RegExpUtility.getSafeRegExp(EnglishDateTime.DateExtractor4));
+            add(RegExpUtility.getSafeRegExp(EnglishDateTime.DateExtractor5));
+            add(RegExpUtility.getSafeRegExp(EnglishDateTime.DateExtractor6));
+            add(RegExpUtility.getSafeRegExp(EnglishDateTime.DateExtractor7L));
+            add(RegExpUtility.getSafeRegExp(EnglishDateTime.DateExtractor7S));
+            add(RegExpUtility.getSafeRegExp(EnglishDateTime.DateExtractor8));
+            add(RegExpUtility.getSafeRegExp(EnglishDateTime.DateExtractor9L));
+            add(RegExpUtility.getSafeRegExp(EnglishDateTime.DateExtractor9S));
+            add(RegExpUtility.getSafeRegExp(EnglishDateTime.DateExtractorA));
         }
     };
 
@@ -83,12 +83,12 @@ public class EnglishDateExtractorConfiguration extends BaseOptionsConfiguration 
         }
     };
 
-    public static final Pattern OfMonth = RegExpUtility.getSafeRegExp(EnglishDateTime.OfMonth, Pattern.CASE_INSENSITIVE);
-    public static final Pattern MonthEnd = RegExpUtility.getSafeRegExp(EnglishDateTime.MonthEnd, Pattern.CASE_INSENSITIVE);
-    public static final Pattern WeekDayEnd = RegExpUtility.getSafeRegExp(EnglishDateTime.WeekDayEnd, Pattern.CASE_INSENSITIVE);
-    public static final Pattern YearSuffix = RegExpUtility.getSafeRegExp(EnglishDateTime.YearSuffix, Pattern.CASE_INSENSITIVE);
-    public static final Pattern LessThanRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.LessThanRegex, Pattern.CASE_INSENSITIVE);
-    public static final Pattern MoreThanRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.MoreThanRegex, Pattern.CASE_INSENSITIVE);
+    public static final Pattern OfMonth = RegExpUtility.getSafeRegExp(EnglishDateTime.OfMonth);
+    public static final Pattern MonthEnd = RegExpUtility.getSafeRegExp(EnglishDateTime.MonthEnd);
+    public static final Pattern WeekDayEnd = RegExpUtility.getSafeRegExp(EnglishDateTime.WeekDayEnd);
+    public static final Pattern YearSuffix = RegExpUtility.getSafeRegExp(EnglishDateTime.YearSuffix);
+    public static final Pattern LessThanRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.LessThanRegex);
+    public static final Pattern MoreThanRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.MoreThanRegex);
 
     public static final ImmutableMap<String, Integer> DayOfWeek = EnglishDateTime.DayOfWeek;
     public static final ImmutableMap<String, Integer> MonthOfYear = EnglishDateTime.MonthOfYear;

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/english/extractors/EnglishDatePeriodExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/english/extractors/EnglishDatePeriodExtractorConfiguration.java
@@ -26,53 +26,51 @@ import java.util.regex.Pattern;
 
 public class EnglishDatePeriodExtractorConfiguration extends BaseOptionsConfiguration implements IDatePeriodExtractorConfiguration {
 
-    private static final int flags = Pattern.CASE_INSENSITIVE;
-
-    public static final Pattern YearRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.YearRegex, flags);
-    public static final Pattern TillRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.TillRegex, flags);
-    public static final Pattern DateUnitRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.DateUnitRegex, flags);
-    public static final Pattern TimeUnitRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.TimeUnitRegex, flags);
-    public static final Pattern FollowedDateUnit = RegExpUtility.getSafeRegExp(EnglishDateTime.FollowedDateUnit, flags);
-    public static final Pattern NumberCombinedWithDateUnit = RegExpUtility.getSafeRegExp(EnglishDateTime.NumberCombinedWithDateUnit, flags);
-    public static final Pattern PastPrefixRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.PastPrefixRegex, flags);
-    public static final Pattern NextPrefixRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.NextPrefixRegex, flags);
-    public static final Pattern FutureSuffixRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.FutureSuffixRegex, flags);
-    public static final Pattern WeekOfRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.WeekOfRegex, flags);
-    public static final Pattern MonthOfRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.MonthOfRegex, flags);
-    public static final Pattern RangeUnitRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.RangeUnitRegex, flags);
-    public static final Pattern InConnectorRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.InConnectorRegex, flags);
-    public static final Pattern WithinNextPrefixRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.WithinNextPrefixRegex, flags);
-    public static final Pattern YearPeriodRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.YearPeriodRegex, flags);
-    public static final Pattern RelativeDecadeRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.RelativeDecadeRegex, flags);
-    public static final Pattern ComplexDatePeriodRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.ComplexDatePeriodRegex, flags);
-    public static final Pattern ReferenceDatePeriodRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.ReferenceDatePeriodRegex, flags);
-    public static final Pattern AgoRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.AgoRegex, flags);
-    public static final Pattern LaterRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.LaterRegex, flags);
-    public static final Pattern LessThanRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.LessThanRegex, flags);
-    public static final Pattern MoreThanRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.MoreThanRegex, flags);
-    public static final Pattern CenturySuffixRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.CenturySuffixRegex, flags);
-    public static final Pattern IllegalYearRegex = RegExpUtility.getSafeRegExp(BaseDateTime.IllegalYearRegex, flags);
+    public static final Pattern YearRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.YearRegex);
+    public static final Pattern TillRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.TillRegex);
+    public static final Pattern DateUnitRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.DateUnitRegex);
+    public static final Pattern TimeUnitRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.TimeUnitRegex);
+    public static final Pattern FollowedDateUnit = RegExpUtility.getSafeRegExp(EnglishDateTime.FollowedDateUnit);
+    public static final Pattern NumberCombinedWithDateUnit = RegExpUtility.getSafeRegExp(EnglishDateTime.NumberCombinedWithDateUnit);
+    public static final Pattern PastPrefixRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.PastPrefixRegex);
+    public static final Pattern NextPrefixRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.NextPrefixRegex);
+    public static final Pattern FutureSuffixRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.FutureSuffixRegex);
+    public static final Pattern WeekOfRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.WeekOfRegex);
+    public static final Pattern MonthOfRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.MonthOfRegex);
+    public static final Pattern RangeUnitRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.RangeUnitRegex);
+    public static final Pattern InConnectorRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.InConnectorRegex);
+    public static final Pattern WithinNextPrefixRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.WithinNextPrefixRegex);
+    public static final Pattern YearPeriodRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.YearPeriodRegex);
+    public static final Pattern RelativeDecadeRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.RelativeDecadeRegex);
+    public static final Pattern ComplexDatePeriodRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.ComplexDatePeriodRegex);
+    public static final Pattern ReferenceDatePeriodRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.ReferenceDatePeriodRegex);
+    public static final Pattern AgoRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.AgoRegex);
+    public static final Pattern LaterRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.LaterRegex);
+    public static final Pattern LessThanRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.LessThanRegex);
+    public static final Pattern MoreThanRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.MoreThanRegex);
+    public static final Pattern CenturySuffixRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.CenturySuffixRegex);
+    public static final Pattern IllegalYearRegex = RegExpUtility.getSafeRegExp(BaseDateTime.IllegalYearRegex);
 
     // composite regexes
-    public static final Pattern SimpleCasesRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.SimpleCasesRegex, flags);
-    public static final Pattern BetweenRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.BetweenRegex, flags);
-    public static final Pattern OneWordPeriodRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.OneWordPeriodRegex, flags);
-    public static final Pattern MonthWithYear = RegExpUtility.getSafeRegExp(EnglishDateTime.MonthWithYear, flags);
-    public static final Pattern MonthNumWithYear = RegExpUtility.getSafeRegExp(EnglishDateTime.MonthNumWithYear, flags);
-    public static final Pattern WeekOfMonthRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.WeekOfMonthRegex, flags);
-    public static final Pattern WeekOfYearRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.WeekOfYearRegex, flags);
-    public static final Pattern MonthFrontBetweenRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.MonthFrontBetweenRegex, flags);
-    public static final Pattern MonthFrontSimpleCasesRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.MonthFrontSimpleCasesRegex, flags);
-    public static final Pattern QuarterRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.QuarterRegex, flags);
-    public static final Pattern QuarterRegexYearFront = RegExpUtility.getSafeRegExp(EnglishDateTime.QuarterRegexYearFront, flags);
-    public static final Pattern AllHalfYearRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.AllHalfYearRegex, flags);
-    public static final Pattern SeasonRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.SeasonRegex, flags);
-    public static final Pattern WhichWeekRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.WhichWeekRegex, flags);
-    public static final Pattern RestOfDateRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.RestOfDateRegex, flags);
-    public static final Pattern LaterEarlyPeriodRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.LaterEarlyPeriodRegex, flags);
-    public static final Pattern WeekWithWeekDayRangeRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.WeekWithWeekDayRangeRegex, flags);
-    public static final Pattern YearPlusNumberRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.YearPlusNumberRegex, flags);
-    public static final Pattern DecadeWithCenturyRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.DecadeWithCenturyRegex, flags);
+    public static final Pattern SimpleCasesRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.SimpleCasesRegex);
+    public static final Pattern BetweenRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.BetweenRegex);
+    public static final Pattern OneWordPeriodRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.OneWordPeriodRegex);
+    public static final Pattern MonthWithYear = RegExpUtility.getSafeRegExp(EnglishDateTime.MonthWithYear);
+    public static final Pattern MonthNumWithYear = RegExpUtility.getSafeRegExp(EnglishDateTime.MonthNumWithYear);
+    public static final Pattern WeekOfMonthRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.WeekOfMonthRegex);
+    public static final Pattern WeekOfYearRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.WeekOfYearRegex);
+    public static final Pattern MonthFrontBetweenRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.MonthFrontBetweenRegex);
+    public static final Pattern MonthFrontSimpleCasesRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.MonthFrontSimpleCasesRegex);
+    public static final Pattern QuarterRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.QuarterRegex);
+    public static final Pattern QuarterRegexYearFront = RegExpUtility.getSafeRegExp(EnglishDateTime.QuarterRegexYearFront);
+    public static final Pattern AllHalfYearRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.AllHalfYearRegex);
+    public static final Pattern SeasonRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.SeasonRegex);
+    public static final Pattern WhichWeekRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.WhichWeekRegex);
+    public static final Pattern RestOfDateRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.RestOfDateRegex);
+    public static final Pattern LaterEarlyPeriodRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.LaterEarlyPeriodRegex);
+    public static final Pattern WeekWithWeekDayRangeRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.WeekWithWeekDayRangeRegex);
+    public static final Pattern YearPlusNumberRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.YearPlusNumberRegex);
+    public static final Pattern DecadeWithCenturyRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.DecadeWithCenturyRegex);
     
     public static final Iterable<Pattern> SimpleCasesRegexes = new ArrayList<Pattern>() {
         {
@@ -120,7 +118,7 @@ public class EnglishDatePeriodExtractorConfiguration extends BaseOptionsConfigur
         numberParser = new BaseNumberParser(new EnglishNumberParserConfiguration());
 
         durationDateRestrictions = EnglishDateTime.DurationDateRestrictions.toArray(new String[0]);
-        rangeConnectorRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.RangeConnectorRegex, flags);
+        rangeConnectorRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.RangeConnectorRegex);
     }
 
     @Override

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/english/extractors/EnglishDateTimeAltExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/english/extractors/EnglishDateTimeAltExtractorConfiguration.java
@@ -15,17 +15,15 @@ import java.util.regex.Pattern;
 
 public class EnglishDateTimeAltExtractorConfiguration extends BaseOptionsConfiguration implements IDateTimeAltExtractorConfiguration {
 
-    private static final int flags = Pattern.CASE_INSENSITIVE;
+    private static final Pattern OrRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.OrRegex);
+    private static final Pattern DayRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.DayRegex);
+    private static final Pattern RangePrefixRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.RangePrefixRegex);
 
-    private static final Pattern OrRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.OrRegex, flags);
-    private static final Pattern DayRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.DayRegex, flags);
-    private static final Pattern RangePrefixRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.RangePrefixRegex, flags);
-
-    public static final Pattern ThisPrefixRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.ThisPrefixRegex, flags);
-    public static final Pattern PastPrefixRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.PastPrefixRegex, flags);
-    public static final Pattern NextPrefixRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.NextPrefixRegex, flags);
-    public static final Pattern AmRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.AmRegex, flags);
-    public static final Pattern PmRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.PmRegex, flags);
+    public static final Pattern ThisPrefixRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.ThisPrefixRegex);
+    public static final Pattern PastPrefixRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.PastPrefixRegex);
+    public static final Pattern NextPrefixRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.NextPrefixRegex);
+    public static final Pattern AmRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.AmRegex);
+    public static final Pattern PmRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.PmRegex);
 
     public static final Iterable<Pattern> RelativePrefixList = new ArrayList<Pattern>() {
         {

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/english/extractors/EnglishDateTimeExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/english/extractors/EnglishDateTimeExtractorConfiguration.java
@@ -20,21 +20,21 @@ import java.util.regex.Pattern;
 
 public class EnglishDateTimeExtractorConfiguration extends BaseOptionsConfiguration implements IDateTimeExtractorConfiguration {
 
-    public static final Pattern PrepositionRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.PrepositionRegex, Pattern.CASE_INSENSITIVE);
-    public static final Pattern NowRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.NowRegex, Pattern.CASE_INSENSITIVE);
-    public static final Pattern SuffixRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.SuffixRegex, Pattern.CASE_INSENSITIVE);
-    public static final Pattern TimeOfDayRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.TimeOfDayRegex, Pattern.CASE_INSENSITIVE);
-    public static final Pattern SpecificTimeOfDayRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.SpecificTimeOfDayRegex, Pattern.CASE_INSENSITIVE);
-    public static final Pattern TimeOfTodayAfterRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.TimeOfTodayAfterRegex, Pattern.CASE_INSENSITIVE);
-    public static final Pattern TimeOfTodayBeforeRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.TimeOfTodayBeforeRegex, Pattern.CASE_INSENSITIVE);
-    public static final Pattern SimpleTimeOfTodayAfterRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.SimpleTimeOfTodayAfterRegex, Pattern.CASE_INSENSITIVE);
-    public static final Pattern SimpleTimeOfTodayBeforeRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.SimpleTimeOfTodayBeforeRegex, Pattern.CASE_INSENSITIVE);
-    public static final Pattern SpecificEndOfRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.SpecificEndOfRegex, Pattern.CASE_INSENSITIVE);
-    public static final Pattern UnspecificEndOfRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.UnspecificEndOfRegex, Pattern.CASE_INSENSITIVE);
-    public static final Pattern UnitRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.TimeUnitRegex, Pattern.CASE_INSENSITIVE);
-    public static final Pattern ConnectorRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.ConnectorRegex, Pattern.CASE_INSENSITIVE);
-    public static final Pattern NumberAsTimeRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.NumberAsTimeRegex, Pattern.CASE_INSENSITIVE);
-    public static final Pattern DateNumberConnectorRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.DateNumberConnectorRegex, Pattern.CASE_INSENSITIVE);
+    public static final Pattern PrepositionRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.PrepositionRegex);
+    public static final Pattern NowRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.NowRegex);
+    public static final Pattern SuffixRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.SuffixRegex);
+    public static final Pattern TimeOfDayRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.TimeOfDayRegex);
+    public static final Pattern SpecificTimeOfDayRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.SpecificTimeOfDayRegex);
+    public static final Pattern TimeOfTodayAfterRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.TimeOfTodayAfterRegex);
+    public static final Pattern TimeOfTodayBeforeRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.TimeOfTodayBeforeRegex);
+    public static final Pattern SimpleTimeOfTodayAfterRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.SimpleTimeOfTodayAfterRegex);
+    public static final Pattern SimpleTimeOfTodayBeforeRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.SimpleTimeOfTodayBeforeRegex);
+    public static final Pattern SpecificEndOfRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.SpecificEndOfRegex);
+    public static final Pattern UnspecificEndOfRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.UnspecificEndOfRegex);
+    public static final Pattern UnitRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.TimeUnitRegex);
+    public static final Pattern ConnectorRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.ConnectorRegex);
+    public static final Pattern NumberAsTimeRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.NumberAsTimeRegex);
+    public static final Pattern DateNumberConnectorRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.DateNumberConnectorRegex);
 
     public IExtractor integerExtractor;
     public IDateTimeExtractor datePointExtractor;

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/english/extractors/EnglishDateTimePeriodExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/english/extractors/EnglishDateTimePeriodExtractorConfiguration.java
@@ -23,8 +23,6 @@ import java.util.regex.Pattern;
 
 public class EnglishDateTimePeriodExtractorConfiguration extends BaseOptionsConfiguration implements IDateTimePeriodExtractorConfiguration {
 
-    private static final int flags = Pattern.CASE_INSENSITIVE;
-
     public static final Iterable<Pattern> SimpleCases = new ArrayList<Pattern>() {
         {
             add(EnglishTimePeriodExtractorConfiguration.PureNumFromTo);
@@ -32,24 +30,24 @@ public class EnglishDateTimePeriodExtractorConfiguration extends BaseOptionsConf
         }
     };
 
-    public static final Pattern PeriodTimeOfDayRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.PeriodTimeOfDayRegex, flags);
-    public static final Pattern PeriodSpecificTimeOfDayRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.PeriodSpecificTimeOfDayRegex, flags);
-    public static final Pattern TimeUnitRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.TimeUnitRegex, flags);
-    public static final Pattern TimeFollowedUnit = RegExpUtility.getSafeRegExp(EnglishDateTime.TimeFollowedUnit, flags);
-    public static final Pattern TimeNumberCombinedWithUnit = RegExpUtility.getSafeRegExp(EnglishDateTime.TimeNumberCombinedWithUnit, flags);
-    public static final Pattern PeriodTimeOfDayWithDateRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.PeriodTimeOfDayWithDateRegex, flags);
-    public static final Pattern RelativeTimeUnitRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.RelativeTimeUnitRegex, flags);
-    public static final Pattern RestOfDateTimeRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.RestOfDateTimeRegex, flags);
-    public static final Pattern GeneralEndingRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.GeneralEndingRegex, flags);
-    public static final Pattern MiddlePauseRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.MiddlePauseRegex, flags);
-    public static final Pattern AmDescRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.AmDescRegex, flags);
-    public static final Pattern PmDescRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.PmDescRegex, flags);
-    public static final Pattern WithinNextPrefixRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.WithinNextPrefixRegex, flags);
-    public static final Pattern DateUnitRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.DateUnitRegex, flags);
-    public static final Pattern PrefixDayRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.PrefixDayRegex, flags);
-    public static final Pattern SuffixRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.SuffixRegex, flags);
-    public static final Pattern BeforeRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.BeforeRegex, flags);
-    public static final Pattern AfterRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.AfterRegex, flags);
+    public static final Pattern PeriodTimeOfDayRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.PeriodTimeOfDayRegex);
+    public static final Pattern PeriodSpecificTimeOfDayRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.PeriodSpecificTimeOfDayRegex);
+    public static final Pattern TimeUnitRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.TimeUnitRegex);
+    public static final Pattern TimeFollowedUnit = RegExpUtility.getSafeRegExp(EnglishDateTime.TimeFollowedUnit);
+    public static final Pattern TimeNumberCombinedWithUnit = RegExpUtility.getSafeRegExp(EnglishDateTime.TimeNumberCombinedWithUnit);
+    public static final Pattern PeriodTimeOfDayWithDateRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.PeriodTimeOfDayWithDateRegex);
+    public static final Pattern RelativeTimeUnitRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.RelativeTimeUnitRegex);
+    public static final Pattern RestOfDateTimeRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.RestOfDateTimeRegex);
+    public static final Pattern GeneralEndingRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.GeneralEndingRegex);
+    public static final Pattern MiddlePauseRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.MiddlePauseRegex);
+    public static final Pattern AmDescRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.AmDescRegex);
+    public static final Pattern PmDescRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.PmDescRegex);
+    public static final Pattern WithinNextPrefixRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.WithinNextPrefixRegex);
+    public static final Pattern DateUnitRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.DateUnitRegex);
+    public static final Pattern PrefixDayRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.PrefixDayRegex);
+    public static final Pattern SuffixRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.SuffixRegex);
+    public static final Pattern BeforeRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.BeforeRegex);
+    public static final Pattern AfterRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.AfterRegex);
 
     private final String tokenBeforeDate;
 
@@ -81,8 +79,8 @@ public class EnglishDateTimePeriodExtractorConfiguration extends BaseOptionsConf
         durationExtractor = new BaseDurationExtractor(new EnglishDurationExtractorConfiguration(options));
         timePeriodExtractor = new BaseTimePeriodExtractor(new EnglishTimePeriodExtractorConfiguration(options));
 
-        weekDayRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.WeekDayRegex, flags);
-        rangeConnectorRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.RangeConnectorRegex, flags);
+        weekDayRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.WeekDayRegex);
+        rangeConnectorRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.RangeConnectorRegex);
     }
 
     @Override

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/english/extractors/EnglishHolidayExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/english/extractors/EnglishHolidayExtractorConfiguration.java
@@ -13,11 +13,11 @@ public class EnglishHolidayExtractorConfiguration extends BaseOptionsConfigurati
 
     public static final Pattern YearPattern = RegExpUtility.getSafeRegExp(EnglishDateTime.YearRegex);
 
-    public static final Pattern H1 = RegExpUtility.getSafeRegExp(EnglishDateTime.HolidayRegex1, Pattern.CASE_INSENSITIVE);
+    public static final Pattern H1 = RegExpUtility.getSafeRegExp(EnglishDateTime.HolidayRegex1);
 
     public static final Pattern H2 = RegExpUtility.getSafeRegExp(EnglishDateTime.HolidayRegex2);
 
-    public static final Pattern H3 = RegExpUtility.getSafeRegExp(EnglishDateTime.HolidayRegex3, Pattern.CASE_INSENSITIVE);
+    public static final Pattern H3 = RegExpUtility.getSafeRegExp(EnglishDateTime.HolidayRegex3);
 
     public static final Iterable<Pattern> HolidayRegexList = new ArrayList<Pattern>() {
         {

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/english/extractors/EnglishMergedExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/english/extractors/EnglishMergedExtractorConfiguration.java
@@ -33,26 +33,26 @@ import org.javatuples.Pair;
 
 public class EnglishMergedExtractorConfiguration extends BaseOptionsConfiguration implements IMergedExtractorConfiguration {
 
-    public static final Pattern AfterRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.AfterRegex, Pattern.CASE_INSENSITIVE);
-    public static final Pattern SinceRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.SinceRegex, Pattern.CASE_INSENSITIVE);
-    public static final Pattern AroundRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.AroundRegex, Pattern.CASE_INSENSITIVE);
-    public static final Pattern BeforeRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.BeforeRegex, Pattern.CASE_INSENSITIVE);
-    public static final Pattern FromToRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.FromToRegex, Pattern.CASE_INSENSITIVE);
-    public static final Pattern DateAfterRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.DateAfterRegex, Pattern.CASE_INSENSITIVE);
-    public static final Pattern NumberEndingPattern = RegExpUtility.getSafeRegExp(EnglishDateTime.NumberEndingPattern, Pattern.CASE_INSENSITIVE);
-    public static final Pattern PrepositionSuffixRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.PrepositionSuffixRegex, Pattern.CASE_INSENSITIVE);
-    public static final Pattern SingleAmbiguousMonthRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.SingleAmbiguousMonthRegex, Pattern.CASE_INSENSITIVE);
-    public static final Pattern UnspecificDatePeriodRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.UnspecificDatePeriodRegex, Pattern.CASE_INSENSITIVE);
+    public static final Pattern AfterRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.AfterRegex);
+    public static final Pattern SinceRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.SinceRegex);
+    public static final Pattern AroundRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.AroundRegex);
+    public static final Pattern BeforeRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.BeforeRegex);
+    public static final Pattern FromToRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.FromToRegex);
+    public static final Pattern DateAfterRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.DateAfterRegex);
+    public static final Pattern NumberEndingPattern = RegExpUtility.getSafeRegExp(EnglishDateTime.NumberEndingPattern);
+    public static final Pattern PrepositionSuffixRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.PrepositionSuffixRegex);
+    public static final Pattern SingleAmbiguousMonthRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.SingleAmbiguousMonthRegex);
+    public static final Pattern UnspecificDatePeriodRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.UnspecificDatePeriodRegex);
     private final Iterable<Pair<Pattern, Pattern>> ambiguityFiltersDict;
 
     public static final StringMatcher SuperfluousWordMatcher = new StringMatcher();
     private static final Iterable<Pattern> filterWordRegexList = new ArrayList<Pattern>() {
         {
             // one on one
-            add(RegExpUtility.getSafeRegExp(EnglishDateTime.OneOnOneRegex, Pattern.CASE_INSENSITIVE));
+            add(RegExpUtility.getSafeRegExp(EnglishDateTime.OneOnOneRegex));
 
             // (the)? (day|week|month|year)
-            add(RegExpUtility.getSafeRegExp(EnglishDateTime.SingleAmbiguousTermsRegex, Pattern.CASE_INSENSITIVE));
+            add(RegExpUtility.getSafeRegExp(EnglishDateTime.SingleAmbiguousTermsRegex));
         }
     };
 
@@ -153,8 +153,8 @@ public class EnglishMergedExtractorConfiguration extends BaseOptionsConfiguratio
         integerExtractor = IntegerExtractor.getInstance();
 
         ambiguityFiltersDict = EnglishDateTime.AmbiguityFiltersDict.entrySet().stream().map(pair -> {
-            Pattern key = RegExpUtility.getSafeRegExp(pair.getKey(), Pattern.CASE_INSENSITIVE);
-            Pattern val = RegExpUtility.getSafeRegExp(pair.getValue(), Pattern.CASE_INSENSITIVE);
+            Pattern key = RegExpUtility.getSafeRegExp(pair.getKey());
+            Pattern val = RegExpUtility.getSafeRegExp(pair.getValue());
             return new Pair<Pattern, Pattern>(key, val);
         }).collect(Collectors.toList());
 

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/english/extractors/EnglishSetExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/english/extractors/EnglishSetExtractorConfiguration.java
@@ -25,7 +25,7 @@ public class EnglishSetExtractorConfiguration extends BaseOptionsConfiguration i
     public static final Pattern EachUnitRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.EachUnitRegex);
     public static final Pattern SetUnitRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.DurationUnitRegex);
     public static final Pattern EachPrefixRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.EachPrefixRegex);
-    public static final Pattern SetWeekDayRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.SetWeekDayRegex, Pattern.CASE_INSENSITIVE);
+    public static final Pattern SetWeekDayRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.SetWeekDayRegex);
 
     public EnglishSetExtractorConfiguration() {
         this(DateTimeOptions.None);

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/english/extractors/EnglishTimeExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/english/extractors/EnglishTimeExtractorConfiguration.java
@@ -60,37 +60,37 @@ public class EnglishTimeExtractorConfiguration extends BaseOptionsConfiguration 
     public static final Iterable<Pattern> TimeRegexList = new ArrayList<Pattern>() {
         {
             // (three min past)? seven|7|(senven thirty) pm
-            add(RegExpUtility.getSafeRegExp(EnglishDateTime.TimeRegex1, Pattern.CASE_INSENSITIVE));
+            add(RegExpUtility.getSafeRegExp(EnglishDateTime.TimeRegex1));
 
             // (three min past)? 3:00(:00)? (pm)?
-            add(RegExpUtility.getSafeRegExp(EnglishDateTime.TimeRegex2, Pattern.CASE_INSENSITIVE));
+            add(RegExpUtility.getSafeRegExp(EnglishDateTime.TimeRegex2));
 
             // (three min past)? 3.00 (pm)
-            add(RegExpUtility.getSafeRegExp(EnglishDateTime.TimeRegex3, Pattern.CASE_INSENSITIVE));
+            add(RegExpUtility.getSafeRegExp(EnglishDateTime.TimeRegex3));
 
             // (three min past) (five thirty|seven|7|7:00(:00)?) (pm)? (in the night)
-            add(RegExpUtility.getSafeRegExp(EnglishDateTime.TimeRegex4, Pattern.CASE_INSENSITIVE));
+            add(RegExpUtility.getSafeRegExp(EnglishDateTime.TimeRegex4));
 
             // (three min past) (five thirty|seven|7|7:00(:00)?) (pm)?
-            add(RegExpUtility.getSafeRegExp(EnglishDateTime.TimeRegex5, Pattern.CASE_INSENSITIVE));
+            add(RegExpUtility.getSafeRegExp(EnglishDateTime.TimeRegex5));
 
             // (five thirty|seven|7|7:00(:00)?) (pm)? (in the night)
-            add(RegExpUtility.getSafeRegExp(EnglishDateTime.TimeRegex6, Pattern.CASE_INSENSITIVE));
+            add(RegExpUtility.getSafeRegExp(EnglishDateTime.TimeRegex6));
 
             // (in the night) at (five thirty|seven|7|7:00(:00)?) (pm)?
-            add(RegExpUtility.getSafeRegExp(EnglishDateTime.TimeRegex7, Pattern.CASE_INSENSITIVE));
+            add(RegExpUtility.getSafeRegExp(EnglishDateTime.TimeRegex7));
 
             // (in the night) (five thirty|seven|7|7:00(:00)?) (pm)?
-            add(RegExpUtility.getSafeRegExp(EnglishDateTime.TimeRegex8, Pattern.CASE_INSENSITIVE));
+            add(RegExpUtility.getSafeRegExp(EnglishDateTime.TimeRegex8));
 
-            add(RegExpUtility.getSafeRegExp(EnglishDateTime.TimeRegex9, Pattern.CASE_INSENSITIVE));
+            add(RegExpUtility.getSafeRegExp(EnglishDateTime.TimeRegex9));
 
             // (three min past)? 3h00 (pm)?
-            add(RegExpUtility.getSafeRegExp(EnglishDateTime.TimeRegex10, Pattern.CASE_INSENSITIVE));
+            add(RegExpUtility.getSafeRegExp(EnglishDateTime.TimeRegex10));
 
             // at 2.30, "at" prefix is required here
             // 3.30pm, "am/pm" suffix is required here
-            add(RegExpUtility.getSafeRegExp(EnglishDateTime.TimeRegex11, Pattern.CASE_INSENSITIVE));
+            add(RegExpUtility.getSafeRegExp(EnglishDateTime.TimeRegex11));
 
             // 340pm
             add(ConnectNumRegex);

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/english/extractors/EnglishTimePeriodExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/english/extractors/EnglishTimePeriodExtractorConfiguration.java
@@ -114,8 +114,7 @@ public class EnglishTimePeriodExtractorConfiguration extends BaseOptionsConfigur
     public final ResultIndex getFromTokenIndex(String input) {
         ResultIndex result = new ResultIndex(false, -1);
         if (input.endsWith("from")) {
-            result = result.withIndex(input.lastIndexOf("from"));
-            result = result.withResult(true);
+            result = new ResultIndex(true, input.lastIndexOf("from"));
         }
 
         return result;
@@ -124,8 +123,7 @@ public class EnglishTimePeriodExtractorConfiguration extends BaseOptionsConfigur
     public final ResultIndex getBetweenTokenIndex(String input) {
         ResultIndex result = new ResultIndex(false, -1);
         if (input.endsWith("between")) {
-            result = result.withIndex(input.lastIndexOf("between"));
-            result = result.withResult(true);
+            result = new ResultIndex(true, input.lastIndexOf("between"));
         }
 
         return result;

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/english/extractors/EnglishTimeZoneExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/english/extractors/EnglishTimeZoneExtractorConfiguration.java
@@ -15,6 +15,7 @@ import java.util.stream.Collectors;
 
 public class EnglishTimeZoneExtractorConfiguration extends BaseOptionsConfiguration implements ITimeZoneExtractorConfiguration {
 
+    // These regexes do need to be case insensitive for them to work correctly
     public static final Pattern DirectUtcRegex = RegExpUtility.getSafeRegExp(EnglishTimeZone.DirectUtcRegex, Pattern.CASE_INSENSITIVE);
     public static final Pattern AbbreviationRegex = RegExpUtility.getSafeRegExp(EnglishTimeZone.AbbreviationsRegex, Pattern.CASE_INSENSITIVE);
     public static final Pattern StandardTimeRegex = RegExpUtility.getSafeRegExp(EnglishTimeZone.FullNameRegex, Pattern.CASE_INSENSITIVE);

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/english/parsers/EnglishCommonDateTimeParserConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/english/parsers/EnglishCommonDateTimeParserConfiguration.java
@@ -44,7 +44,7 @@ import java.util.regex.Pattern;
 
 public class EnglishCommonDateTimeParserConfiguration extends BaseDateParserConfiguration implements ICommonDateTimeParserConfiguration {
 
-    public static final Pattern AmbiguousMonthP0Regex = RegExpUtility.getSafeRegExp(EnglishDateTime.AmbiguousMonthP0Regex, Pattern.CASE_INSENSITIVE);
+    public static final Pattern AmbiguousMonthP0Regex = RegExpUtility.getSafeRegExp(EnglishDateTime.AmbiguousMonthP0Regex);
 
     private final IDateTimeUtilityConfiguration utilityConfiguration;
 

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/english/parsers/EnglishDateParserConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/english/parsers/EnglishDateParserConfiguration.java
@@ -61,15 +61,15 @@ public class EnglishDateParserConfiguration extends BaseOptionsConfiguration imp
         cardinalMap = config.getCardinalMap();
         utilityConfiguration = config.getUtilityConfiguration();
 
+        relativeDayRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.RelativeDayRegex);
+        nextPrefixRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.NextPrefixRegex);
+        pastPrefixRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.PastPrefixRegex);
         sameDayTerms = Collections.unmodifiableList(EnglishDateTime.SameDayTerms);
         plusOneDayTerms = Collections.unmodifiableList(EnglishDateTime.PlusOneDayTerms);
         plusTwoDayTerms = Collections.unmodifiableList(EnglishDateTime.PlusTwoDayTerms);
         minusOneDayTerms = Collections.unmodifiableList(EnglishDateTime.MinusOneDayTerms);
         minusTwoDayTerms = Collections.unmodifiableList(EnglishDateTime.MinusTwoDayTerms);
 
-        relativeDayRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.RelativeDayRegex, Pattern.CASE_INSENSITIVE);
-        nextPrefixRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.NextPrefixRegex, Pattern.CASE_INSENSITIVE);
-        pastPrefixRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.PastPrefixRegex, Pattern.CASE_INSENSITIVE);
     }
 
     private final String dateTokenPrefix;

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/english/parsers/EnglishDatePeriodParserConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/english/parsers/EnglishDatePeriodParserConfiguration.java
@@ -75,8 +75,8 @@ public class EnglishDatePeriodParserConfiguration extends BaseOptionsConfigurati
         lessThanRegex = EnglishDatePeriodExtractorConfiguration.LessThanRegex;
         moreThanRegex = EnglishDatePeriodExtractorConfiguration.MoreThanRegex;
         centurySuffixRegex = EnglishDatePeriodExtractorConfiguration.CenturySuffixRegex;
-        relativeRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.RelativeRegex, Pattern.CASE_INSENSITIVE);
-        unspecificEndOfRangeRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.UnspecificEndOfRangeRegex, Pattern.CASE_INSENSITIVE);
+        relativeRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.RelativeRegex);
+        unspecificEndOfRangeRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.UnspecificEndOfRangeRegex);
 
         unitMap = config.getUnitMap();
         cardinalMap = config.getCardinalMap();
@@ -87,10 +87,10 @@ public class EnglishDatePeriodParserConfiguration extends BaseOptionsConfigurati
         numbers = config.getNumbers();
         specialDecadeCases = config.getSpecialDecadeCases();
 
-        nextPrefixRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.NextPrefixRegex, Pattern.CASE_INSENSITIVE);
-        pastPrefixRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.PastPrefixRegex, Pattern.CASE_INSENSITIVE);
-        thisPrefixRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.ThisPrefixRegex, Pattern.CASE_INSENSITIVE);
-        afterNextSuffixRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.AfterNextSuffixRegex, Pattern.CASE_INSENSITIVE);
+        nextPrefixRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.NextPrefixRegex);
+        pastPrefixRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.PastPrefixRegex);
+        thisPrefixRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.ThisPrefixRegex);
+        afterNextSuffixRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.AfterNextSuffixRegex);
     }
 
     private final String tokenBeforeDate;

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/english/parsers/EnglishDateTimeParserConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/english/parsers/EnglishDateTimeParserConfiguration.java
@@ -67,8 +67,8 @@ public class EnglishDateTimeParserConfiguration extends BaseOptionsConfiguration
         
         nowRegex = EnglishDateTimeExtractorConfiguration.NowRegex;
 
-        amTimeRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.AMTimeRegex, Pattern.CASE_INSENSITIVE);
-        pmTimeRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.PMTimeRegex, Pattern.CASE_INSENSITIVE);
+        amTimeRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.AMTimeRegex);
+        pmTimeRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.PMTimeRegex);
 
         simpleTimeOfTodayAfterRegex = EnglishDateTimeExtractorConfiguration.SimpleTimeOfTodayAfterRegex;
         simpleTimeOfTodayBeforeRegex = EnglishDateTimeExtractorConfiguration.SimpleTimeOfTodayBeforeRegex;

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/english/parsers/EnglishDateTimePeriodParserConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/english/parsers/EnglishDateTimePeriodParserConfiguration.java
@@ -59,10 +59,10 @@ public class EnglishDateTimePeriodParserConfiguration extends BaseOptionsConfigu
     private final ImmutableMap<String, String> unitMap;
     private final ImmutableMap<String, Integer> numbers;
 
-    public static final Pattern MorningStartEndRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.MorningStartEndRegex, Pattern.CASE_INSENSITIVE);
-    public static final Pattern AfternoonStartEndRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.AfternoonStartEndRegex, Pattern.CASE_INSENSITIVE);
-    public static final Pattern EveningStartEndRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.EveningStartEndRegex, Pattern.CASE_INSENSITIVE);
-    public static final Pattern NightStartEndRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.NightStartEndRegex, Pattern.CASE_INSENSITIVE);
+    public static final Pattern MorningStartEndRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.MorningStartEndRegex);
+    public static final Pattern AfternoonStartEndRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.AfternoonStartEndRegex);
+    public static final Pattern EveningStartEndRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.EveningStartEndRegex);
+    public static final Pattern NightStartEndRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.NightStartEndRegex);
     
     public EnglishDateTimePeriodParserConfiguration(ICommonDateTimeParserConfiguration config) {
 

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/english/parsers/EnglishSetParserConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/english/parsers/EnglishSetParserConfiguration.java
@@ -175,19 +175,19 @@ public class EnglishSetParserConfiguration extends BaseOptionsConfiguration impl
         String trimmedText = text.trim().toLowerCase(Locale.ROOT);
 
         if (trimmedText.equals("daily")) {
-            result = result.withTimex("P1D");
+            result.setTimex("P1D");
         } else if (trimmedText.equals("weekly")) {
-            result = result.withTimex("P1W");
+            result.setTimex("P1W");
         } else if (trimmedText.equals("biweekly")) {
-            result = result.withTimex("P2W");
+            result.setTimex("P2W");
         } else if (trimmedText.equals("monthly")) {
-            result = result.withTimex("P1M");
+            result.setTimex("P1M");
         } else if (trimmedText.equals("yearly") || trimmedText.equals("annually") || trimmedText.equals("annual")) {
-            result = result.withTimex("P1Y");
+            result.setTimex("P1Y");
         }
 
-        if (result.timex != "") {
-            result = result.withResult(true);
+        if (result.getTimex() != "") {
+            result.setResult(true);
         }
 
         return result;
@@ -199,17 +199,17 @@ public class EnglishSetParserConfiguration extends BaseOptionsConfiguration impl
         String trimmedText = text.trim().toLowerCase(Locale.ROOT);
 
         if (trimmedText.equals("day")) {
-            result = result.withTimex("P1D");
+            result.setTimex("P1D");
         } else if (trimmedText.equals("week")) {
-            result = result.withTimex("P1W");
+            result.setTimex("P1W");
         } else if (trimmedText.equals("month")) {
-            result = result.withTimex("P1M");
+            result.setTimex("P1M");
         } else if (trimmedText.equals("year")) {
-            result = result.withTimex("P1Y");
+            result.setTimex("P1Y");
         }
 
-        if (result.timex != "") {
-            result = result.withResult(true);
+        if (result.getTimex() != "") {
+            result.setResult(true);
         }
 
         return result;

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/extractors/AbstractYearExtractor.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/extractors/AbstractYearExtractor.java
@@ -45,24 +45,24 @@ public abstract class AbstractYearExtractor implements IDateExtractor {
             MatchGroup firstTwoYear = match.getGroup("firsttwoyearnum");
 
             if (!StringUtility.isNullOrEmpty(firstTwoYear.value)) {
-                ExtractResult er = new ExtractResult()
-                    .withText(firstTwoYear.value)
-                    .withStart(firstTwoYear.index)
-                    .withLength(firstTwoYear.length);
+                ExtractResult er = new ExtractResult();
+                er.setStart(firstTwoYear.index);
+                er.setLength(firstTwoYear.length);
+                er.setText(firstTwoYear.value);
 
-                int firstTwoYearNum = Math.round(Double.valueOf((double)config.getNumberParser().parse(er).value).floatValue());
+                int firstTwoYearNum = Math.round(Double.valueOf((double)config.getNumberParser().parse(er).getValue()).floatValue());
 
                 int lastTwoYearNum = 0;
 
                 MatchGroup lastTwoYear = match.getGroup("lasttwoyearnum");
 
                 if (!StringUtility.isNullOrEmpty(lastTwoYear.value)) {
-                    er = new ExtractResult()
-                        .withText(lastTwoYear.value)
-                        .withStart(lastTwoYear.index)
-                        .withLength(lastTwoYear.length);
+                    er = new ExtractResult();
+                    er.setStart(lastTwoYear.index);
+                    er.setLength(lastTwoYear.length);
+                    er.setText(lastTwoYear.value);
 
-                    lastTwoYearNum = Math.round(Double.valueOf((double)config.getNumberParser().parse(er).value).floatValue());
+                    lastTwoYearNum = Math.round(Double.valueOf((double)config.getNumberParser().parse(er).getValue()).floatValue());
                 }
 
                 // Exclude pure number like "nineteen", "twenty four"

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/extractors/BaseSetExtractor.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/extractors/BaseSetExtractor.java
@@ -78,15 +78,15 @@ public class BaseSetExtractor implements IDateTimeExtractor {
         for (ExtractResult er : ers) {
             // "each last summer" doesn't make sense
             Pattern lastRegex = this.config.getLastRegex();
-            if (RegExpUtility.getMatches(lastRegex, er.text).length > 0) {
+            if (RegExpUtility.getMatches(lastRegex, er.getText()).length > 0) {
                 continue;
             }
 
-            String beforeStr = text.substring(0, (er.start != null) ? er.start : 0);
+            String beforeStr = text.substring(0, (er.getStart() != null) ? er.getStart() : 0);
             Pattern eachPrefixRegex = this.config.getEachPrefixRegex();
             Optional<Match> match = Arrays.stream(RegExpUtility.getMatches(eachPrefixRegex, beforeStr)).findFirst();
             if (match.isPresent()) {
-                ret.add(new Token(match.get().index, er.start + er.length));
+                ret.add(new Token(match.get().index, er.getStart() + er.getLength()));
             }
         }
         return ret;
@@ -96,19 +96,19 @@ public class BaseSetExtractor implements IDateTimeExtractor {
         List<Token> ret = new ArrayList<>();
         List<ExtractResult> ers = this.config.getTimeExtractor().extract(text, reference);
         for (ExtractResult er : ers) {
-            String afterStr = text.substring(er.start + er.length);
+            String afterStr = text.substring(er.getStart() + er.getLength());
             if (StringUtility.isNullOrEmpty(afterStr) && this.config.getBeforeEachDayRegex() != null) {
-                String beforeStr = text.substring(0, er.start);
+                String beforeStr = text.substring(0, er.getStart());
                 Pattern eachPrefixRegex = this.config.getEachPrefixRegex();
                 Optional<Match> match = Arrays.stream(RegExpUtility.getMatches(eachPrefixRegex, beforeStr)).findFirst();
                 if (match.isPresent()) {
-                    ret.add(new Token(match.get().index, er.start + er.length));
+                    ret.add(new Token(match.get().index, er.getStart() + er.getLength()));
                 }
             } else {
                 Pattern eachDayRegex = this.config.getEachDayRegex();
                 Optional<Match> match = Arrays.stream(RegExpUtility.getMatches(eachDayRegex, afterStr)).findFirst();
                 if (match.isPresent()) {
-                    ret.add(new Token(er.start, er.start + er.length + match.get().length));
+                    ret.add(new Token(er.getStart(), er.getStart() + er.getLength() + match.get().length));
                 }
             }
         }
@@ -126,8 +126,8 @@ public class BaseSetExtractor implements IDateTimeExtractor {
                 String trimedText = sb.delete(match.index, match.index + match.length).toString();
                 List<ExtractResult> ers = extractor.extract(trimedText, reference);
                 for (ExtractResult er : ers) {
-                    if (er.start <= match.index && (er.start + er.length) > match.index) {
-                        ret.add(new Token(er.start, er.start + er.length + match.length));
+                    if (er.getStart() <= match.index && (er.getStart() + er.getLength()) > match.index) {
+                        ret.add(new Token(er.getStart(), er.getStart() + er.getLength() + match.length));
                     }
                 }
             }
@@ -144,12 +144,12 @@ public class BaseSetExtractor implements IDateTimeExtractor {
 
                 List<ExtractResult> ers = extractor.extract(trimedText, reference);
                 for (ExtractResult er : ers) {
-                    if (er.start <= match.index && er.text.contains(match.getGroup("weekday").value)) {
-                        int len = er.length + 1;
+                    if (er.getStart() <= match.index && er.getText().contains(match.getGroup("weekday").value)) {
+                        int len = er.getLength() + 1;
                         if (match.getGroup(Constants.PrefixGroupName).value != "") {
                             len += match.getGroup(Constants.PrefixGroupName).value.length();
                         }
-                        ret.add(new Token(er.start, er.start + len));
+                        ret.add(new Token(er.getStart(), er.getStart() + len));
                     }
                 }
             }

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/extractors/BaseTimeExtractor.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/extractors/BaseTimeExtractor.java
@@ -10,7 +10,6 @@ import com.microsoft.recognizers.text.utilities.RegExpUtility;
 import com.microsoft.recognizers.text.utilities.StringUtility;
 
 import java.time.LocalDateTime;
-import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -54,22 +53,22 @@ public class BaseTimeExtractor implements IDateTimeExtractor {
         int erIndex = 0;
         for (ExtractResult er : timeErs.toArray(new ExtractResult[0])) {
             for (ExtractResult timeZoneEr : timeZoneErs) {
-                int begin = er.start + er.length;
-                int end = timeZoneEr.start;
+                int begin = er.getStart() + er.getLength();
+                int end = timeZoneEr.getStart();
 
                 if (begin < end) {
                     String gapText = text.substring(begin, end);
 
                     if (StringUtility.isNullOrWhiteSpace(gapText)) {
-                        int newLenght = timeZoneEr.start + timeZoneEr.length;
-                        String newText = text.substring(er.start, newLenght);
+                        int newLenght = timeZoneEr.getStart() + timeZoneEr.getLength();
+                        String newText = text.substring(er.getStart(), newLenght);
                         Map<String, Object> newData = new HashMap<>();
                         newData.put(Constants.SYS_DATETIME_TIMEZONE, timeZoneEr);
 
-                        timeErs.set(erIndex, er
-                                .withText(newText)
-                                .withLength(newLenght - er.start)
-                                .withData(newData));
+                        er.setData(newData);
+                        er.setText(newText);
+                        er.setLength(newLenght - er.getStart());
+                        timeErs.set(erIndex, er);
                     }
                 }
             }

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/extractors/BaseTimeZoneExtractor.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/extractors/BaseTimeZoneExtractor.java
@@ -15,7 +15,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
 
 public class BaseTimeZoneExtractor implements IDateTimeZoneExtractor {
 
@@ -46,7 +45,7 @@ public class BaseTimeZoneExtractor implements IDateTimeZoneExtractor {
 
     @Override
     public List<ExtractResult> removeAmbiguousTimezone(List<ExtractResult> extractResults) {
-        return extractResults.stream().filter(o -> !config.getAmbiguousTimezoneList().contains(o.text.toLowerCase())).collect(Collectors.toList());
+        return extractResults.stream().filter(o -> !config.getAmbiguousTimezoneList().contains(o.getText().toLowerCase())).collect(Collectors.toList());
     }
 
     private List<Token> matchLocationTimes(String text) {

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/extractors/config/ProcessedSuperfluousWords.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/extractors/config/ProcessedSuperfluousWords.java
@@ -5,11 +5,19 @@ import com.microsoft.recognizers.text.matcher.MatchResult;
 import java.util.List;
 
 public class ProcessedSuperfluousWords {
-    public final String text;
-    public final Iterable<MatchResult<String>> superfluousWordMatches;
+    private String text;
+    private Iterable<MatchResult<String>> superfluousWordMatches;
 
     public ProcessedSuperfluousWords(String text, Iterable<MatchResult<String>> superfluousWordMatches) {
         this.text = text;
         this.superfluousWordMatches = superfluousWordMatches;
+    }
+
+    public String getText() {
+        return text;
+    }
+
+    public Iterable<MatchResult<String>> getSuperfluousWordMatches() {
+        return superfluousWordMatches;
     }
 }

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/extractors/config/ResultIndex.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/extractors/config/ResultIndex.java
@@ -1,19 +1,27 @@
 package com.microsoft.recognizers.text.datetime.extractors.config;
 
 public class ResultIndex {
-    public final boolean result;
-    public final int index;
+    private boolean result;
+    private int index;
 
     public ResultIndex(boolean result, int index) {
         this.result = result;
         this.index = index;
     }
 
-    public ResultIndex withResult(boolean newResult) {
-        return new ResultIndex(newResult, this.index);
+    public boolean getResult() {
+        return result;
     }
 
-    public ResultIndex withIndex(int newIndex) {
-        return new ResultIndex(this.result, newIndex);
+    public int getIndex() {
+        return index;
+    }
+
+    public void setResult(boolean result) {
+        this.result = result;
+    }
+
+    public void setIndex(int index) {
+        this.index = index;
     }
 }

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/extractors/config/ResultTimex.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/extractors/config/ResultTimex.java
@@ -1,19 +1,27 @@
 package com.microsoft.recognizers.text.datetime.extractors.config;
 
 public class ResultTimex {
-    public final boolean result;
-    public final String timex;
+    private boolean result;
+    private String timex;
 
     public ResultTimex(boolean result, String timex) {
         this.result = result;
         this.timex = timex;
     }
 
-    public ResultTimex withResult(boolean newResult) {
-        return new ResultTimex(newResult, this.timex);
+    public boolean getResult() {
+        return result;
     }
 
-    public ResultTimex withTimex(String newTimex) {
-        return new ResultTimex(this.result, newTimex);
+    public String getTimex() {
+        return timex;
+    }
+
+    public void setResult(boolean result) {
+        this.result = result;
+    }
+
+    public void setTimex(String timex) {
+        this.timex = timex;
     }
 }

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/models/DateTimeModel.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/models/DateTimeModel.java
@@ -48,8 +48,8 @@ public class DateTimeModel implements IModel {
             for (ExtractResult result : extractResults) {
                 DateTimeParseResult parseResult = parser.parse(result, reference);
 
-                if (parseResult.value instanceof List) {
-                    parsedDateTimes.addAll((List<DateTimeParseResult>)parseResult.value);
+                if (parseResult.getValue() instanceof List) {
+                    parsedDateTimes.addAll((List<DateTimeParseResult>)parseResult.getValue());
                 } else {
                     parsedDateTimes.add(parseResult);
                 }
@@ -69,15 +69,15 @@ public class DateTimeModel implements IModel {
 
     private ModelResult getModelResult(DateTimeParseResult parsedDateTime) {
 
-        int start = parsedDateTime.start;
-        int end = parsedDateTime.start + parsedDateTime.length - 1;
-        String typeName = parsedDateTime.type;
-        SortedMap<String, Object> resolution = (SortedMap<String, Object>)parsedDateTime.value;
-        String text = parsedDateTime.text;
+        int start = parsedDateTime.getStart();
+        int end = parsedDateTime.getStart() + parsedDateTime.getLength() - 1;
+        String typeName = parsedDateTime.getType();
+        SortedMap<String, Object> resolution = (SortedMap<String, Object>)parsedDateTime.getValue();
+        String text = parsedDateTime.getText();
 
         ModelResult result = new ModelResult(text, start, end, typeName, resolution);
 
-        String[] types = parsedDateTime.type.split("\\.");
+        String[] types = parsedDateTime.getType().split("\\.");
         String type = types[types.length - 1];
         if (type.equals(Constants.SYS_DATETIME_DATETIMEALT)) {
             result = new ExtendedModelResult(result, getParentText(parsedDateTime));
@@ -87,7 +87,7 @@ public class DateTimeModel implements IModel {
     }
 
     private String getParentText(DateTimeParseResult parsedDateTime) {
-        Map<String, Object> map = (Map<String, Object>)parsedDateTime.data;
+        Map<String, Object> map = (Map<String, Object>)parsedDateTime.getData();
         Object result = map.get(ExtendedModelResult.ParentTextKey);
         return String.valueOf(result);
     }

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/parsers/BaseDateParser.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/parsers/BaseDateParser.java
@@ -48,29 +48,29 @@ public class BaseDateParser implements IDateTimeParser {
 
         Object value = null;
 
-        if (er.type.equals(getParserName())) {
-            DateTimeResolutionResult innerResult = this.parseBasicRegexMatch(er.text, referenceDate);
+        if (er.getType().equals(getParserName())) {
+            DateTimeResolutionResult innerResult = this.parseBasicRegexMatch(er.getText(), referenceDate);
 
             if (!innerResult.getSuccess()) {
-                innerResult = this.parseImplicitDate(er.text, referenceDate);
+                innerResult = this.parseImplicitDate(er.getText(), referenceDate);
             }
 
             if (!innerResult.getSuccess()) {
-                innerResult = this.parseWeekdayOfMonth(er.text, referenceDate);
+                innerResult = this.parseWeekdayOfMonth(er.getText(), referenceDate);
             }
 
             if (!innerResult.getSuccess()) {
-                innerResult = this.parseDurationWithAgoAndLater(er.text, referenceDate);
+                innerResult = this.parseDurationWithAgoAndLater(er.getText(), referenceDate);
             }
 
             // NumberWithMonth must be the second last one, because it only need to find a number and a month to get a "success"
             if (!innerResult.getSuccess()) {
-                innerResult = this.parseNumberWithMonth(er.text, referenceDate);
+                innerResult = this.parseNumberWithMonth(er.getText(), referenceDate);
             }
 
             // SingleNumber last one
             if (!innerResult.getSuccess()) {
-                innerResult = this.parseSingleNumber(er.text, referenceDate);
+                innerResult = this.parseSingleNumber(er.getText(), referenceDate);
             }
 
             if (innerResult.getSuccess()) {
@@ -89,11 +89,11 @@ public class BaseDateParser implements IDateTimeParser {
         }
 
         DateTimeParseResult ret = new DateTimeParseResult(
-                er.start,
-                er.length,
-                er.text,
-                er.type,
-                er.data,
+                er.getStart(),
+                er.getLength(),
+                er.getText(),
+                er.getType(),
+                er.getData(),
                 value,
                 "",
                 value == null ? "" : ((DateTimeResolutionResult)value).getTimex());
@@ -195,7 +195,7 @@ public class BaseDateParser implements IDateTimeParser {
 
             int swift = getSwiftDay(exactMatch.getMatch().get().getGroup("day").value);
             List<ExtractResult> numErs = this.config.getIntegerExtractor().extract(trimmedText);
-            Object numberParsed = this.config.getNumberParser().parse(numErs.get(0)).value;
+            Object numberParsed = this.config.getNumberParser().parse(numErs.get(0)).getValue();
             int numOfDays = Math.round(((Double)numberParsed).floatValue());
 
             LocalDateTime value = referenceDate.plusDays(numOfDays + swift);
@@ -213,7 +213,7 @@ public class BaseDateParser implements IDateTimeParser {
 
         if (exactMatch.getSuccess()) {
             List<ExtractResult> numErs = this.config.getIntegerExtractor().extract(trimmedText);
-            Object numberParsed = this.config.getNumberParser().parse(numErs.get(0)).value;
+            Object numberParsed = this.config.getNumberParser().parse(numErs.get(0)).getValue();
             int num = Math.round(((Double)numberParsed).floatValue());
 
             String weekdayStr = exactMatch.getMatch().get().getGroup("weekday").value.toLowerCase();
@@ -329,7 +329,7 @@ public class BaseDateParser implements IDateTimeParser {
             // create a extract comments which content ordinal string of text
             ExtractResult er = new ExtractResult(start, length, dayStr, null, null);
 
-            Object numberParsed = this.config.getNumberParser().parse(er).value;
+            Object numberParsed = this.config.getNumberParser().parse(er).getValue();
             day = Math.round(((Double)numberParsed).floatValue());
 
             ret.setTimex(FormatUtil.luisDate(-1, -1, day));
@@ -363,7 +363,7 @@ public class BaseDateParser implements IDateTimeParser {
             // create a extract comments which content ordinal string of text
             ExtractResult erTmp = new ExtractResult(start, length, dayStr, null, null);
 
-            Object numberParsed = this.config.getNumberParser().parse(erTmp).value;
+            Object numberParsed = this.config.getNumberParser().parse(erTmp).getValue();
             int day = Math.round(((Double)numberParsed).floatValue());
 
             // the validity of the phrase is guaranteed in the Date Extractor
@@ -467,7 +467,7 @@ public class BaseDateParser implements IDateTimeParser {
             return ret;
         }
 
-        Object numberParsed = this.config.getNumberParser().parse(er.get(0)).value;
+        Object numberParsed = this.config.getNumberParser().parse(er.get(0)).getValue();
         int num = Math.round(((Double)numberParsed).floatValue());
 
         Optional<Match> match = Arrays.stream(RegExpUtility.getMatches(this.config.getMonthRegex(), trimmedText)).findFirst();
@@ -475,7 +475,7 @@ public class BaseDateParser implements IDateTimeParser {
             month = this.config.getMonthOfYear().get(match.get().value.trim());
             day = num;
 
-            String suffix = trimmedText.substring((er.get(0).start + er.get(0).length));
+            String suffix = trimmedText.substring((er.get(0).getStart() + er.get(0).getLength()));
 
             Optional<Match> matchYear = Arrays.stream(RegExpUtility.getMatches(this.config.getYearSuffix(), suffix)).findFirst();
             if (matchYear.isPresent()) {
@@ -559,7 +559,7 @@ public class BaseDateParser implements IDateTimeParser {
             return ret;
         }
 
-        Object numberParsed = this.config.getNumberParser().parse(er.get(0)).value;
+        Object numberParsed = this.config.getNumberParser().parse(er.get(0)).getValue();
         day = Math.round(((Double)numberParsed).floatValue());
 
         int month = referenceDate.getMonthValue();

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/parsers/BaseDateTimeAltParser.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/parsers/BaseDateTimeAltParser.java
@@ -7,7 +7,6 @@ import com.microsoft.recognizers.text.ParseResult;
 import com.microsoft.recognizers.text.datetime.Constants;
 import com.microsoft.recognizers.text.datetime.TimeTypeConstants;
 import com.microsoft.recognizers.text.datetime.parsers.config.IDateTimeAltParserConfiguration;
-import com.microsoft.recognizers.text.datetime.utilities.DateTimeFormatUtil;
 import com.microsoft.recognizers.text.datetime.utilities.DateTimeResolutionResult;
 import com.microsoft.recognizers.text.datetime.utilities.FormatUtil;
 
@@ -38,7 +37,7 @@ public class BaseDateTimeAltParser implements IDateTimeParser {
     @Override
     public DateTimeParseResult parse(ExtractResult er, LocalDateTime reference) {
         DateTimeResolutionResult value = null;
-        if (er.type.equals(getParserName())) {
+        if (er.getType().equals(getParserName())) {
             DateTimeResolutionResult innerResult = parseDateTimeAndTimeAlt(er, reference);
 
             if (innerResult.getSuccess()) {
@@ -47,11 +46,11 @@ public class BaseDateTimeAltParser implements IDateTimeParser {
         }
 
         DateTimeParseResult ret = new DateTimeParseResult(
-                er.start,
-                er.length,
-                er.text,
-                er.type,
-                er.data,
+                er.getStart(),
+                er.getLength(),
+                er.getText(),
+                er.getType(),
+                er.getData(),
                 value,
                 "",
                 value == null ? "" : value.getTimex());
@@ -65,70 +64,70 @@ public class BaseDateTimeAltParser implements IDateTimeParser {
         DateTimeResolutionResult ret = new DateTimeResolutionResult();
 
         // Original type of the extracted entity
-        String subType = ((Map<String, Object>)(er.data)).get(Constants.SubType).toString();
+        String subType = ((Map<String, Object>)(er.getData())).get(Constants.SubType).toString();
         ExtractResult dateTimeEr = new ExtractResult();
 
         // e.g. {next week Mon} or {Tue}, formmer--"next week Mon" doesn't contain "context" key
         boolean hasContext = false;
         ExtractResult contextEr = null;
-        if (((Map<String, Object>)er.data).containsKey(Constants.Context)) {
-            contextEr = (ExtractResult)((Map<String, Object>)er.data).get(Constants.Context);
-            if (contextEr.type.equals(Constants.ContextType_RelativeSuffix)) {
-                dateTimeEr = dateTimeEr.withText(String.format("%s %s", er.text, contextEr.text));
+        if (((Map<String, Object>)er.getData()).containsKey(Constants.Context)) {
+            contextEr = (ExtractResult)((Map<String, Object>)er.getData()).get(Constants.Context);
+            if (contextEr.getType().equals(Constants.ContextType_RelativeSuffix)) {
+                dateTimeEr.setText(String.format("%s %s", er.getText(), contextEr.getText()));
             } else {
-                dateTimeEr = dateTimeEr.withText(String.format("%s %s", contextEr.text, er.text));
+                dateTimeEr.setText(String.format("%s %s", contextEr.getText(), er.getText()));
             }
 
             hasContext = true;
         } else {
-            dateTimeEr = dateTimeEr.withText(er.text);
+            dateTimeEr.setText(er.getText());
         }
 
-        dateTimeEr = dateTimeEr.withData(er.data);
+        dateTimeEr.setData(er.getData());
         DateTimeParseResult dateTimePr = null;
 
         if (subType.equals(Constants.SYS_DATETIME_DATE)) {
-            dateTimeEr = dateTimeEr.withType(Constants.SYS_DATETIME_DATE);
+            dateTimeEr.setType(Constants.SYS_DATETIME_DATE);
             dateTimePr = this.config.getDateParser().parse(dateTimeEr, referenceTime);
         } else if (subType.equals(Constants.SYS_DATETIME_TIME)) {
             if (!hasContext) {
-                dateTimeEr = dateTimeEr.withType(Constants.SYS_DATETIME_TIME);
+                dateTimeEr.setType(Constants.SYS_DATETIME_TIME);
                 dateTimePr = this.config.getTimeParser().parse(dateTimeEr, referenceTime);
-            } else if (contextEr.type.equals(Constants.SYS_DATETIME_DATE) || contextEr.type.equals(Constants.ContextType_RelativePrefix)) {
+            } else if (contextEr.getType().equals(Constants.SYS_DATETIME_DATE) || contextEr.getType().equals(Constants.ContextType_RelativePrefix)) {
                 // For cases:
                 //      Monday 9 am or 11 am
                 //      next 9 am or 11 am
-                dateTimeEr = dateTimeEr.withType(Constants.SYS_DATETIME_DATETIME);
+                dateTimeEr.setType(Constants.SYS_DATETIME_DATETIME);
                 dateTimePr = this.config.getDateTimeParser().parse(dateTimeEr, referenceTime);
-            } else if (contextEr.type.equals(Constants.ContextType_AmPm)) {
+            } else if (contextEr.getType().equals(Constants.ContextType_AmPm)) {
                 // For cases: in the afternoon 3 o'clock or 5 o'clock
-                dateTimeEr = dateTimeEr.withType(Constants.SYS_DATETIME_TIME);
+                dateTimeEr.setType(Constants.SYS_DATETIME_TIME);
                 dateTimePr = this.config.getTimeParser().parse(dateTimeEr, referenceTime);
             }
         } else if (subType.equals(Constants.SYS_DATETIME_DATETIME)) {
             // "next week Mon 9 am or Tue 1 pm"
-            dateTimeEr = dateTimeEr.withType(Constants.SYS_DATETIME_DATETIME);
+            dateTimeEr.setType(Constants.SYS_DATETIME_DATETIME);
             dateTimePr = this.config.getDateTimeParser().parse(dateTimeEr, referenceTime);
         } else if (subType.equals(Constants.SYS_DATETIME_TIMEPERIOD)) {
             if (!hasContext) {
-                dateTimeEr = dateTimeEr.withType(Constants.SYS_DATETIME_TIMEPERIOD);
+                dateTimeEr.setType(Constants.SYS_DATETIME_TIMEPERIOD);
                 dateTimePr = this.config.getTimePeriodParser().parse(dateTimeEr, referenceTime);
-            } else if (contextEr.type.equals(Constants.SYS_DATETIME_DATE) || contextEr.type.equals(Constants.ContextType_RelativePrefix)) {
-                dateTimeEr = dateTimeEr.withType(Constants.SYS_DATETIME_DATETIMEPERIOD);
+            } else if (contextEr.getType().equals(Constants.SYS_DATETIME_DATE) || contextEr.getType().equals(Constants.ContextType_RelativePrefix)) {
+                dateTimeEr.setType(Constants.SYS_DATETIME_DATETIMEPERIOD);
                 dateTimePr = this.config.getDateTimePeriodParser().parse(dateTimeEr, referenceTime);
             }
         } else if (subType.equals(Constants.SYS_DATETIME_DATETIMEPERIOD)) {
-            dateTimeEr = dateTimeEr.withType(Constants.SYS_DATETIME_DATETIMEPERIOD);
+            dateTimeEr.setType(Constants.SYS_DATETIME_DATETIMEPERIOD);
             dateTimePr = this.config.getDateTimePeriodParser().parse(dateTimeEr, referenceTime);
         } else if (subType.equals(Constants.SYS_DATETIME_DATEPERIOD)) {
-            dateTimeEr = dateTimeEr.withType(Constants.SYS_DATETIME_DATEPERIOD);
+            dateTimeEr.setType(Constants.SYS_DATETIME_DATEPERIOD);
             dateTimePr = this.config.getDatePeriodParser().parse(dateTimeEr, referenceTime);
         }
 
-        if (dateTimePr != null && dateTimePr.value != null) {
-            ret.setFutureValue(((DateTimeResolutionResult)dateTimePr.value).getFutureValue());
-            ret.setPastValue(((DateTimeResolutionResult)dateTimePr.value).getPastValue());
-            ret.setTimex(dateTimePr.timexStr);
+        if (dateTimePr != null && dateTimePr.getValue() != null) {
+            ret.setFutureValue(((DateTimeResolutionResult)dateTimePr.getValue()).getFutureValue());
+            ret.setPastValue(((DateTimeResolutionResult)dateTimePr.getValue()).getPastValue());
+            ret.setTimex(dateTimePr.getTimexStr());
 
             // Create resolution
             getResolution(er, dateTimePr, ret);
@@ -140,8 +139,8 @@ public class BaseDateTimeAltParser implements IDateTimeParser {
     }
 
     private void getResolution(ExtractResult er, DateTimeParseResult pr, DateTimeResolutionResult ret) {
-        String parentText = ((Map<String, Object>)er.data).get(ExtendedModelResult.ParentTextKey).toString();
-        String type = pr.type;
+        String parentText = ((Map<String, Object>)er.getData()).get(ExtendedModelResult.ParentTextKey).toString();
+        String type = pr.getType();
 
         boolean isPeriod = false;
         boolean isSinglePoint = false;
@@ -240,12 +239,12 @@ public class BaseDateTimeAltParser implements IDateTimeParser {
                     .build());
         }
 
-        if (((DateTimeResolutionResult)pr.value).getMod() != null) {
-            ret.setMod(((DateTimeResolutionResult)pr.value).getMod());
+        if (((DateTimeResolutionResult)pr.getValue()).getMod() != null) {
+            ret.setMod(((DateTimeResolutionResult)pr.getValue()).getMod());
         }
 
-        if (((DateTimeResolutionResult)pr.value).getTimeZoneResolution() != null) {
-            ret.setTimeZoneResolution(((DateTimeResolutionResult)pr.value).getTimeZoneResolution());
+        if (((DateTimeResolutionResult)pr.getValue()).getTimeZoneResolution() != null) {
+            ret.setTimeZoneResolution(((DateTimeResolutionResult)pr.getValue()).getTimeZoneResolution());
         }
     }
 

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/parsers/BaseDateTimePeriodParser.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/parsers/BaseDateTimePeriodParser.java
@@ -60,32 +60,32 @@ public class BaseDateTimePeriodParser implements IDateTimeParser {
 
         Object value = null;
 
-        if (er.type.equals(getParserName())) {
-            DateTimeResolutionResult innerResult = this.mergeDateAndTimePeriods(er.text, referenceDate);
+        if (er.getType().equals(getParserName())) {
+            DateTimeResolutionResult innerResult = this.mergeDateAndTimePeriods(er.getText(), referenceDate);
 
             if (!innerResult.getSuccess()) {
-                innerResult = this.mergeTwoTimePoints(er.text, referenceDate);
+                innerResult = this.mergeTwoTimePoints(er.getText(), referenceDate);
             }
 
             if (!innerResult.getSuccess()) {
-                innerResult = this.parseSpecificTimeOfDay(er.text, referenceDate);
+                innerResult = this.parseSpecificTimeOfDay(er.getText(), referenceDate);
             }
 
             if (!innerResult.getSuccess()) {
-                innerResult = this.parseDuration(er.text, referenceDate);
+                innerResult = this.parseDuration(er.getText(), referenceDate);
             }
 
             if (!innerResult.getSuccess()) {
-                innerResult = this.parseRelativeUnit(er.text, referenceDate);
+                innerResult = this.parseRelativeUnit(er.getText(), referenceDate);
             }
 
             if (!innerResult.getSuccess()) {
-                innerResult = this.parseDateWithPeriodPrefix(er.text, referenceDate);
+                innerResult = this.parseDateWithPeriodPrefix(er.getText(), referenceDate);
             }
 
             if (!innerResult.getSuccess()) {
                 // Cases like "today after 2:00pm", "1/1/2015 before 2:00 in the afternoon"
-                innerResult = this.parseDateWithTimePeriodSuffix(er.text, referenceDate);
+                innerResult = this.parseDateWithTimePeriodSuffix(er.getText(), referenceDate);
             }
 
             if (innerResult.getSuccess()) {
@@ -133,11 +133,11 @@ public class BaseDateTimePeriodParser implements IDateTimeParser {
         }
 
         DateTimeParseResult ret = new DateTimeParseResult(
-                er.start,
-                er.length,
-                er.text,
-                er.type,
-                er.data,
+                er.getStart(),
+                er.getLength(),
+                er.getText(),
+                er.getType(),
+                er.getData(),
                 value,
                 "",
                 value == null ? "" : ((DateTimeResolutionResult)value).getTimex());
@@ -161,7 +161,7 @@ public class BaseDateTimePeriodParser implements IDateTimeParser {
             return parsePureNumberCases(text, referenceTime);
         } else if (ers.size() == 1) {
             ParseResult timePeriodParseResult = config.getTimePeriodParser().parse(ers.get(0));
-            DateTimeResolutionResult timePeriodResolutionResult = (DateTimeResolutionResult)timePeriodParseResult.value;
+            DateTimeResolutionResult timePeriodResolutionResult = (DateTimeResolutionResult)timePeriodParseResult.getValue();
 
             if (timePeriodResolutionResult == null) {
                 return parsePureNumberCases(text, referenceTime);
@@ -176,22 +176,22 @@ public class BaseDateTimePeriodParser implements IDateTimeParser {
 
             // If it is a range type timex
             if (TimexUtility.isRangeTimex(timePeriodTimex)) {
-                List<ExtractResult> dateResult = config.getDateExtractor().extract(trimmedText.replace(ers.get(0).text, ""), referenceTime);
-                String dateText = trimmedText.replace(ers.get(0).text, "").replace(config.getTokenBeforeDate(), "").trim();
+                List<ExtractResult> dateResult = config.getDateExtractor().extract(trimmedText.replace(ers.get(0).getText(), ""), referenceTime);
+                String dateText = trimmedText.replace(ers.get(0).getText(), "").replace(config.getTokenBeforeDate(), "").trim();
 
                 // If only one Date is extracted and the Date text equals to the rest part of source text
-                if (dateResult.size() == 1 && dateText.equals(dateResult.get(0).text)) {
+                if (dateResult.size() == 1 && dateText.equals(dateResult.get(0).getText())) {
                     String dateTimex;
                     LocalDateTime futureTime;
                     LocalDateTime pastTime;
 
                     DateTimeParseResult pr = config.getDateParser().parse(dateResult.get(0), referenceTime);
 
-                    if (pr.value != null) {
-                        futureTime = (LocalDateTime)((DateTimeResolutionResult)pr.value).getFutureValue();
-                        pastTime = (LocalDateTime)((DateTimeResolutionResult)pr.value).getPastValue();
+                    if (pr.getValue() != null) {
+                        futureTime = (LocalDateTime)((DateTimeResolutionResult)pr.getValue()).getFutureValue();
+                        pastTime = (LocalDateTime)((DateTimeResolutionResult)pr.getValue()).getPastValue();
 
-                        dateTimex = pr.timexStr;
+                        dateTimex = pr.getTimexStr();
                     } else {
                         return parsePureNumberCases(text, referenceTime);
                     }
@@ -273,12 +273,12 @@ public class BaseDateTimePeriodParser implements IDateTimeParser {
 
             if (ers.size() > 0) {
                 DateTimeParseResult pr = config.getDateParser().parse(ers.get(0), referenceTime);
-                if (pr.value != null) {
-                    DateTimeResolutionResult prValue = (DateTimeResolutionResult)pr.value;
+                if (pr.getValue() != null) {
+                    DateTimeResolutionResult prValue = (DateTimeResolutionResult)pr.getValue();
                     futureDate = (LocalDateTime)prValue.getFutureValue();
                     pastDate = (LocalDateTime)prValue.getPastValue();
 
-                    dateStr = pr.timexStr;
+                    dateStr = pr.getTimexStr();
 
                     if (prValue.getTimeZoneResolution() != null) {
                         ret.setTimeZoneResolution(prValue.getTimeZoneResolution());
@@ -411,11 +411,11 @@ public class BaseDateTimePeriodParser implements IDateTimeParser {
                 beginHasDate = true;
             }
         } else if (dateTimeExtractResults.size() == 1 && timeExtractResults.size() == 1) {
-            if (timeExtractResults.get(0).start < dateTimeExtractResults.get(0).start) {
+            if (timeExtractResults.get(0).getStart() < dateTimeExtractResults.get(0).getStart()) {
                 pr1 = config.getTimeParser().parse(timeExtractResults.get(0), referenceDate);
                 pr2 = config.getDateTimeParser().parse(dateTimeExtractResults.get(0), referenceDate);
                 endHasDate = true;
-            } else if (timeExtractResults.get(0).start >= dateTimeExtractResults.get(0).start + dateTimeExtractResults.get(0).length) {
+            } else if (timeExtractResults.get(0).getStart() >= dateTimeExtractResults.get(0).getStart() + dateTimeExtractResults.get(0).getLength()) {
                 pr1 = config.getDateTimeParser().parse(dateTimeExtractResults.get(0), referenceDate);
                 pr2 = config.getTimeParser().parse(timeExtractResults.get(0), referenceDate);
                 beginHasDate = true;
@@ -430,15 +430,15 @@ public class BaseDateTimePeriodParser implements IDateTimeParser {
             return result;
         }
 
-        if (pr1.value == null || pr2.value == null) {
+        if (pr1.getValue() == null || pr2.getValue() == null) {
             return result;
         }
 
-        LocalDateTime futureBegin = (LocalDateTime)((DateTimeResolutionResult)pr1.value).getFutureValue();
-        LocalDateTime futureEnd = (LocalDateTime)((DateTimeResolutionResult)pr2.value).getFutureValue();
+        LocalDateTime futureBegin = (LocalDateTime)((DateTimeResolutionResult)pr1.getValue()).getFutureValue();
+        LocalDateTime futureEnd = (LocalDateTime)((DateTimeResolutionResult)pr2.getValue()).getFutureValue();
 
-        LocalDateTime pastBegin = (LocalDateTime)((DateTimeResolutionResult)pr1.value).getPastValue();
-        LocalDateTime pastEnd = (LocalDateTime)((DateTimeResolutionResult)pr2.value).getPastValue();
+        LocalDateTime pastBegin = (LocalDateTime)((DateTimeResolutionResult)pr1.getValue()).getPastValue();
+        LocalDateTime pastEnd = (LocalDateTime)((DateTimeResolutionResult)pr2.getValue()).getPastValue();
 
         if (bothHaveDates) {
             if (futureBegin.isAfter(futureEnd)) {
@@ -451,14 +451,14 @@ public class BaseDateTimePeriodParser implements IDateTimeParser {
         }
 
         if (bothHaveDates) {
-            result.setTimex(String.format("(%s,%s,PT%dH)", pr1.timexStr, pr2.timexStr, Math.round(ChronoUnit.SECONDS.between(futureBegin, futureEnd) / 3600f)));
+            result.setTimex(String.format("(%s,%s,PT%dH)", pr1.getTimexStr(), pr2.getTimexStr(), Math.round(ChronoUnit.SECONDS.between(futureBegin, futureEnd) / 3600f)));
             // Do nothing
         } else if (beginHasDate) {
             futureEnd = DateUtil.safeCreateFromMinValue(futureBegin.toLocalDate(), futureEnd.toLocalTime());
             pastEnd = DateUtil.safeCreateFromMinValue(pastBegin.toLocalDate(), pastEnd.toLocalTime());
 
-            String dateStr = pr1.timexStr.split("T")[0];
-            result.setTimex(String.format("(%s,%s,PT%dH)", pr1.timexStr, dateStr + pr2.timexStr, ChronoUnit.HOURS.between(futureBegin, futureEnd)));
+            String dateStr = pr1.getTimexStr().split("T")[0];
+            result.setTimex(String.format("(%s,%s,PT%dH)", pr1.getTimexStr(), dateStr + pr2.getTimexStr(), ChronoUnit.HOURS.between(futureBegin, futureEnd)));
         } else if (endHasDate) {
             futureBegin = DateUtil.safeCreateFromMinValue(futureEnd.getYear(), futureEnd.getMonthValue(), futureEnd.getDayOfMonth(),
                     futureBegin.getHour(), futureBegin.getMinute(), futureBegin.getSecond());
@@ -467,12 +467,12 @@ public class BaseDateTimePeriodParser implements IDateTimeParser {
                     pastBegin.getHour(), pastBegin.getMinute(), pastBegin.getSecond());
 
 
-            String dateStr = pr2.timexStr.split("T")[0];
-            result.setTimex(String.format("(%s,%s,PT%dH)", dateStr + pr1.timexStr, pr2.timexStr, ChronoUnit.HOURS.between(futureBegin, futureEnd)));
+            String dateStr = pr2.getTimexStr().split("T")[0];
+            result.setTimex(String.format("(%s,%s,PT%dH)", dateStr + pr1.getTimexStr(), pr2.getTimexStr(), ChronoUnit.HOURS.between(futureBegin, futureEnd)));
         }
 
-        DateTimeResolutionResult pr1Value = (DateTimeResolutionResult)pr1.value;
-        DateTimeResolutionResult pr2Value = (DateTimeResolutionResult)pr2.value;
+        DateTimeResolutionResult pr1Value = (DateTimeResolutionResult)pr1.getValue();
+        DateTimeResolutionResult pr2Value = (DateTimeResolutionResult)pr2.getValue();
 
         String ampmStr1 = pr1Value.getComment();
         String ampmStr2 = pr2Value.getComment();
@@ -610,21 +610,23 @@ public class BaseDateTimePeriodParser implements IDateTimeParser {
             // Eliminate time period, if any
             List<ExtractResult> timePeriodErs = config.getTimePeriodExtractor().extract(beforeStr);
             if (timePeriodErs.size() > 0) {
-                beforeStr = beforeStr.substring(0, timePeriodErs.get(0).start) + beforeStr.substring(timePeriodErs.get(0).start + timePeriodErs.get(0).length).trim();
+                beforeStr = beforeStr.substring(0, timePeriodErs.get(0).getStart()) + beforeStr.substring(timePeriodErs.get(0).getStart() + timePeriodErs.get(0).getLength())
+                        .trim();
             } else {
                 timePeriodErs = config.getTimePeriodExtractor().extract(afterStr);
                 if (timePeriodErs.size() > 0) {
-                    afterStr = afterStr.substring(0, timePeriodErs.get(0).start) + afterStr.substring(timePeriodErs.get(0).start + timePeriodErs.get(0).length).trim();
+                    afterStr = afterStr.substring(0, timePeriodErs.get(0).getStart()) + afterStr.substring(timePeriodErs.get(0).getStart() + timePeriodErs.get(0).getLength())
+                            .trim();
                 }
             }
 
             List<ExtractResult> ers = config.getDateExtractor().extract(beforeStr + " " + afterStr, referenceDate);
 
-            if (ers.size() == 0 || ers.get(0).length < beforeStr.length()) {
+            if (ers.size() == 0 || ers.get(0).getLength() < beforeStr.length()) {
                 boolean valid = false;
 
-                if (ers.size() > 0 && ers.get(0).start == 0) {
-                    String midStr = beforeStr.substring(ers.get(0).start + ers.get(0).length);
+                if (ers.size() > 0 && ers.get(0).getStart() == 0) {
+                    String midStr = beforeStr.substring(ers.get(0).getStart() + ers.get(0).getLength());
                     if (StringUtility.isNullOrWhiteSpace(midStr.replace(",", " "))) {
                         valid = true;
                     }
@@ -633,9 +635,9 @@ public class BaseDateTimePeriodParser implements IDateTimeParser {
                 if (!valid) {
                     ers = config.getDateExtractor().extract(afterStr, referenceDate);
 
-                    if (ers.size() == 0 || ers.get(0).length != beforeStr.length()) {
-                        if (ers.size() > 0 && ers.get(0).start + ers.get(0).length == afterStr.length()) {
-                            String midStr = afterStr.substring(0, ers.get(0).start);
+                    if (ers.size() == 0 || ers.get(0).getLength() != beforeStr.length()) {
+                        if (ers.size() > 0 && ers.get(0).getStart() + ers.get(0).getLength() == afterStr.length()) {
+                            String midStr = afterStr.substring(0, ers.get(0).getStart());
                             if (StringUtility.isNullOrWhiteSpace(midStr.replace(",", " "))) {
                                 valid = true;
                             }
@@ -654,8 +656,8 @@ public class BaseDateTimePeriodParser implements IDateTimeParser {
             if (timePeriodErs.size() > 0) {
                 DateTimeParseResult timePr = config.getTimePeriodParser().parse(timePeriodErs.get(0), referenceDate);
                 if (timePr != null) {
-                    Pair<LocalDateTime, LocalDateTime> periodFuture = (Pair<LocalDateTime, LocalDateTime>)((DateTimeResolutionResult)timePr.value).getFutureValue();
-                    Pair<LocalDateTime, LocalDateTime> periodPast = (Pair<LocalDateTime, LocalDateTime>)((DateTimeResolutionResult)timePr.value).getPastValue();
+                    Pair<LocalDateTime, LocalDateTime> periodFuture = (Pair<LocalDateTime, LocalDateTime>)((DateTimeResolutionResult)timePr.getValue()).getFutureValue();
+                    Pair<LocalDateTime, LocalDateTime> periodPast = (Pair<LocalDateTime, LocalDateTime>)((DateTimeResolutionResult)timePr.getValue()).getPastValue();
 
                     if (periodFuture == periodPast) {
                         beginHour = periodFuture.getValue0().getHour();
@@ -675,13 +677,13 @@ public class BaseDateTimePeriodParser implements IDateTimeParser {
             }
 
             DateTimeParseResult pr = config.getDateParser().parse(ers.get(0), referenceDate);
-            LocalDateTime futureDate = (LocalDateTime)((DateTimeResolutionResult)pr.value).getFutureValue();
-            LocalDateTime pastDate = (LocalDateTime)((DateTimeResolutionResult)pr.value).getPastValue();
+            LocalDateTime futureDate = (LocalDateTime)((DateTimeResolutionResult)pr.getValue()).getFutureValue();
+            LocalDateTime pastDate = (LocalDateTime)((DateTimeResolutionResult)pr.getValue()).getPastValue();
 
             if (!hasSpecificTimePeriod) {
-                result.setTimex(pr.timexStr + timeStr);
+                result.setTimex(pr.getTimexStr() + timeStr);
             } else {
-                result.setTimex(String.format("(%sT%d,%sT%d,PT%dH)", pr.timexStr, beginHour, pr.timexStr, endHour, endHour - beginHour));
+                result.setTimex(String.format("(%sT%d,%sT%d,PT%dH)", pr.getTimexStr(), beginHour, pr.getTimexStr(), endHour, endHour - beginHour));
             }
 
             Pair<LocalDateTime, LocalDateTime> futureResult = new Pair<LocalDateTime, LocalDateTime>(
@@ -728,31 +730,31 @@ public class BaseDateTimePeriodParser implements IDateTimeParser {
         if (ers.size() == 1) {
             ParseResult pr = config.getDurationParser().parse(ers.get(0));
 
-            String beforeStr = text.substring(0, pr.start).trim().toLowerCase();
-            String afterStr = text.substring(pr.start + pr.length).trim().toLowerCase();
+            String beforeStr = text.substring(0, pr.getStart()).trim().toLowerCase();
+            String afterStr = text.substring(pr.getStart() + pr.getLength()).trim().toLowerCase();
 
             List<ExtractResult> numbersInSuffix = config.getCardinalExtractor().extract(beforeStr);
-            List<ExtractResult> numbersInDuration = config.getCardinalExtractor().extract(ers.get(0).text);
+            List<ExtractResult> numbersInDuration = config.getCardinalExtractor().extract(ers.get(0).getText());
 
             // Handle cases like "2 upcoming days", "5 previous years"
             if (!numbersInSuffix.isEmpty() && numbersInDuration.isEmpty()) {
                 ExtractResult numberEr = numbersInSuffix.get(0);
-                String numberText = numberEr.text;
-                String durationText = ers.get(0).text;
+                String numberText = numberEr.getText();
+                String durationText = ers.get(0).getText();
                 String combinedText = String.format("%s %s", numberText, durationText);
                 List<ExtractResult> combinedDurationEr = config.getDurationExtractor().extract(combinedText, referenceTime);
 
                 if (!combinedDurationEr.isEmpty()) {
                     pr = config.getDurationParser().parse(combinedDurationEr.get(0));
-                    int startIndex = numberEr.start + numberEr.length;
+                    int startIndex = numberEr.getStart() + numberEr.getLength();
                     beforeStr = beforeStr.substring(startIndex).trim();
                 }
             }
 
-            if (pr.value != null) {
+            if (pr.getValue() != null) {
                 int swiftSeconds = 0;
                 String mod = "";
-                DateTimeResolutionResult durationResult = (DateTimeResolutionResult)pr.value;
+                DateTimeResolutionResult durationResult = (DateTimeResolutionResult)pr.getValue();
 
                 if (durationResult.getPastValue() instanceof Double && durationResult.getFutureValue() instanceof Double) {
                     swiftSeconds = Math.round(((Double)durationResult.getPastValue()).floatValue());
@@ -809,7 +811,7 @@ public class BaseDateTimePeriodParser implements IDateTimeParser {
                 result.setSuccess(true);
 
                 if (!StringUtility.isNullOrEmpty(mod)) {
-                    ((DateTimeResolutionResult)pr.value).setMod(mod);
+                    ((DateTimeResolutionResult)pr.getValue()).setMod(mod);
                 }
 
                 List<Object> subDateTimeEntities = new ArrayList<Object>();
@@ -900,12 +902,12 @@ public class BaseDateTimePeriodParser implements IDateTimeParser {
 
         List<ExtractResult> dateResult = config.getDateExtractor().extract(text);
         if (dateResult.size() > 0) {
-            String beforeStr = StringUtility.trimEnd(text.substring(0, dateResult.get(dateResult.size() - 1).start));
+            String beforeStr = StringUtility.trimEnd(text.substring(0, dateResult.get(dateResult.size() - 1).getStart()));
             Optional<Match> match = Arrays.stream(RegExpUtility.getMatches(config.getPrefixDayRegex(), beforeStr)).findFirst();
             if (match.isPresent()) {
                 DateTimeParseResult pr = config.getDateParser().parse(dateResult.get(dateResult.size() - 1), referenceDate);
-                if (pr.value != null) {
-                    LocalDateTime startTime = (LocalDateTime)((DateTimeResolutionResult)pr.value).getFutureValue();
+                if (pr.getValue() != null) {
+                    LocalDateTime startTime = (LocalDateTime)((DateTimeResolutionResult)pr.getValue()).getFutureValue();
                     startTime = LocalDateTime.of(startTime.getYear(), startTime.getMonthValue(), startTime.getDayOfMonth(), 0, 0, 0);
                     LocalDateTime endTime = startTime;
 
@@ -924,7 +926,7 @@ public class BaseDateTimePeriodParser implements IDateTimeParser {
                         return result;
                     }
 
-                    result.setTimex(pr.timexStr);
+                    result.setTimex(pr.getTimexStr());
 
                     Pair<LocalDateTime, LocalDateTime> resultValue = new Pair<LocalDateTime, LocalDateTime>(startTime, endTime);
 
@@ -946,25 +948,25 @@ public class BaseDateTimePeriodParser implements IDateTimeParser {
         Optional<ExtractResult> timeEr = config.getTimeExtractor().extract(text).stream().findFirst();
 
         if (dateEr.isPresent() && timeEr.isPresent()) {
-            int dateStrEnd = dateEr.get().start + dateEr.get().length;
+            int dateStrEnd = dateEr.get().getStart() + dateEr.get().getLength();
 
-            if (dateStrEnd < timeEr.get().start) {
-                String midStr = text.substring(dateStrEnd, timeEr.get().start);
+            if (dateStrEnd < timeEr.get().getStart()) {
+                String midStr = text.substring(dateStrEnd, timeEr.get().getStart());
 
                 if (isValidConnectorForDateAndTimePeriod(midStr)) {
                     DateTimeParseResult datePr = config.getDateParser().parse(dateEr.get(), referenceDate);
                     DateTimeParseResult timePr = config.getTimeParser().parse(timeEr.get(), referenceDate);
 
                     if (datePr != null && timePr != null) {
-                        DateTimeResolutionResult timeResolutionResult = (DateTimeResolutionResult)timePr.value;
-                        DateTimeResolutionResult dateResolutionResult = (DateTimeResolutionResult)datePr.value;
+                        DateTimeResolutionResult timeResolutionResult = (DateTimeResolutionResult)timePr.getValue();
+                        DateTimeResolutionResult dateResolutionResult = (DateTimeResolutionResult)datePr.getValue();
                         LocalDateTime futureDateValue = (LocalDateTime)dateResolutionResult.getFutureValue();
                         LocalDateTime pastDateValue = (LocalDateTime)dateResolutionResult.getPastValue();
                         LocalDateTime futureTimeValue = (LocalDateTime)timeResolutionResult.getFutureValue();
                         LocalDateTime pastTimeValue = (LocalDateTime)timeResolutionResult.getPastValue();
 
                         result.setComment(timeResolutionResult.getComment());
-                        result.setTimex(datePr.timexStr + timePr.timexStr);
+                        result.setTimex(datePr.getTimexStr() + timePr.getTimexStr());
 
                         result.setFutureValue(DateUtil.safeCreateFromMinValue(futureDateValue.toLocalDate(), futureTimeValue.toLocalTime()));
                         result.setPastValue(DateUtil.safeCreateFromMinValue(pastDateValue.toLocalDate(), pastTimeValue.toLocalTime()));
@@ -981,8 +983,8 @@ public class BaseDateTimePeriodParser implements IDateTimeParser {
 
                         result.setSubDateTimeEntities(subDateTimeEntities);
 
-                        if (((DateTimeResolutionResult)timePr.value).getTimeZoneResolution() != null) {
-                            result.setTimeZoneResolution(((DateTimeResolutionResult)timePr.value).getTimeZoneResolution());
+                        if (((DateTimeResolutionResult)timePr.getValue()).getTimeZoneResolution() != null) {
+                            result.setTimeZoneResolution(((DateTimeResolutionResult)timePr.getValue()).getTimeZoneResolution());
                         }
 
                         result.setSuccess(true);

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/parsers/BaseDurationParser.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/parsers/BaseDurationParser.java
@@ -46,17 +46,17 @@ public class BaseDurationParser implements IDateTimeParser {
 
         Object value = null;
 
-        if (er.type.equals(getParserName())) {
+        if (er.getType().equals(getParserName())) {
             DateTimeResolutionResult innerResult;
 
-            innerResult = parseMergedDuration(er.text, reference);
+            innerResult = parseMergedDuration(er.getText(), reference);
 
             if (!innerResult.getSuccess()) {
-                innerResult = parseNumberWithUnit(er.text, reference);
+                innerResult = parseNumberWithUnit(er.getText(), reference);
             }
 
             if (!innerResult.getSuccess()) {
-                innerResult = parseImplicitDuration(er.text, reference);
+                innerResult = parseImplicitDuration(er.getText(), reference);
             }
 
             if (innerResult.getSuccess()) {
@@ -68,10 +68,10 @@ public class BaseDurationParser implements IDateTimeParser {
                         .put(TimeTypeConstants.DURATION, StringUtility.format((Double)innerResult.getPastValue()))
                         .build());
 
-                if (er.data != null) {
-                    if (er.data.equals(Constants.MORE_THAN_MOD)) {
+                if (er.getData() != null) {
+                    if (er.getData().equals(Constants.MORE_THAN_MOD)) {
                         innerResult.setMod(Constants.MORE_THAN_MOD);
-                    } else if (er.data.equals(Constants.LESS_THAN_MOD)) {
+                    } else if (er.getData().equals(Constants.LESS_THAN_MOD)) {
                         innerResult.setMod(Constants.LESS_THAN_MOD);
                     }
                 }
@@ -81,11 +81,11 @@ public class BaseDurationParser implements IDateTimeParser {
         }
 
         DateTimeParseResult result = new DateTimeParseResult(
-                er.start,
-                er.length,
-                er.text,
-                er.type,
-                er.data,
+                er.getStart(),
+                er.getLength(),
+                er.getText(),
+                er.getType(),
+                er.getData(),
                 value,
                 "",
                 value == null ? "" : ((DateTimeResolutionResult)value).getTimex()
@@ -108,7 +108,7 @@ public class BaseDurationParser implements IDateTimeParser {
             return result;
         }
 
-        int start = ers.get(0).start;
+        int start = ers.get(0).getStart();
         if (start != 0) {
             String beforeStr = text.substring(0, start - 1);
             if (!StringUtility.isNullOrWhiteSpace(beforeStr)) {
@@ -116,7 +116,7 @@ public class BaseDurationParser implements IDateTimeParser {
             }
         }
 
-        int end = ers.get(ers.size() - 1).start + ers.get(ers.size() - 1).length;
+        int end = ers.get(ers.size() - 1).getStart() + ers.get(ers.size() - 1).getLength();
         if (end != text.length()) {
             String afterStr = text.substring(end);
             if (!StringUtility.isNullOrWhiteSpace(afterStr)) {
@@ -130,11 +130,11 @@ public class BaseDurationParser implements IDateTimeParser {
         // insert timex into a dictionary
         for (ExtractResult er : ers) {
             Pattern unitRegex = config.getDurationUnitRegex();
-            Optional<Match> unitMatch = Arrays.stream(RegExpUtility.getMatches(unitRegex, er.text)).findFirst();
+            Optional<Match> unitMatch = Arrays.stream(RegExpUtility.getMatches(unitRegex, er.getText())).findFirst();
             if (unitMatch.isPresent()) {
                 DateTimeParseResult pr = (DateTimeParseResult)parse(er);
-                if (pr.value != null) {
-                    timexMap.put(unitMatch.get().getGroup("unit").value, pr.timexStr);
+                if (pr.getValue() != null) {
+                    timexMap.put(unitMatch.get().getGroup("unit").value, pr.getTimexStr());
                     prs.add(pr);
                 }
             }
@@ -147,7 +147,7 @@ public class BaseDurationParser implements IDateTimeParser {
 
             double value = 0;
             for (DateTimeParseResult pr : prs) {
-                value += Double.parseDouble(((DateTimeResolutionResult)pr.value).getFutureValue().toString());
+                value += Double.parseDouble(((DateTimeResolutionResult)pr.getValue()).getFutureValue().toString());
             }
 
             result.setFutureValue(value);
@@ -202,7 +202,7 @@ public class BaseDurationParser implements IDateTimeParser {
 
             // followed unit: {num} (<followed unit>and a half hours)
             String srcUnit = "";
-            String noNum = text.substring(er.start + er.length).trim().toLowerCase();
+            String noNum = text.substring(er.getStart() + er.getLength()).trim().toLowerCase();
             String suffixStr = text;
 
             Optional<Match> match = Arrays.stream(RegExpUtility.getMatches(config.getFollowedUnit(), noNum)).findFirst();
@@ -212,7 +212,7 @@ public class BaseDurationParser implements IDateTimeParser {
             }
 
             if (match.isPresent() && !StringUtility.isNullOrEmpty(match.get().getGroup(Constants.BusinessDayGroupName).value)) {
-                int numVal = Math.round(Double.valueOf(pr.value.toString()).floatValue());
+                int numVal = Math.round(Double.valueOf(pr.getValue().toString()).floatValue());
 
                 String timex = TimexUtility.generateDurationTimex(numVal, Constants.TimexBusinessDay, false);
                 double timeValue = numVal * config.getUnitValueMap().get(srcUnit.split(" ")[1]);
@@ -225,7 +225,7 @@ public class BaseDurationParser implements IDateTimeParser {
             }
 
             if (config.getUnitMap().containsKey(srcUnit)) {
-                double numVal = Double.parseDouble(pr.value.toString()) + parseNumberWithUnitAndSuffix(suffixStr);
+                double numVal = Double.parseDouble(pr.getValue().toString()) + parseNumberWithUnitAndSuffix(suffixStr);
 
                 String unitStr = config.getUnitMap().get(srcUnit);
 

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/parsers/BaseHolidayParser.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/parsers/BaseHolidayParser.java
@@ -49,9 +49,9 @@ public class BaseHolidayParser implements IDateTimeParser {
         LocalDateTime referenceDate = reference;
         Object value = null;
 
-        if (er.type.equals(getParserName())) {
+        if (er.getType().equals(getParserName())) {
             
-            DateTimeResolutionResult innerResult = parseHolidayRegexMatch(er.text, referenceDate);
+            DateTimeResolutionResult innerResult = parseHolidayRegexMatch(er.getText(), referenceDate);
 
             if (innerResult.getSuccess()) {
                 HashMap<String, String> futureResolution = new HashMap<>();
@@ -66,11 +66,11 @@ public class BaseHolidayParser implements IDateTimeParser {
         }
 
         DateTimeParseResult ret = new DateTimeParseResult(
-                er.start,
-                er.length,
-                er.text,
-                er.type,
-                er.data,
+                er.getStart(),
+                er.getLength(),
+                er.getText(),
+                er.getType(),
+                er.getData(),
                 value,
                 "",
                 value == null ? "" : ((DateTimeResolutionResult)value).getTimex()

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/parsers/BaseTimeParser.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/parsers/BaseTimeParser.java
@@ -4,7 +4,6 @@ import com.google.common.collect.ImmutableMap;
 import com.microsoft.recognizers.text.ExtractResult;
 import com.microsoft.recognizers.text.ParseResult;
 import com.microsoft.recognizers.text.datetime.Constants;
-import com.microsoft.recognizers.text.datetime.DateTimeOptions;
 import com.microsoft.recognizers.text.datetime.TimeTypeConstants;
 import com.microsoft.recognizers.text.datetime.parsers.config.ITimeParserConfiguration;
 import com.microsoft.recognizers.text.datetime.parsers.config.PrefixAdjustResult;
@@ -56,24 +55,24 @@ public class BaseTimeParser implements IDateTimeParser {
 
         Object value = null;
 
-        if (er.type.equals(getParserName())) {
+        if (er.getType().equals(getParserName())) {
             DateTimeResolutionResult innerResult;
 
             // Resolve timezome
             if (TimeZoneUtility.shouldResolveTimeZone(er, config.getOptions())) {
-                Map<String, Object> metadata = (Map)er.data;
+                Map<String, Object> metadata = (Map)er.getData();
                 ExtractResult timezoneEr = (ExtractResult)metadata.get(Constants.SYS_DATETIME_TIMEZONE);
                 ParseResult timezonePr = config.getTimeZoneParser().parse(timezoneEr);
 
-                innerResult = internalParse(er.text.substring(0, er.text.length() - timezoneEr.length), referenceTime);
+                innerResult = internalParse(er.getText().substring(0, er.getText().length() - timezoneEr.getLength()), referenceTime);
 
-                if (timezonePr.value != null) {
-                    TimeZoneResolutionResult timeZoneResolution = ((DateTimeResolutionResult)timezonePr.value).getTimeZoneResolution();
+                if (timezonePr.getValue() != null) {
+                    TimeZoneResolutionResult timeZoneResolution = ((DateTimeResolutionResult)timezonePr.getValue()).getTimeZoneResolution();
                     innerResult.setTimeZoneResolution(timeZoneResolution);
                 }
 
             } else {
-                innerResult = internalParse(er.text, referenceTime);
+                innerResult = internalParse(er.getText(), referenceTime);
             }
 
             if (innerResult.getSuccess()) {
@@ -92,11 +91,11 @@ public class BaseTimeParser implements IDateTimeParser {
         }
 
         DateTimeParseResult ret = new DateTimeParseResult(
-                er.start,
-                er.length,
-                er.text,
-                er.type,
-                er.data,
+                er.getStart(),
+                er.getLength(),
+                er.getText(),
+                er.getType(),
+                er.getData(),
                 value,
                 "",
                 value == null ? "" : ((DateTimeResolutionResult)value).getTimex());

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/parsers/BaseTimePeriodParser.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/parsers/BaseTimePeriodParser.java
@@ -52,23 +52,23 @@ public class BaseTimePeriodParser implements IDateTimeParser {
     public DateTimeParseResult parse(ExtractResult er, LocalDateTime reference) {
         Object value = null;
 
-        if (er.type.equals(getParserName())) {
+        if (er.getType().equals(getParserName())) {
 
             DateTimeResolutionResult innerResult;
 
             if (TimeZoneUtility.shouldResolveTimeZone(er, config.getOptions())) {
-                Map<String, Object> metadata = (HashMap<String, Object>)er.data;
+                Map<String, Object> metadata = (HashMap<String, Object>)er.getData();
 
                 ExtractResult timezoneEr = (ExtractResult)metadata.get(Constants.SYS_DATETIME_TIMEZONE);
                 ParseResult timezonePr = config.getTimeZoneParser().parse(timezoneEr);
 
-                innerResult = internalParse(er.text.substring(0, er.length - timezoneEr.length), reference);
+                innerResult = internalParse(er.getText().substring(0, er.getLength() - timezoneEr.getLength()), reference);
 
-                if (timezonePr.value != null) {
-                    innerResult.setTimeZoneResolution(((DateTimeResolutionResult)timezonePr.value).getTimeZoneResolution());
+                if (timezonePr.getValue() != null) {
+                    innerResult.setTimeZoneResolution(((DateTimeResolutionResult)timezonePr.getValue()).getTimeZoneResolution());
                 }
             } else {
-                innerResult = internalParse(er.text, reference);
+                innerResult = internalParse(er.getText(), reference);
             }
 
             if (innerResult.getSuccess()) {
@@ -97,11 +97,11 @@ public class BaseTimePeriodParser implements IDateTimeParser {
         }
 
         DateTimeParseResult ret = new DateTimeParseResult(
-                er.start,
-                er.length,
-                er.text,
-                er.type,
-                er.data,
+                er.getStart(),
+                er.getLength(),
+                er.getText(),
+                er.getType(),
+                er.getData(),
                 value,
                 "",
                 value == null ? "" : ((DateTimeResolutionResult)value).getTimex());
@@ -514,12 +514,12 @@ public class BaseTimePeriodParser implements IDateTimeParser {
         if (ers.size() != 2) {
             if (ers.size() == 1) {
                 List<ExtractResult> numErs = this.config.getIntegerExtractor().extract(text);
-                int erStart = ers.get(0).start != null ? ers.get(0).start : 0;
-                int erLength = ers.get(0).length != null ? ers.get(0).length : 0;
+                int erStart = ers.get(0).getStart() != null ? ers.get(0).getStart() : 0;
+                int erLength = ers.get(0).getLength() != null ? ers.get(0).getLength() : 0;
 
                 for (ExtractResult num : numErs) {
-                    int numStart = num.start != null ? num.start : 0;
-                    int numLength = num.length != null ? num.length : 0;
+                    int numStart = num.getStart() != null ? num.getStart() : 0;
+                    int numLength = num.getLength() != null ? num.getLength() : 0;
                     int midStrBegin = 0;
                     int midStrEnd = 0;
                     // ending number
@@ -535,13 +535,15 @@ public class BaseTimePeriodParser implements IDateTimeParser {
                     String middleStr = text.substring(midStrBegin, midStrBegin + midStrEnd);
                     Optional<Match> tillMatch = Arrays.stream(RegExpUtility.getMatches(this.config.getTillRegex(), middleStr)).findFirst();
                     if (tillMatch.isPresent()) {
-                        ers.add(num.withData(null).withType(Constants.SYS_DATETIME_TIME));
+                        num.setData(null);
+                        num.setType(Constants.SYS_DATETIME_TIME);
+                        ers.add(num);
                         validTimeNumber = true;
                         break;
                     }
                 }
 
-                ers.sort(Comparator.comparingInt(x -> x.start));
+                ers.sort(Comparator.comparingInt(x -> x.getStart()));
             }
 
             if (!validTimeNumber) {
@@ -552,32 +554,32 @@ public class BaseTimePeriodParser implements IDateTimeParser {
         pr1 = this.config.getTimeParser().parse(ers.get(0), referenceTime);
         pr2 = this.config.getTimeParser().parse(ers.get(1), referenceTime);
 
-        if (pr1.value == null || pr2.value == null) {
+        if (pr1.getValue() == null || pr2.getValue() == null) {
             return ret;
         }
 
-        String ampmStr1 = ((DateTimeResolutionResult)pr1.value).getComment();
-        String ampmStr2 = ((DateTimeResolutionResult)pr2.value).getComment();
+        String ampmStr1 = ((DateTimeResolutionResult)pr1.getValue()).getComment();
+        String ampmStr2 = ((DateTimeResolutionResult)pr2.getValue()).getComment();
 
-        LocalDateTime beginTime = (LocalDateTime)((DateTimeResolutionResult)pr1.value).getFutureValue();
-        LocalDateTime endTime = (LocalDateTime)((DateTimeResolutionResult)pr2.value).getFutureValue();
+        LocalDateTime beginTime = (LocalDateTime)((DateTimeResolutionResult)pr1.getValue()).getFutureValue();
+        LocalDateTime endTime = (LocalDateTime)((DateTimeResolutionResult)pr2.getValue()).getFutureValue();
 
         if (!StringUtility.isNullOrEmpty(ampmStr2) && ampmStr2.endsWith(Constants.Comment_AmPm) &&
                 (endTime.compareTo(beginTime) < 1) && endTime.plusHours(Constants.HalfDayHourCount).isAfter(beginTime)) {
             endTime = endTime.plusHours(Constants.HalfDayHourCount);
-            ((DateTimeResolutionResult)pr2.value).setFutureValue(endTime);
-            pr2 = pr2.withTimexStr(String.format("T%s", endTime.getHour()));
+            ((DateTimeResolutionResult)pr2.getValue()).setFutureValue(endTime);
+            pr2.setTimexStr(String.format("T%s", endTime.getHour()));
             if (endTime.getMinute() > 0) {
-                pr2 = pr2.withTimexStr(String.format("%s:%s", pr2.timexStr, endTime.getMinute()));
+                pr2.setTimexStr(String.format("%s:%s", pr2.getTimexStr(), endTime.getMinute()));
             }
         }
 
         if (!StringUtility.isNullOrEmpty(ampmStr1) && ampmStr1.endsWith(Constants.Comment_AmPm) && endTime.isAfter(beginTime.plusHours(Constants.HalfDayHourCount))) {
             beginTime = beginTime.plusHours(Constants.HalfDayHourCount);
-            ((DateTimeResolutionResult)pr1.value).setFutureValue(beginTime);
-            pr1 = pr1.withTimexStr(String.format("T%s", beginTime.getHour()));
+            ((DateTimeResolutionResult)pr1.getValue()).setFutureValue(beginTime);
+            pr1.setTimexStr(String.format("T%s", beginTime.getHour()));
             if (beginTime.getMinute() > 0) {
-                pr1 = pr1.withTimexStr(String.format("%s:%s", pr1.timexStr, beginTime.getMinute()));
+                pr1.setTimexStr(String.format("%s:%s", pr1.getTimexStr(), beginTime.getMinute()));
             }
         }
 
@@ -587,7 +589,7 @@ public class BaseTimePeriodParser implements IDateTimeParser {
 
         long minutes = (Duration.between(beginTime, endTime).toMinutes() % 60);
         long hours = (Duration.between(beginTime, endTime).toHours() % 24);
-        ret.setTimex(String.format("(%s,%s,PT", pr1.timexStr, pr2.timexStr));
+        ret.setTimex(String.format("(%s,%s,PT", pr1.getTimexStr(), pr2.getTimexStr()));
 
         if (hours > 0) {
             ret.setTimex(String.format("%s%sH", ret.getTimex(), hours));
@@ -606,10 +608,10 @@ public class BaseTimePeriodParser implements IDateTimeParser {
             ret.setComment(Constants.Comment_AmPm);
         }
 
-        if (((DateTimeResolutionResult)pr1.value).getTimeZoneResolution() != null) {
-            ret.setTimeZoneResolution(((DateTimeResolutionResult)pr1.value).getTimeZoneResolution());
-        } else if (((DateTimeResolutionResult)pr2.value).getTimeZoneResolution() != null) {
-            ret.setTimeZoneResolution(((DateTimeResolutionResult)pr2.value).getTimeZoneResolution());
+        if (((DateTimeResolutionResult)pr1.getValue()).getTimeZoneResolution() != null) {
+            ret.setTimeZoneResolution(((DateTimeResolutionResult)pr1.getValue()).getTimeZoneResolution());
+        } else if (((DateTimeResolutionResult)pr2.getValue()).getTimeZoneResolution() != null) {
+            ret.setTimeZoneResolution(((DateTimeResolutionResult)pr2.getValue()).getTimeZoneResolution());
         }
 
         List<Object> subDateTimeEntities = new ArrayList<>();

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/parsers/BaseTimeZoneParser.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/parsers/BaseTimeZoneParser.java
@@ -42,7 +42,7 @@ public class BaseTimeZoneParser implements IDateTimeParser {
         DateTimeParseResult result;
         result = new DateTimeParseResult(er);
 
-        String text = er.text.toLowerCase();
+        String text = er.getText().toLowerCase();
         Match match = Arrays.stream(RegExpUtility.getMatches(directUtcRegex, text)).findFirst().orElse(null);
         String matched = match != null ? match.getGroup("").value : "";
         int offsetInMinutes = computeMinutes(matched);
@@ -51,24 +51,24 @@ public class BaseTimeZoneParser implements IDateTimeParser {
             DateTimeResolutionResult value = getDateTimeResolutionResult(offsetInMinutes, text);
             String resolutionStr = String.format("%s: %d", Constants.UtcOffsetMinsKey, offsetInMinutes);
 
-            result = new DateTimeParseResult(result.withValue(value));
-            result = new DateTimeParseResult(result.withResolutionStr(resolutionStr));
+            result.setValue(value);
+            result.setResolutionStr(resolutionStr);
         } else if (checkAbbrToMin(text)) {
             int utcMinuteShift = EnglishTimeZone.AbbrToMinMapping.getOrDefault(text, 0);
 
             DateTimeResolutionResult value = getDateTimeResolutionResult(utcMinuteShift, text);
             String resolutionStr = String.format("%s: %d", Constants.UtcOffsetMinsKey, utcMinuteShift);
 
-            result = new DateTimeParseResult(result.withValue(value));
-            result = new DateTimeParseResult(result.withResolutionStr(resolutionStr));
+            result.setValue(value);
+            result.setResolutionStr(resolutionStr);
         } else if (checkFullToMin(text)) {
             int utcMinuteShift = EnglishTimeZone.FullToMinMapping.getOrDefault(text, 0);
 
             DateTimeResolutionResult value = getDateTimeResolutionResult(utcMinuteShift, text);
             String resolutionStr = String.format("%s: %d", Constants.UtcOffsetMinsKey, utcMinuteShift);
 
-            result = new DateTimeParseResult(result.withValue(value));
-            result = new DateTimeParseResult(result.withResolutionStr(resolutionStr));
+            result.setValue(value);
+            result.setResolutionStr(resolutionStr);
         } else {
             // TODO: Temporary solution for city timezone and ambiguous data
             DateTimeResolutionResult value = new DateTimeResolutionResult();
@@ -76,8 +76,8 @@ public class BaseTimeZoneParser implements IDateTimeParser {
             value.setTimeZoneResolution(new TimeZoneResolutionResult("UTC+XX:XX", Constants.InvalidOffsetValue, text));
             String resolutionStr = String.format("%s: %s", Constants.UtcOffsetMinsKey, "XX:XX");
 
-            result = new DateTimeParseResult(result.withValue(value));
-            result = new DateTimeParseResult(result.withResolutionStr(resolutionStr));
+            result.setValue(value);
+            result.setResolutionStr(resolutionStr);
         }
 
         return result;

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/parsers/DateTimeParseResult.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/parsers/DateTimeParseResult.java
@@ -3,12 +3,10 @@ package com.microsoft.recognizers.text.datetime.parsers;
 import com.microsoft.recognizers.text.ExtractResult;
 import com.microsoft.recognizers.text.ParseResult;
 
-import java.util.Optional;
-
 public class DateTimeParseResult extends ParseResult {
     //TimexStr is only used in extractors related with date and time
     //It will output the TIMEX representation of a time string.
-    public final String timexStr;
+    private String timexStr;
 
     public DateTimeParseResult(Integer start, Integer length, String text, String type, Object data, Object value, String resolutionStr, String timexStr) {
         super(start, length, text, type, data, value, resolutionStr);
@@ -16,34 +14,18 @@ public class DateTimeParseResult extends ParseResult {
     }
 
     public DateTimeParseResult(ExtractResult er) {
-        this(er.start, er.length, er.text, er.type, er.data, null, null, null);
+        this(er.getStart(), er.getLength(), er.getText(), er.getType(), er.getData(), null, null, null);
     }
 
     public DateTimeParseResult(ParseResult pr) {
-        this(pr.start, pr.length, pr.text, pr.type, pr.data, pr.value, pr.resolutionStr, null);
+        this(pr.getStart(), pr.getLength(), pr.getText(), pr.getType(), pr.getData(), pr.getValue(), pr.getResolutionStr(), null);
     }
 
-    public DateTimeParseResult withTimexStr(String newTimexStr) {
-        return new DateTimeParseResult(
-                this.start,
-                this.length,
-                this.text,
-                this.type,
-                this.data,
-                this.value,
-                this.resolutionStr,
-                newTimexStr);
+    public String getTimexStr() {
+        return timexStr;
     }
 
-    public DateTimeParseResult withValue(Object value) {
-        return new DateTimeParseResult(
-                this.start,
-                this.length,
-                this.text,
-                this.type,
-                this.data,
-                value,
-                this.resolutionStr,
-                this.timexStr);
+    public void setTimexStr(String timexStr) {
+        this.timexStr = timexStr;
     }
 }

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/extractors/SpanishDurationExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/extractors/SpanishDurationExtractorConfiguration.java
@@ -1,0 +1,139 @@
+package com.microsoft.recognizers.text.datetime.spanish.extractors;
+
+import com.google.common.collect.ImmutableMap;
+import com.microsoft.recognizers.text.IExtractor;
+import com.microsoft.recognizers.text.datetime.DateTimeOptions;
+import com.microsoft.recognizers.text.datetime.config.BaseOptionsConfiguration;
+import com.microsoft.recognizers.text.datetime.extractors.config.IDurationExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.resources.SpanishDateTime;
+import com.microsoft.recognizers.text.number.spanish.extractors.CardinalExtractor;
+import com.microsoft.recognizers.text.utilities.RegExpUtility;
+
+import java.util.regex.Pattern;
+
+public class SpanishDurationExtractorConfiguration extends BaseOptionsConfiguration implements IDurationExtractorConfiguration {
+
+    //public static final Pattern UnitRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.UnitRegex);
+    public static final Pattern SuffixAndRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.SuffixAndRegex);
+    public static final Pattern FollowedUnit = RegExpUtility.getSafeRegExp(SpanishDateTime.FollowedUnit);
+    public static final Pattern NumberCombinedWithUnit = RegExpUtility.getSafeRegExp(SpanishDateTime.DurationNumberCombinedWithUnit);
+    public static final Pattern AnUnitRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.AnUnitRegex);
+    public static final Pattern DuringRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.DuringRegex);
+    public static final Pattern AllRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.AllRegex);
+    public static final Pattern HalfRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.HalfRegex);
+    public static final Pattern ConjunctionRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.ConjunctionRegex);
+    public static final Pattern InexactNumberRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.InexactNumberRegex);
+    public static final Pattern InexactNumberUnitRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.InexactNumberUnitRegex);
+    public static final Pattern RelativeDurationUnitRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.RelativeDurationUnitRegex);
+    public static final Pattern DurationUnitRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.DurationUnitRegex);
+    public static final Pattern DurationConnectorRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.DurationConnectorRegex);
+    public static final Pattern MoreThanRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.MoreThanRegex);
+    public static final Pattern LessThanRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.LessThanRegex);
+
+    private final IExtractor cardinalExtractor;
+    private final ImmutableMap<String, String> unitMap;
+    private final ImmutableMap<String, Long> unitValueMap;
+
+    public SpanishDurationExtractorConfiguration() {
+        this(DateTimeOptions.None);
+    }
+
+    public SpanishDurationExtractorConfiguration(DateTimeOptions options) {
+
+        super(options);
+
+        cardinalExtractor = CardinalExtractor.getInstance();
+        unitMap = SpanishDateTime.UnitMap;
+        unitValueMap = SpanishDateTime.UnitValueMap;
+    }
+
+    @Override
+    public Pattern getFollowedUnit() {
+        return FollowedUnit;
+    }
+
+    @Override
+    public Pattern getNumberCombinedWithUnit() {
+        return NumberCombinedWithUnit;
+    }
+
+    @Override
+    public Pattern getAnUnitRegex() {
+        return AnUnitRegex;
+    }
+
+    @Override
+    public Pattern getDuringRegex() {
+        return DuringRegex;
+    }
+
+    @Override
+    public Pattern getAllRegex() {
+        return AllRegex;
+    }
+
+    @Override
+    public Pattern getHalfRegex() {
+        return HalfRegex;
+    }
+
+    @Override
+    public Pattern getSuffixAndRegex() {
+        return SuffixAndRegex;
+    }
+
+    @Override
+    public Pattern getConjunctionRegex() {
+        return ConjunctionRegex;
+    }
+
+    @Override
+    public Pattern getInexactNumberRegex() {
+        return InexactNumberRegex;
+    }
+
+    @Override
+    public Pattern getInexactNumberUnitRegex() {
+        return InexactNumberUnitRegex;
+    }
+
+    @Override
+    public Pattern getRelativeDurationUnitRegex() {
+        return RelativeDurationUnitRegex;
+    }
+
+    @Override
+    public Pattern getDurationUnitRegex() {
+        return DurationUnitRegex;
+    }
+
+    @Override
+    public Pattern getDurationConnectorRegex() {
+        return DurationConnectorRegex;
+    }
+
+    @Override
+    public Pattern getLessThanRegex() {
+        return LessThanRegex;
+    }
+
+    @Override
+    public Pattern getMoreThanRegex() {
+        return MoreThanRegex;
+    }
+
+    @Override
+    public IExtractor getCardinalExtractor() {
+        return cardinalExtractor;
+    }
+
+    @Override
+    public ImmutableMap<String, String> getUnitMap() {
+        return unitMap;
+    }
+
+    @Override
+    public ImmutableMap<String, Long> getUnitValueMap() {
+        return unitValueMap;
+    }
+}

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/extractors/SpanishTimeExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/extractors/SpanishTimeExtractorConfiguration.java
@@ -1,0 +1,132 @@
+package com.microsoft.recognizers.text.datetime.spanish.extractors;
+
+import com.microsoft.recognizers.text.datetime.DateTimeOptions;
+import com.microsoft.recognizers.text.datetime.config.BaseOptionsConfiguration;
+import com.microsoft.recognizers.text.datetime.extractors.BaseDurationExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.BaseTimeZoneExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.IDateTimeExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.config.ITimeExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.resources.SpanishDateTime;
+import com.microsoft.recognizers.text.utilities.RegExpUtility;
+
+import java.util.ArrayList;
+import java.util.regex.Pattern;
+
+public class SpanishTimeExtractorConfiguration extends BaseOptionsConfiguration
+    implements ITimeExtractorConfiguration {
+
+    // part 1: smallest component
+    // --------------------------------------
+    public static final Pattern DescRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.DescRegex);
+    public static final Pattern HourNumRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.HourNumRegex);
+    public static final Pattern MinuteNumRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.MinuteNumRegex);
+
+    // part 2: middle level component
+    // --------------------------------------
+    // handle "... en punto"
+    public static final Pattern OclockRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.OclockRegex);
+
+    // handle "... tarde"
+    public static final Pattern PmRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.PmRegex);
+
+    // handle "... de la mañana"
+    public static final Pattern AmRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.AmRegex);
+
+    // handle "y media ..." "menos cuarto ..."
+    public static final Pattern LessThanOneHour = RegExpUtility.getSafeRegExp(SpanishDateTime.LessThanOneHour);
+    public static final Pattern TensTimeRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.TensTimeRegex);
+
+    // handle "seis treinta", "seis veintiuno", "seis menos diez"
+    public static final Pattern WrittenTimeRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.WrittenTimeRegex);
+    public static final Pattern TimePrefix = RegExpUtility.getSafeRegExp(SpanishDateTime.TimePrefix);
+    public static final Pattern TimeSuffix = RegExpUtility.getSafeRegExp(SpanishDateTime.TimeSuffix);
+    public static final Pattern BasicTime = RegExpUtility.getSafeRegExp(SpanishDateTime.BasicTime);
+
+    // part 3: regex for time
+    // --------------------------------------
+    // handle "a las cuatro" "a las 3"
+    //TODO: add some new regex which have used in AtRegex
+    //TODO: modify according to corresponding English regex
+    public static final Pattern AtRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.AtRegex);
+    public static final Pattern ConnectNumRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.ConnectNumRegex);
+    public static final Pattern TimeBeforeAfterRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.TimeBeforeAfterRegex);
+    public static final Iterable<Pattern> TimeRegexList = new ArrayList<Pattern>() {
+        {
+            // (tres min pasadas las)? siete|7|(siete treinta) pm
+            add(RegExpUtility.getSafeRegExp(SpanishDateTime.TimeRegex1));
+
+            // (tres min pasadas las)? 3:00(:00)? (pm)?
+            add(RegExpUtility.getSafeRegExp(SpanishDateTime.TimeRegex2));
+
+            // (tres min pasadas las)? 3.00 (pm)
+            add(RegExpUtility.getSafeRegExp(SpanishDateTime.TimeRegex3));
+
+            // (tres min pasadas las) (cinco treinta|siete|7|7:00(:00)?) (pm)?
+            add(RegExpUtility.getSafeRegExp(SpanishDateTime.TimeRegex4));
+
+            // (tres min pasadas las) (cinco treinta|siete|7|7:00(:00)?) (pm)? (de la noche)
+            add(RegExpUtility.getSafeRegExp(SpanishDateTime.TimeRegex5));
+
+            // (cinco treinta|siete|7|7:00(:00)?) (pm)? (de la noche)
+            add(RegExpUtility.getSafeRegExp(SpanishDateTime.TimeRegex6));
+
+            // (En la noche) a las (cinco treinta|siete|7|7:00(:00)?) (pm)?
+            add(RegExpUtility.getSafeRegExp(SpanishDateTime.TimeRegex7));
+
+            // (En la noche) (cinco treinta|siete|7|7:00(:00)?) (pm)?
+            add(RegExpUtility.getSafeRegExp(SpanishDateTime.TimeRegex8));
+
+            // once (y)? veinticinco
+            add(RegExpUtility.getSafeRegExp(SpanishDateTime.TimeRegex9));
+
+            add(RegExpUtility.getSafeRegExp(SpanishDateTime.TimeRegex10));
+
+            // (tres menos veinte) (pm)?
+            add(RegExpUtility.getSafeRegExp(SpanishDateTime.TimeRegex11));
+
+            // (tres min pasadas las)? 3h00 (pm)?
+            add(RegExpUtility.getSafeRegExp(SpanishDateTime.TimeRegex12));
+
+            // 340pm
+            add(ConnectNumRegex);
+        }
+    };
+
+    public final Pattern getIshRegex() {
+        return null;
+    }
+
+    public final Iterable<Pattern> getTimeRegexList() {
+        return TimeRegexList;
+    }
+
+    public final Pattern getAtRegex() {
+        return AtRegex;
+    }
+
+    public final Pattern getTimeBeforeAfterRegex() {
+        return TimeBeforeAfterRegex;
+    }
+
+    private IDateTimeExtractor durationExtractor;
+
+    public final IDateTimeExtractor getDurationExtractor() {
+        return durationExtractor;
+    }
+
+    private IDateTimeExtractor timeZoneExtractor;
+
+    public final IDateTimeExtractor getTimeZoneExtractor() {
+        return timeZoneExtractor;
+    }
+
+    public SpanishTimeExtractorConfiguration() {
+        this(DateTimeOptions.None);
+    }
+
+    public SpanishTimeExtractorConfiguration(DateTimeOptions options) {
+        super(options);
+        durationExtractor = new BaseDurationExtractor(new SpanishDurationExtractorConfiguration());
+        timeZoneExtractor = new BaseTimeZoneExtractor(new SpanishTimeZoneExtractorConfiguration(options));
+    }
+}

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/extractors/SpanishTimeZoneExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/extractors/SpanishTimeZoneExtractorConfiguration.java
@@ -1,0 +1,39 @@
+package com.microsoft.recognizers.text.datetime.spanish.extractors;
+
+import com.microsoft.recognizers.text.datetime.DateTimeOptions;
+import com.microsoft.recognizers.text.datetime.config.BaseOptionsConfiguration;
+import com.microsoft.recognizers.text.datetime.extractors.config.ITimeZoneExtractorConfiguration;
+import com.microsoft.recognizers.text.matcher.StringMatcher;
+
+import java.util.ArrayList;
+import java.util.regex.Pattern;
+
+public class SpanishTimeZoneExtractorConfiguration extends BaseOptionsConfiguration implements ITimeZoneExtractorConfiguration {
+
+    public static final Iterable<Pattern> TimeZoneRegexList = new ArrayList<>();
+
+    public SpanishTimeZoneExtractorConfiguration(DateTimeOptions options) {
+        super(options);
+
+    }
+
+    public final Iterable<Pattern> getTimeZoneRegexes() {
+        return TimeZoneRegexList;
+    }
+
+    private Pattern locationTimeSuffixRegex;
+
+    public final Pattern getLocationTimeSuffixRegex() {
+        return locationTimeSuffixRegex;
+    }
+
+    private StringMatcher locationMatcher;
+
+    public final StringMatcher getLocationMatcher() {
+        return locationMatcher;
+    }
+
+    public final ArrayList<String> getAmbiguousTimezoneList() {
+        return new ArrayList<>();
+    }
+}

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/utilities/SpanishDatetimeUtilityConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/utilities/SpanishDatetimeUtilityConfiguration.java
@@ -30,68 +30,57 @@ public class SpanishDatetimeUtilityConfiguration implements IDateTimeUtilityConf
     public static final Pattern CommonDatePrefixRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.CommonDatePrefixRegex);
 
     @Override
-    public final Pattern getLaterRegex()
-    {
+    public final Pattern getLaterRegex() {
         return LaterRegex;
     }
 
     @Override
-    public final Pattern getAgoRegex()
-    {
+    public final Pattern getAgoRegex() {
         return AgoRegex;
     }
 
     @Override
-    public final Pattern getInConnectorRegex()
-    {
+    public final Pattern getInConnectorRegex() {
         return InConnectorRegex;
     }
 
     @Override
-    public final Pattern getWithinNextPrefixRegex()
-    {
+    public final Pattern getWithinNextPrefixRegex() {
         return WithinNextPrefixRegex;
     }
 
     @Override
-    public final Pattern getAmDescRegex()
-    {
+    public final Pattern getAmDescRegex() {
         return AmDescRegex;
     }
 
     @Override
-    public final Pattern getPmDescRegex()
-    {
+    public final Pattern getPmDescRegex() {
         return PmDescRegex;
     }
 
     @Override
-    public final Pattern getAmPmDescRegex()
-    {
+    public final Pattern getAmPmDescRegex() {
         return AmPmDescRegex;
     }
 
     @Override
-    public final Pattern getRangeUnitRegex()
-    {
+    public final Pattern getRangeUnitRegex() {
         return RangeUnitRegex;
     }
 
     @Override
-    public final Pattern getTimeUnitRegex()
-    {
+    public final Pattern getTimeUnitRegex() {
         return TimeUnitRegex;
     }
 
     @Override
-    public final Pattern getDateUnitRegex()
-    {
+    public final Pattern getDateUnitRegex() {
         return DateUnitRegex;
     }
 
     @Override
-    public final Pattern getCommonDatePrefixRegex()
-    {
+    public final Pattern getCommonDatePrefixRegex() {
         return CommonDatePrefixRegex;
     }
 }

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/utilities/SpanishDatetimeUtilityConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/utilities/SpanishDatetimeUtilityConfiguration.java
@@ -1,0 +1,97 @@
+package com.microsoft.recognizers.text.datetime.spanish.utilities;
+
+import com.microsoft.recognizers.text.datetime.resources.SpanishDateTime;
+import com.microsoft.recognizers.text.datetime.utilities.IDateTimeUtilityConfiguration;
+import com.microsoft.recognizers.text.utilities.RegExpUtility;
+
+import java.util.regex.Pattern;
+
+public class SpanishDatetimeUtilityConfiguration implements IDateTimeUtilityConfiguration {
+    public static final Pattern AgoRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.AgoRegex);
+
+    public static final Pattern LaterRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.LaterRegex);
+
+    public static final Pattern InConnectorRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.InConnectorRegex);
+
+    public static final Pattern WithinNextPrefixRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.WithinNextPrefixRegex);
+
+    public static final Pattern AmDescRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.AmDescRegex);
+
+    public static final Pattern PmDescRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.PmDescRegex);
+
+    public static final Pattern AmPmDescRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.AmPmDescRegex);
+
+    public static final Pattern RangeUnitRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.RangeUnitRegex);
+
+    public static final Pattern TimeUnitRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.TimeUnitRegex);
+
+    public static final Pattern DateUnitRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.DateUnitRegex);
+
+    public static final Pattern CommonDatePrefixRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.CommonDatePrefixRegex);
+
+    @Override
+    public final Pattern getLaterRegex()
+    {
+        return LaterRegex;
+    }
+
+    @Override
+    public final Pattern getAgoRegex()
+    {
+        return AgoRegex;
+    }
+
+    @Override
+    public final Pattern getInConnectorRegex()
+    {
+        return InConnectorRegex;
+    }
+
+    @Override
+    public final Pattern getWithinNextPrefixRegex()
+    {
+        return WithinNextPrefixRegex;
+    }
+
+    @Override
+    public final Pattern getAmDescRegex()
+    {
+        return AmDescRegex;
+    }
+
+    @Override
+    public final Pattern getPmDescRegex()
+    {
+        return PmDescRegex;
+    }
+
+    @Override
+    public final Pattern getAmPmDescRegex()
+    {
+        return AmPmDescRegex;
+    }
+
+    @Override
+    public final Pattern getRangeUnitRegex()
+    {
+        return RangeUnitRegex;
+    }
+
+    @Override
+    public final Pattern getTimeUnitRegex()
+    {
+        return TimeUnitRegex;
+    }
+
+    @Override
+    public final Pattern getDateUnitRegex()
+    {
+        return DateUnitRegex;
+    }
+
+    @Override
+    public final Pattern getCommonDatePrefixRegex()
+    {
+        return CommonDatePrefixRegex;
+    }
+}

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/utilities/DateContext.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/utilities/DateContext.java
@@ -19,9 +19,8 @@ public class DateContext {
 
     public DateTimeParseResult processDateEntityParsingResult(DateTimeParseResult originalResult) {
         if (!isEmpty()) {
-            originalResult = originalResult
-                    .withTimexStr(TimexUtility.setTimexWithContext(originalResult.timexStr, this))
-                    .withValue(processDateEntityResolution((DateTimeResolutionResult)originalResult.value));
+            originalResult.setTimexStr(TimexUtility.setTimexWithContext(originalResult.getTimexStr(), this));
+            originalResult.setValue(processDateEntityResolution((DateTimeResolutionResult)originalResult.getValue()));
         }
 
         return originalResult;

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/utilities/MatchedTimexResult.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/utilities/MatchedTimexResult.java
@@ -1,8 +1,8 @@
 package com.microsoft.recognizers.text.datetime.utilities;
 
 public class MatchedTimexResult {
-    public final boolean result;
-    public final String timex;
+    private boolean result;
+    private String timex;
 
     public MatchedTimexResult(boolean result, String timex) {
         this.result = result;
@@ -13,11 +13,19 @@ public class MatchedTimexResult {
         this(false, "");
     }
 
-    public MatchedTimexResult withTimex(String timex) {
-        return new MatchedTimexResult(this.result, timex);
+    public boolean getResult() {
+        return result;
     }
 
-    public MatchedTimexResult withResult(boolean result) {
-        return new MatchedTimexResult(result, this.timex);
+    public String getTimex() {
+        return timex;
+    }
+
+    public void setResult(boolean result) {
+        this.result = result;
+    }
+
+    public void setTimex(String timex) {
+        this.timex = timex;
     }
 }

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/utilities/MatchingUtil.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/utilities/MatchingUtil.java
@@ -71,13 +71,15 @@ public class MatchingUtil {
         for (MatchResult<String> match : superfluousWordMatches) {
             int index = 0;
             for (ExtractResult extractResult : extractResults.toArray(new ExtractResult[0])) {
-                int extractResultEnd = extractResult.start + extractResult.length;
-                if (match.getStart() > extractResult.start && extractResultEnd >= match.getStart()) {
-                    extractResults.set(index, extractResult.withLength(extractResult.length + match.getLength()));
+                int extractResultEnd = extractResult.getStart() + extractResult.getLength();
+                if (match.getStart() > extractResult.getStart() && extractResultEnd >= match.getStart()) {
+                    extractResult.setLength(extractResult.getLength() + match.getLength());
+                    extractResults.set(index, extractResult);
                 }
 
-                if (match.getStart() <= extractResult.start) {
-                    extractResults.set(index, extractResult.withStart(extractResult.start + match.getLength()));
+                if (match.getStart() <= extractResult.getStart()) {
+                    extractResult.setStart(extractResult.getStart() + match.getLength());
+                    extractResults.set(index, extractResult);
                 }
                 index++;
             }
@@ -85,7 +87,8 @@ public class MatchingUtil {
 
         int index = 0;
         for (ExtractResult er : extractResults.toArray(new ExtractResult[0])) {
-            extractResults.set(index, er.withText(originText.substring(er.start, er.start + er.length)));
+            er.setText(originText.substring(er.getStart(), er.getStart() + er.getLength()));
+            extractResults.set(index, er);
             index++;
         }
 

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/utilities/TimeZoneUtility.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/utilities/TimeZoneUtility.java
@@ -15,18 +15,18 @@ public abstract class TimeZoneUtility {
         int index = 0;
         for (ExtractResult er : originalErs.toArray(new ExtractResult[0])) {
             for (ExtractResult timeZoneEr : timeZoneErs) {
-                int begin = er.start + er.length;
-                int end = timeZoneEr.start;
+                int begin = er.getStart() + er.getLength();
+                int end = timeZoneEr.getStart();
 
                 if (begin < end) {
                     String gapText = text.substring(begin, end);
 
                     if (StringUtility.isNullOrWhiteSpace(gapText)) {
-                        int length = timeZoneEr.start + timeZoneEr.length - er.start;
+                        int length = timeZoneEr.getStart() + timeZoneEr.getLength() - er.getStart();
                         Map<String, Object> data = new HashMap<>();
                         data.put(Constants.SYS_DATETIME_TIMEZONE, timeZoneEr);
 
-                        originalErs.set(index, new ExtractResult(er.start, length, text.substring(er.start, er.start + length), er.type, data));
+                        originalErs.set(index, new ExtractResult(er.getStart(), length, text.substring(er.getStart(), er.getStart() + length), er.getType(), data));
                     }
                 }
             }
@@ -40,8 +40,8 @@ public abstract class TimeZoneUtility {
         boolean enablePreview = options.match(DateTimeOptions.EnablePreview);
         boolean hasTimeZoneData = false;
 
-        if (er.data instanceof Map) {
-            Map<String, Object> metadata = (HashMap<String, Object>)er.data;
+        if (er.getData() instanceof Map) {
+            Map<String, Object> metadata = (HashMap<String, Object>)er.getData();
 
             if (metadata.containsKey(Constants.SYS_DATETIME_TIMEZONE)) {
                 hasTimeZoneData = true;

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/extractors/BaseMergedUnitExtractor.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/extractors/BaseMergedUnitExtractor.java
@@ -43,19 +43,19 @@ public class BaseMergedUnitExtractor implements IExtractor {
         int[] groups = new int[ers.size()];
         groups[0] = 0;
         for (int idx = 0; idx < ers.size() - 1; idx++) {
-            if (!ers.get(idx).type.equals(ers.get(idx + 1).type) &&
-                !ers.get(idx).type.equals(Constants.SYS_NUM) &&
-                !ers.get(idx + 1).type.equals(Constants.SYS_NUM)) {
+            if (!ers.get(idx).getType().equals(ers.get(idx + 1).getType()) &&
+                !ers.get(idx).getType().equals(Constants.SYS_NUM) &&
+                !ers.get(idx + 1).getType().equals(Constants.SYS_NUM)) {
                 continue;
             }
 
-            if (ers.get(idx).data instanceof ExtractResult && !((ExtractResult)ers.get(idx).data).data.toString().startsWith("Integer")) {
+            if (ers.get(idx).getData() instanceof ExtractResult && !((ExtractResult)ers.get(idx).getData()).getData().toString().startsWith("Integer")) {
                 groups[idx + 1] = groups[idx] + 1;
                 continue;
             }
 
-            int middleBegin = ers.get(idx).start + ers.get(idx).length;
-            int middleEnd = ers.get(idx + 1).start;
+            int middleBegin = ers.get(idx).getStart() + ers.get(idx).getLength();
+            int middleEnd = ers.get(idx + 1).getStart();
 
             String middleStr = source.substring(middleBegin, middleEnd).trim().toLowerCase();
 
@@ -77,13 +77,13 @@ public class BaseMergedUnitExtractor implements IExtractor {
         for (int idx = 0; idx < ers.size(); idx++) {
             if (idx == 0 || groups[idx] != groups[idx - 1]) {
                 ExtractResult tmpExtractResult = ers.get(idx);
-                tmpExtractResult = tmpExtractResult.withData(Lists.newArrayList(
+                tmpExtractResult.setData(Lists.newArrayList(
                         new ExtractResult(
-                                tmpExtractResult.start,
-                                tmpExtractResult.length,
-                                tmpExtractResult.text,
-                                tmpExtractResult.type,
-                                tmpExtractResult.data)));
+                                tmpExtractResult.getStart(),
+                                tmpExtractResult.getLength(),
+                                tmpExtractResult.getText(),
+                                tmpExtractResult.getType(),
+                                tmpExtractResult.getData())));
 
                 ers.set(idx, tmpExtractResult);
                 result.add(tmpExtractResult);
@@ -93,32 +93,32 @@ public class BaseMergedUnitExtractor implements IExtractor {
             if (idx + 1 < ers.size() && groups[idx + 1] == groups[idx]) {
                 int group = groups[idx];
 
-                int periodBegin = result.get(group).start;
-                int periodEnd = ers.get(idx + 1).start + ers.get(idx + 1).length;
+                int periodBegin = result.get(group).getStart();
+                int periodEnd = ers.get(idx + 1).getStart() + ers.get(idx + 1).getLength();
 
                 ExtractResult r = result.get(group);
 
-                List<ExtractResult> data = (List<ExtractResult>)r.data;
+                List<ExtractResult> data = (List<ExtractResult>)r.getData();
                 data.add(ers.get(idx + 1));
-                r = r.withLength(periodEnd - periodBegin)
-                        .withText(source.substring(periodBegin, periodEnd))
-                        .withType(Constants.SYS_UNIT_CURRENCY)
-                        .withData(data);
+                r.setLength(periodEnd - periodBegin);
+                r.setText(source.substring(periodBegin, periodEnd));
+                r.setType(Constants.SYS_UNIT_CURRENCY);
+                r.setData(data);
 
                 result.set(group, r);
             }
         }
 
         for (int idx = 0; idx < result.size(); idx++) {
-            if (result.get(idx).data instanceof List) {
-                List<ExtractResult> innerData = (List<ExtractResult>)result.get(idx).data;
+            if (result.get(idx).getData() instanceof List) {
+                List<ExtractResult> innerData = (List<ExtractResult>)result.get(idx).getData();
                 if (innerData.size() == 1) {
                     result.set(idx, innerData.get(0));
                 }
             }
         }
 
-        result = result.stream().filter(o -> !o.type.equals(Constants.SYS_NUM))
+        result = result.stream().filter(o -> !o.getType().equals(Constants.SYS_NUM))
                 .collect(Collectors.toList());
 
         return result;
@@ -130,7 +130,7 @@ public class BaseMergedUnitExtractor implements IExtractor {
         List<ExtractResult> unitNumbers = new ArrayList<>();
         for (int i = 0, j = 0; i < numErs.size(); i++) {
             boolean hasBehindExtraction = false;
-            while (j < ers.size() && ers.get(j).start + ers.get(j).length < numErs.get(i).start) {
+            while (j < ers.size() && ers.get(j).getStart() + ers.get(j).getLength() < numErs.get(i).getStart()) {
                 hasBehindExtraction = true;
                 j++;
             }
@@ -139,8 +139,8 @@ public class BaseMergedUnitExtractor implements IExtractor {
                 continue;
             }
 
-            int middleBegin = ers.get(j - 1).start + ers.get(j - 1).length;
-            int middleEnd = numErs.get(i).start;
+            int middleBegin = ers.get(j - 1).getStart() + ers.get(j - 1).getLength();
+            int middleEnd = numErs.get(i).getStart();
 
             String middleStr = source.substring(middleBegin, middleEnd).trim().toLowerCase();
 
@@ -166,7 +166,7 @@ public class BaseMergedUnitExtractor implements IExtractor {
         for (ExtractResult extractResult : unitNumbers) {
             boolean overlap = false;
             for (ExtractResult er : ers) {
-                if (er.start <= extractResult.start && er.start + er.length >= extractResult.start) {
+                if (er.getStart() <= extractResult.getStart() && er.getStart() + er.getLength() >= extractResult.getStart()) {
                     overlap = true;
                 }
             }
@@ -179,7 +179,7 @@ public class BaseMergedUnitExtractor implements IExtractor {
         Collections.sort(ers, (Comparator<ExtractResult>)(xo, yo) -> {
             ExtractResult x = (ExtractResult)xo;
             ExtractResult y = (ExtractResult)yo;
-            return x.start - y.start;
+            return x.getStart() - y.getStart();
         });
     }
 }

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/extractors/NumberWithUnitExtractor.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/extractors/NumberWithUnitExtractor.java
@@ -84,11 +84,11 @@ public class NumberWithUnitExtractor implements IExtractor {
             for (int i = 0; i < numbers.size(); i++) {
                 ExtractResult number = numbers.get(i);
 
-                Match[] matches = RegExpUtility.getMatches(ambiguousMultiplierRegex, number.text);
+                Match[] matches = RegExpUtility.getMatches(ambiguousMultiplierRegex, number.getText());
                 if (matches.length == 1) {
-                    int newLength = number.length - matches[0].length;
-                    numbers.set(i, new ExtractResult(number.start, newLength, number.text.substring(0, newLength),
-                                                     number.type, number.data));
+                    int newLength = number.getLength() - matches[0].length;
+                    numbers.set(i, new ExtractResult(number.getStart(), newLength, number.getText().substring(0, newLength),
+                            number.getType(), number.getData()));
                 }
             }
         }
@@ -96,17 +96,17 @@ public class NumberWithUnitExtractor implements IExtractor {
         /* Mix prefix and numbers, make up a prefix-number combination */
         if (maxPrefixMatchLen != 0) {
             for (ExtractResult number : numbers) {
-                if (number.start == null || number.length == null) {
+                if (number.getStart() == null || number.getLength() == null) {
                     continue;
                 }
 
-                int maxFindPref = Math.min(maxPrefixMatchLen, number.start);
+                int maxFindPref = Math.min(maxPrefixMatchLen, number.getStart());
                 if (maxFindPref == 0) {
                     continue;
                 }
 
                 /* Scan from left to right , find the longest match */
-                String leftStr = source.substring(number.start - maxFindPref, number.start);
+                String leftStr = source.substring(number.getStart() - maxFindPref, number.getStart());
                 int lastIndex = leftStr.length();
 
                 MatchResult bestMatch = null;
@@ -124,18 +124,18 @@ public class NumberWithUnitExtractor implements IExtractor {
                 if (bestMatch != null) {
                     int offset = lastIndex - bestMatch.start();
                     String unitStr = leftStr.substring(bestMatch.start(), lastIndex);
-                    mappingPrefix.put(number.start, new PrefixUnitResult(offset, unitStr));
+                    mappingPrefix.put(number.getStart(), new PrefixUnitResult(offset, unitStr));
                 }
             }
         }
 
         for (ExtractResult number : numbers) {
-            if (number.start == null || number.length == null) {
+            if (number.getStart() == null || number.getLength() == null) {
                 continue;
             }
 
-            int start = number.start;
-            int length = number.length;
+            int start = number.getStart();
+            int length = number.getLength();
             int maxFindLen = sourceLen - start - length;
 
             PrefixUnitResult prefixUnit = null;
@@ -170,15 +170,14 @@ public class NumberWithUnitExtractor implements IExtractor {
                     ExtractResult er = new ExtractResult(start, length + maxlen, substr, this.config.getExtractType(), null);
 
                     if (prefixUnit != null) {
-                        er = er
-                                .withStart(er.start - prefixUnit.offset)
-                                .withLength(er.length + prefixUnit.offset)
-                                .withText(prefixUnit.unitStr + er.text);
+                        er.setStart(er.getStart() - prefixUnit.offset);
+                        er.setLength(er.getLength() + prefixUnit.offset);
+                        er.setText(prefixUnit.unitStr + er.getText());
                     }
 
                     /* Relative position will be used in Parser */
-                    number = number.withStart(start - er.start);
-                    er = er.withData(number);
+                    number.setStart(start - er.getStart());
+                    er.setData(number);
                     result.add(er);
 
                     continue;
@@ -187,15 +186,15 @@ public class NumberWithUnitExtractor implements IExtractor {
 
             if (prefixUnit != null) {
                 ExtractResult er = new ExtractResult(
-                        number.start - prefixUnit.offset,
-                        number.length + prefixUnit.offset,
-                        prefixUnit.unitStr + number.text,
+                        number.getStart() - prefixUnit.offset,
+                        number.getLength() + prefixUnit.offset,
+                        prefixUnit.unitStr + number.getText(),
                         this.config.getExtractType(),
                         null);
 
                 /* Relative position will be used in Parser */
-                number = number.withStart(start - er.start);
-                er = er.withData(number);
+                number.setStart(start - er.getStart());
+                er.setData(number);
                 result.add(er);
             }
         }
@@ -214,11 +213,11 @@ public class NumberWithUnitExtractor implements IExtractor {
         Arrays.fill(matchResult, false);
 
         for (ExtractResult numDependResult : numDependResults) {
-            int start = numDependResult.start;
+            int start = numDependResult.getStart();
             int i = 0;
             do {
                 matchResult[start + i++] = true;
-            } while (i < numDependResult.length);
+            } while (i < numDependResult.getLength());
         }
 
         //Extract all SeparateUnits, then merge it with numDependResults

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/models/AbstractNumberWithUnitModel.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/models/AbstractNumberWithUnitModel.java
@@ -48,8 +48,8 @@ public abstract class AbstractNumberWithUnitModel implements IModel {
 
                 for (ExtractResult result : extractedResults) {
                     ParseResult parseResult = parser.parse(result);
-                    if (parseResult.value instanceof List) {
-                        parsedResults.addAll((List<ParseResult>)parseResult.value);
+                    if (parseResult.getValue() instanceof List) {
+                        parsedResults.addAll((List<ParseResult>)parseResult.getValue());
                     } else {
                         parsedResults.add(parseResult);
                     }
@@ -58,21 +58,21 @@ public abstract class AbstractNumberWithUnitModel implements IModel {
                 List<ModelResult> modelResults = parsedResults.stream().map(o -> {
                     
                     SortedMap<String, Object> resolutionValues = new TreeMap<String, Object>();
-                    if (o.value instanceof UnitValue) {
-                        resolutionValues.put(ResolutionKey.Value, ((UnitValue)o.value).number);
-                        resolutionValues.put(ResolutionKey.Unit, ((UnitValue)o.value).unit);
-                    } else if (o.value instanceof CurrencyUnitValue) {
-                        resolutionValues.put(ResolutionKey.Value, ((CurrencyUnitValue)o.value).number);
-                        resolutionValues.put(ResolutionKey.Unit, ((CurrencyUnitValue)o.value).unit);
-                        resolutionValues.put(ResolutionKey.IsoCurrency, ((CurrencyUnitValue)o.value).isoCurrency);
+                    if (o.getValue() instanceof UnitValue) {
+                        resolutionValues.put(ResolutionKey.Value, ((UnitValue)o.getValue()).number);
+                        resolutionValues.put(ResolutionKey.Unit, ((UnitValue)o.getValue()).unit);
+                    } else if (o.getValue() instanceof CurrencyUnitValue) {
+                        resolutionValues.put(ResolutionKey.Value, ((CurrencyUnitValue)o.getValue()).number);
+                        resolutionValues.put(ResolutionKey.Unit, ((CurrencyUnitValue)o.getValue()).unit);
+                        resolutionValues.put(ResolutionKey.IsoCurrency, ((CurrencyUnitValue)o.getValue()).isoCurrency);
                     } else {
-                        resolutionValues.put(ResolutionKey.Value, (String)o.value);
+                        resolutionValues.put(ResolutionKey.Value, (String)o.getValue());
                     }
 
                     return new ModelResult(
-                            o.text,
-                            o.start,
-                            o.start + o.length - 1,
+                            o.getText(),
+                            o.getStart(),
+                            o.getStart() + o.getLength() - 1,
                             getModelTypeName(),
                             resolutionValues);
                 }).collect(Collectors.toList());

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/parsers/BaseMergedUnitParser.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/parsers/BaseMergedUnitParser.java
@@ -18,7 +18,7 @@ public class BaseMergedUnitParser implements IParser {
     @Override
     public ParseResult parse(ExtractResult extResult) {
         // For now only currency model recognizes compound units.
-        if (extResult.type.equals(Constants.SYS_UNIT_CURRENCY)) {
+        if (extResult.getType().equals(Constants.SYS_UNIT_CURRENCY)) {
             return new BaseCurrencyParser(config).parse(extResult);
         } else {
             return numberWithUnitParser.parse(extResult);

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/parsers/NumberWithUnitParser.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/parsers/NumberWithUnitParser.java
@@ -27,17 +27,18 @@ public class NumberWithUnitParser implements IParser {
         ParseResult ret = new ParseResult(extResult);
         ExtractResult numberResult;
 
-        if (extResult.data instanceof ExtractResult) {
-            numberResult = (ExtractResult)extResult.data;
-        } else if (extResult.type.equals(Constants.SYS_NUM)) {
-            return ret.withValue(config.getInternalNumberParser().parse(extResult).value);
+        if (extResult.getData() instanceof ExtractResult) {
+            numberResult = (ExtractResult)extResult.getData();
+        } else if (extResult.getType().equals(Constants.SYS_NUM)) {
+            ret.setValue(config.getInternalNumberParser().parse(extResult).getValue());
+            return ret;
         } else {
             // if there is no unitResult, means there is just unit
             numberResult = new ExtractResult(-1, 0, null, null, null);
         }
 
         // key contains units
-        String key = extResult.text;
+        String key = extResult.getText();
         StringBuilder unitKeyBuild = new StringBuilder();
         List<String> unitKeys = new ArrayList<>();
 
@@ -47,13 +48,13 @@ public class NumberWithUnitParser implements IParser {
                 if (unitKeyBuild.length() != 0) {
                     addIfNotContained(unitKeys, unitKeyBuild.toString().trim());
                 }
-            } else if (i == numberResult.start) {
+            } else if (i == numberResult.getStart()) {
                 // numberResult.start is a relative position
                 if (unitKeyBuild.length() != 0) {
                     addIfNotContained(unitKeys, unitKeyBuild.toString().trim());
                     unitKeyBuild = new StringBuilder();
                 }
-                i = numberResult.start + numberResult.length - 1;
+                i = numberResult.getStart() + numberResult.getLength() - 1;
             } else {
                 unitKeyBuild.append(key.charAt(i));
             }
@@ -80,19 +81,19 @@ public class NumberWithUnitParser implements IParser {
 
             if (unitValue != null) {
 
-                ParseResult numValue = numberResult.text == null || numberResult.text.isEmpty() ?
+                ParseResult numValue = numberResult.getText() == null || numberResult.getText().isEmpty() ?
                         null :
                         this.config.getInternalNumberParser().parse(numberResult);
 
-                String resolutionStr = numValue != null ? numValue.resolutionStr : null;
+                String resolutionStr = numValue != null ? numValue.getResolutionStr() : null;
 
-                ret = ret.withValue(new UnitValue(resolutionStr, unitValue))
-                         .withResolutionStr(String.format("%s %s", resolutionStr != null ? resolutionStr : "", unitValue).trim());
+                ret.setValue(new UnitValue(resolutionStr, unitValue));
+                ret.setResolutionStr(String.format("%s %s", resolutionStr != null ? resolutionStr : "", unitValue).trim());
             }
         }
 
         if (ret != null) {
-            ret = ret.withText(ret.text.toLowerCase(Locale.ROOT));
+            ret.setText(ret.getText().toLowerCase(Locale.ROOT));
         }
 
         return ret;

--- a/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/extractors/BaseNumberRangeExtractor.java
+++ b/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/extractors/BaseNumberRangeExtractor.java
@@ -118,15 +118,15 @@ public abstract class BaseNumberRangeExtractor implements IExtractor {
             if (extractNumList1 != null && extractNumList2 != null) {
                 if (type.contains(NumberRangeConstants.TWONUMTILL)) {
                     // num1 must have same type with num2
-                    if (!extractNumList1.get(0).type.equals(extractNumList2.get(0).type)) {
+                    if (!extractNumList1.get(0).getType().equals(extractNumList2.get(0).getType())) {
                         return Pair.with(start, length);
                     }
 
                     // num1 must less than num2
                     ParseResult numExt1 = numberParser.parse(extractNumList1.get(0));
                     ParseResult numExt2 = numberParser.parse(extractNumList2.get(0));
-                    double num1 = numExt1.value != null ? (double)numExt1.value : 0;
-                    double num2 = numExt1.value != null ? (double)numExt2.value : 0;
+                    double num1 = numExt1.getValue() != null ? (double)numExt1.getValue() : 0;
+                    double num2 = numExt1.getValue() != null ? (double)numExt2.getValue() : 0;
 
                     if (num1 > num2) {
                         return Pair.with(start, length);
@@ -179,14 +179,14 @@ public abstract class BaseNumberRangeExtractor implements IExtractor {
         boolean validNum = false;
 
         for (ExtractResult extractNum : extractNumList) {
-            if (numberStr.trim().endsWith(extractNum.text) && match.group().startsWith(numberStr)) {
-                start = source.indexOf(numberStr) + (extractNum.start != null ? extractNum.start : 0);
-                length = length - (extractNum.start != null ? extractNum.start : 0);
+            if (numberStr.trim().endsWith(extractNum.getText()) && match.group().startsWith(numberStr)) {
+                start = source.indexOf(numberStr) + (extractNum.getStart() != null ? extractNum.getStart() : 0);
+                length = length - (extractNum.getStart() != null ? extractNum.getStart() : 0);
                 validNum = true;
-            } else if (extractNum.start == 0 && match.group().endsWith(numberStr)) {
-                length = length - numberStr.length() + (extractNum.length != null ? extractNum.length : 0);
+            } else if (extractNum.getStart() == 0 && match.group().endsWith(numberStr)) {
+                length = length - numberStr.length() + (extractNum.getLength() != null ? extractNum.getLength() : 0);
                 validNum = true;
-            } else if (extractNum.start == 0 && extractNum.length == numberStr.trim().length()) {
+            } else if (extractNum.getStart() == 0 && extractNum.getLength() == numberStr.trim().length()) {
                 validNum = true;
             }
 
@@ -214,16 +214,16 @@ public abstract class BaseNumberRangeExtractor implements IExtractor {
 
         //        extractNumber = extractNumber.OrderByDescending(num => num.Length).ThenByDescending(num => num.Start).ToList();
         Collections.sort(extractNumber, (Comparator<ExtractResult>)(o1, o2) -> {
-            Integer x1 = ((ExtractResult)o1).length;
-            Integer x2 = ((ExtractResult)o2).length;
+            Integer x1 = ((ExtractResult)o1).getLength();
+            Integer x2 = ((ExtractResult)o2).getLength();
             int scomp = x2.compareTo(x1);
 
             if (scomp != 0) {
                 return scomp;
             }
 
-            x1 = ((ExtractResult)o1).start;
-            x2 = ((ExtractResult)o2).start;
+            x1 = ((ExtractResult)o1).getStart();
+            x2 = ((ExtractResult)o2).getStart();
             return x2.compareTo(x1);
         });
 

--- a/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/extractors/BasePercentageExtractor.java
+++ b/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/extractors/BasePercentageExtractor.java
@@ -98,9 +98,9 @@ public abstract class BasePercentageExtractor implements IExtractor {
         String replaceFracNumText = "@" + FracNumExtType;
 
         for (int i = 0; i < results.size(); i++) {
-            int start = results.get(i).start;
-            int end = start + results.get(i).length;
-            String str = results.get(i).text;
+            int start = results.get(i).getStart();
+            int end = start + results.get(i).getLength();
+            String str = results.get(i).getText();
             List<Pair<String, ExtractResult>> data = new ArrayList<>();
 
             String replaceText;
@@ -113,7 +113,7 @@ public abstract class BasePercentageExtractor implements IExtractor {
             if (positionMap.containsKey(start) && positionMap.containsKey(end)) {
                 int originStart = positionMap.get(start);
                 int originLength = positionMap.get(end) - originStart;
-                results.set(i, new ExtractResult(originStart, originLength, originSource.substring(originStart, originLength + originStart), results.get(i).type, null));
+                results.set(i, new ExtractResult(originStart, originLength, originSource.substring(originStart, originLength + originStart), results.get(i).getType(), null));
 
                 int numStart = str.indexOf(replaceText);
                 if (numStart != -1) {
@@ -121,10 +121,10 @@ public abstract class BasePercentageExtractor implements IExtractor {
                         for (int j = i; j < numExtResults.size(); j++) {
                             ExtractResult r = results.get(i);
                             ExtractResult n = numExtResults.get(j);
-                            if ((r.start.equals(n.start) ||
-                                r.start + r.length == n.start + n.length) &&
-                                r.text.contains(n.text)) {
-                                data.add(Pair.with(n.text, n));
+                            if ((r.getStart().equals(n.getStart()) ||
+                                r.getStart() + r.getLength() == n.getStart() + n.getLength()) &&
+                                r.getText().contains(n.getText())) {
+                                data.add(Pair.with(n.getText(), n));
                             }
                         }
                     }
@@ -135,14 +135,14 @@ public abstract class BasePercentageExtractor implements IExtractor {
                 // deal with special cases like "<fraction number> of" and "one in two" in percentageMode
                 if (str.contains(replaceFracNumText) || data.size() > 1) {
                     ExtractResult r = results.get(i);
-                    results.set(i, new ExtractResult(r.start, r.length, r.text, r.type, data));
+                    results.set(i, new ExtractResult(r.getStart(), r.getLength(), r.getText(), r.getType(), data));
                 } else if (data.size() == 1) {
                     ExtractResult r = results.get(i);
-                    results.set(i, new ExtractResult(r.start, r.length, r.text, r.type, data.get(0)));
+                    results.set(i, new ExtractResult(r.getStart(), r.getLength(), r.getText(), r.getType(), data.get(0)));
                 }
             } else if (data.size() == 1) {
                 ExtractResult r = results.get(i);
-                results.set(i, new ExtractResult(r.start, r.length, r.text, r.type, data.get(0)));
+                results.set(i, new ExtractResult(r.getStart(), r.getLength(), r.getText(), r.getType(), data.get(0)));
             }
         }
     }
@@ -165,11 +165,11 @@ public abstract class BasePercentageExtractor implements IExtractor {
 
         for (int i = 0; i < numExtractResults.size(); i++) {
             ExtractResult extraction = numExtractResults.get(i);
-            start = extraction.start;
-            end = extraction.length + start;
+            start = extraction.getStart();
+            end = extraction.getLength() + start;
             for (int j = start; j < end; j++) {
                 if (match[j] == 0) {
-                    if (percentModeEnabled && extraction.data.toString().startsWith("Frac")) {
+                    if (percentModeEnabled && extraction.getData().toString().startsWith("Frac")) {
                         match[j] = -(i + 1);
                     } else {
                         match[j] = i + 1;

--- a/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/models/AbstractNumberModel.java
+++ b/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/models/AbstractNumberModel.java
@@ -49,12 +49,12 @@ public abstract class AbstractNumberModel implements IModel {
 
         return parsedNumbers.stream().map(o -> {
             SortedMap<String, Object> sortedMap = new TreeMap<String, Object>();
-            sortedMap.put(ResolutionKey.Value, o.resolutionStr);
+            sortedMap.put(ResolutionKey.Value, o.getResolutionStr());
 
             return new ModelResult(
-                o.text,
-                o.start,
-                o.start + o.length,
+                    o.getText(),
+                    o.getStart(),
+                o.getStart() + o.getLength(),
                 getModelTypeName(),
                 sortedMap
             );                

--- a/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/parsers/BaseCJKNumberParser.java
+++ b/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/parsers/BaseCJKNumberParser.java
@@ -23,17 +23,17 @@ public class BaseCJKNumberParser extends BaseNumberParser {
     public ParseResult parse(ExtractResult extResult) {
 
         // check if the parser is configured to support specific types
-        if (supportedTypes.isPresent() && !supportedTypes.get().stream().anyMatch(t -> extResult.type.equals(t))) {
+        if (supportedTypes.isPresent() && !supportedTypes.get().stream().anyMatch(t -> extResult.getType().equals(t))) {
             return null;
         }
 
-        String extra = extResult.data instanceof String ? (String)extResult.data : null;
+        String extra = extResult.getData() instanceof String ? (String)extResult.getData() : null;
         ParseResult ret = null;
 
-        ExtractResult getExtResult = new ExtractResult(extResult.start, extResult.length, extResult.text, extResult.type, extResult.data);
+        ExtractResult getExtResult = new ExtractResult(extResult.getStart(), extResult.getLength(), extResult.getText(), extResult.getType(), extResult.getData());
 
         if (config.getCultureInfo().cultureCode.equalsIgnoreCase("zh-CN")) {
-            getExtResult = getExtResult.withText(replaceTraWithSim(getExtResult.text));
+            getExtResult.setText(replaceTraWithSim(getExtResult.getText()));
         }
 
         if (extra == null) {
@@ -43,17 +43,17 @@ public class BaseCJKNumberParser extends BaseNumberParser {
         if (extra.contains("Per")) {
             ret = parsePercentage(getExtResult);
         } else if (extra.contains("Num")) {
-            getExtResult = getExtResult.withText(normalizeCharWidth(getExtResult.text));
+            getExtResult.setText(normalizeCharWidth(getExtResult.getText()));
             ret = digitNumberParse(getExtResult);
-            if (config.getNegativeNumberSignRegex().matcher(getExtResult.text).find() && (double)ret.value > 0) {
-                ret = ret.withValue(-(double)ret.value);
+            if (config.getNegativeNumberSignRegex().matcher(getExtResult.getText()).find() && (double)ret.getValue() > 0) {
+                ret.setValue(-(double)ret.getValue());
             }
 
-            ret = ret.withResolutionStr(getResolutionString((double)ret.value));
+            ret.setResolutionStr(getResolutionString((double)ret.getValue()));
         } else if (extra.contains("Pow")) {
-            getExtResult = getExtResult.withText(normalizeCharWidth(getExtResult.text));
+            getExtResult.setText(normalizeCharWidth(getExtResult.getText()));
             ret = powerNumberParse(getExtResult);
-            ret = ret.withResolutionStr(getResolutionString((double)ret.value));
+            ret.setResolutionStr(getResolutionString((double)ret.getValue()));
         } else if (extra.contains("Frac")) {
             ret = parseFraction(getExtResult);
         } else if (extra.contains("Dou")) {
@@ -65,7 +65,7 @@ public class BaseCJKNumberParser extends BaseNumberParser {
         }
 
         if (ret != null) {
-            ret = ret.withText(extResult.text.toLowerCase(Locale.ROOT));
+            ret.setText(extResult.getText().toLowerCase(Locale.ROOT));
         }
 
         return ret;
@@ -73,9 +73,9 @@ public class BaseCJKNumberParser extends BaseNumberParser {
 
     // Parse Fraction phrase.
     protected ParseResult parseFraction(ExtractResult extResult) {
-        ParseResult result = new ParseResult(extResult.start, extResult.length, extResult.text, extResult.type, null, null, null);
+        ParseResult result = new ParseResult(extResult.getStart(), extResult.getLength(), extResult.getText(), extResult.getType(), null, null, null);
 
-        String resultText = extResult.text;
+        String resultText = extResult.getText();
         String[] splitResult = cjkConfig.getFracSplitRegex().split(resultText);
         String intPart = "";
         String demoPart = "";
@@ -106,31 +106,31 @@ public class BaseCJKNumberParser extends BaseNumberParser {
                 getIntValue(demoPart);
 
         if (cjkConfig.getNegativeNumberSignRegex().matcher(intPart).find()) {
-            result = result.withValue(intValue - numValue / demoValue);
+            result.setValue(intValue - numValue / demoValue);
         } else {
-            result = result.withValue(intValue + numValue / demoValue);
+            result.setValue(intValue + numValue / demoValue);
         }
 
-        result = result.withResolutionStr(getResolutionString((double)result.value));
+        result.setResolutionStr(getResolutionString((double)result.getValue()));
         return result;
     }
 
     // Parse percentage phrase.
     protected ParseResult parsePercentage(ExtractResult extResult) {
-        ParseResult result = new ParseResult(extResult.start, extResult.length, extResult.text, extResult.type, null, null, null);
+        ParseResult result = new ParseResult(extResult.getStart(), extResult.getLength(), extResult.getText(), extResult.getType(), null, null, null);
         Map<Character, Double> zeroToNineMap = cjkConfig.getZeroToNineMap();
 
-        String resultText = extResult.text;
+        String resultText = extResult.getText();
         long power = 1;
 
-        if (extResult.data.toString().contains("Spe")) {
+        if (extResult.getData().toString().contains("Spe")) {
             resultText = normalizeCharWidth(resultText);
             resultText = replaceUnit(resultText);
 
             if (resultText.equals("半額") || resultText.equals("半値") || resultText.equals("半折")) {
-                result = result.withValue(50);
+                result.setValue(50);
             } else if (resultText.equals("10成") || resultText.equals("10割") || resultText.equals("十割")) {
-                result = result.withValue(100);
+                result.setValue(100);
             } else {
                 Match[] matches = RegExpUtility.getMatches(this.cjkConfig.getSpeGetNumberRegex(), resultText);
                 double intNumber;
@@ -154,7 +154,7 @@ public class BaseCJKNumberParser extends BaseNumberParser {
                         pointNumber = zeroToNineMap.get(pointNumberChar) * 0.1;
                     }
 
-                    result = result.withValue((intNumber + pointNumber) * 10);
+                    result.setValue((intNumber + pointNumber) * 10);
                 } else if (matches.length == 5) {
                     // Deal the Japanese percentage case like "xxx割xxx分xxx厘", get the integer value and convert into result.
                     char intNumberChar = matches[0].value.charAt(0);
@@ -166,7 +166,7 @@ public class BaseCJKNumberParser extends BaseNumberParser {
 
                     intNumber = zeroToNineMap.get(intNumberChar);
 
-                    result = result.withValue((intNumber + pointNumber + dotNumber) * 10);
+                    result.setValue((intNumber + pointNumber + dotNumber) * 10);
                 } else {
                     char intNumberChar = matches[0].value.charAt(0);
 
@@ -178,10 +178,10 @@ public class BaseCJKNumberParser extends BaseNumberParser {
                         intNumber = zeroToNineMap.get(intNumberChar);
                     }
 
-                    result = result.withValue(intNumber * 10);
+                    result.setValue(intNumber * 10);
                 }
             }
-        } else if (extResult.data.toString().contains("Num")) {
+        } else if (extResult.getData().toString().contains("Num")) {
 
             Match[] doubleMatches = RegExpUtility.getMatches(cjkConfig.getPercentageRegex(), resultText);
             String doubleText = doubleMatches[doubleMatches.length - 1].value;
@@ -203,7 +203,7 @@ public class BaseCJKNumberParser extends BaseNumberParser {
                 power = 1000000000000L;
             }
 
-            result = result.withValue(getDigitValue(resultText, power));
+            result.setValue(getDigitValue(resultText, power));
         } else {
             Match[] doubleMatches = RegExpUtility.getMatches(cjkConfig.getPercentageRegex(), resultText);
             String doubleText = doubleMatches[doubleMatches.length - 1].value;
@@ -224,13 +224,13 @@ public class BaseCJKNumberParser extends BaseNumberParser {
                 }
             }
 
-            result = result.withValue(doubleValue);
+            result.setValue(doubleValue);
         }
 
-        if (result.value instanceof Double) {
-            result = result.withResolutionStr(getResolutionString((double)result.value) + "%");
-        } else if (result.value instanceof Integer) {
-            result = result.withResolutionStr(getResolutionString((int)result.value) + "%");
+        if (result.getValue() instanceof Double) {
+            result.setResolutionStr(getResolutionString((double)result.getValue()) + "%");
+        } else if (result.getValue() instanceof Integer) {
+            result.setResolutionStr(getResolutionString((int)result.getValue()) + "%");
         }
 
         return result;
@@ -238,9 +238,9 @@ public class BaseCJKNumberParser extends BaseNumberParser {
 
     // Parse ordinal phrase.
     protected ParseResult parseOrdinal(ExtractResult extResult) {
-        ParseResult result = new ParseResult(extResult.start, extResult.length, extResult.text, extResult.type, null, null, null);
+        ParseResult result = new ParseResult(extResult.getStart(), extResult.getLength(), extResult.getText(), extResult.getType(), null, null, null);
 
-        String resultText = extResult.text;
+        String resultText = extResult.getText();
         resultText = resultText.substring(1);
 
         boolean isDigit = cjkConfig.getDigitNumRegex().matcher(resultText).find();
@@ -248,20 +248,20 @@ public class BaseCJKNumberParser extends BaseNumberParser {
 
         double newValue = isDigit && !isRoundInt ? getDigitValue(resultText, 1) : getIntValue(resultText);
 
-        result = result.withValue(newValue)
-                .withResolutionStr(getResolutionString(newValue));
+        result.setValue(newValue);
+        result.setResolutionStr(getResolutionString(newValue));
 
         return result;
     }
 
     // Parse double phrase
     protected ParseResult parseDouble(ExtractResult extResult) {
-        ParseResult result = new ParseResult(extResult.start, extResult.length, extResult.text, extResult.type, null, null, null);
-        String resultText = extResult.text;
+        ParseResult result = new ParseResult(extResult.getStart(), extResult.getLength(), extResult.getText(), extResult.getType(), null, null, null);
+        String resultText = extResult.getText();
 
         if (cjkConfig.getDoubleAndRoundRegex().matcher(resultText).find()) {
             resultText = replaceUnit(resultText);
-            result = result.withValue(getDigitValue(
+            result.setValue(getDigitValue(
                     resultText.substring(0, resultText.length() - 1),
                     cjkConfig.getRoundNumberMapChar().get(resultText.charAt(resultText.length() - 1))));
         } else {
@@ -273,20 +273,20 @@ public class BaseCJKNumberParser extends BaseNumberParser {
             }
 
             if (cjkConfig.getNegativeNumberSignRegex().matcher(splitResult[0]).find()) {
-                result = result.withValue(getIntValue(splitResult[0]) - getPointValue(splitResult[1]));
+                result.setValue(getIntValue(splitResult[0]) - getPointValue(splitResult[1]));
             } else {
-                result = result.withValue(getIntValue(splitResult[0]) + getPointValue(splitResult[1]));
+                result.setValue(getIntValue(splitResult[0]) + getPointValue(splitResult[1]));
             }
         }
 
-        result = result.withResolutionStr(getResolutionString((double)result.value));
+        result.setResolutionStr(getResolutionString((double)result.getValue()));
         return result;
     }
 
     // Parse integer phrase
     protected ParseResult parseInteger(ExtractResult extResult) {
-        double value = getIntValue(extResult.text);
-        return new ParseResult(extResult.start, extResult.length, extResult.text, extResult.type, extResult.text, value, getResolutionString(value));
+        double value = getIntValue(extResult.getText());
+        return new ParseResult(extResult.getStart(), extResult.getLength(), extResult.getText(), extResult.getType(), extResult.getText(), value, getResolutionString(value));
     }
 
     // Replace traditional Chinese characters with simpilified Chinese ones.

--- a/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/parsers/BaseNumberRangeParser.java
+++ b/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/parsers/BaseNumberRangeParser.java
@@ -23,8 +23,8 @@ public class BaseNumberRangeParser implements IParser {
 
         ParseResult ret = null;
 
-        if (extractResult.data != null && !extractResult.data.toString().isEmpty()) {
-            String type = extractResult.data.toString();
+        if (extractResult.getData() != null && !extractResult.getData().toString().isEmpty()) {
+            String type = extractResult.getData().toString();
             if (type.contains(NumberRangeConstants.TWONUM)) {
                 ret = parseNumberRangeWhichHasTwoNum(extractResult);
             } else {
@@ -37,12 +37,12 @@ public class BaseNumberRangeParser implements IParser {
 
     private ParseResult parseNumberRangeWhichHasTwoNum(ExtractResult extractResult) {
 
-        ParseResult result = new ParseResult(extractResult.start, extractResult.length, extractResult.text, extractResult.type, null, null, null);
-        List<ExtractResult> er = config.getNumberExtractor().extract(extractResult.text);
+        ParseResult result = new ParseResult(extractResult.getStart(), extractResult.getLength(), extractResult.getText(), extractResult.getType(), null, null, null);
+        List<ExtractResult> er = config.getNumberExtractor().extract(extractResult.getText());
 
         // Valid extracted results for this type should have two numbers
         if (er.size() != 2) {
-            er = config.getOrdinalExtractor().extract(extractResult.text);
+            er = config.getOrdinalExtractor().extract(extractResult.getText());
 
             if (er.size() != 2) {
                 return result;
@@ -50,7 +50,7 @@ public class BaseNumberRangeParser implements IParser {
         }
 
         List<Double> nums = er.stream().map(r -> {
-            Object value = config.getNumberParser().parse(r).value;
+            Object value = config.getNumberParser().parse(r).getValue();
             return value == null ? 0 : (Double)value;
         }).collect(Collectors.toList());
 
@@ -70,7 +70,7 @@ public class BaseNumberRangeParser implements IParser {
         char leftBracket;
         char rightBracket;
 
-        String type = (String)extractResult.data;
+        String type = (String)extractResult.getData();
         if (type.contains(NumberRangeConstants.TWONUMBETWEEN)) {
             // between 20 and 30: (20,30)
             leftBracket = NumberRangeConstants.LEFT_OPEN;
@@ -81,10 +81,10 @@ public class BaseNumberRangeParser implements IParser {
             rightBracket = NumberRangeConstants.RIGHT_OPEN;
         } else {
             // check whether it contains string like "more or equal", "less or equal", "at least", etc.
-            Matcher match = config.getMoreOrEqual().matcher(extractResult.text);
+            Matcher match = config.getMoreOrEqual().matcher(extractResult.getText());
             boolean matches = match.find();
             if (!matches) {
-                match = config.getMoreOrEqualSuffix().matcher(extractResult.text);
+                match = config.getMoreOrEqualSuffix().matcher(extractResult.getText());
                 matches = match.find();
             }
 
@@ -94,11 +94,11 @@ public class BaseNumberRangeParser implements IParser {
                 leftBracket = NumberRangeConstants.LEFT_OPEN;
             }
 
-            match = config.getLessOrEqual().matcher(extractResult.text);
+            match = config.getLessOrEqual().matcher(extractResult.getText());
             matches = match.find();
 
             if (!matches) {
-                match = config.getLessOrEqualSuffix().matcher(extractResult.text);
+                match = config.getLessOrEqualSuffix().matcher(extractResult.getText());
                 matches = match.find();
             }
 
@@ -109,11 +109,10 @@ public class BaseNumberRangeParser implements IParser {
             }
         }
 
-        result = result
-                .withValue(ImmutableMap.of(
+        result.setValue(ImmutableMap.of(
                         "StartValue", startValue,
-                        "EndValue", endValue))
-                .withResolutionStr(new StringBuilder()
+                        "EndValue", endValue));
+        result.setResolutionStr(new StringBuilder()
                         .append(leftBracket)
                         .append(startValueStr)
                         .append(NumberRangeConstants.INTERVAL_SEPARATOR)
@@ -125,13 +124,13 @@ public class BaseNumberRangeParser implements IParser {
 
     private ParseResult parseNumberRangeWhichHasOneNum(ExtractResult extractResult) {
 
-        ParseResult result = new ParseResult(extractResult.start, extractResult.length, extractResult.text, extractResult.type, null, null, null);
+        ParseResult result = new ParseResult(extractResult.getStart(), extractResult.getLength(), extractResult.getText(), extractResult.getType(), null, null, null);
 
-        List<ExtractResult> er = config.getNumberExtractor().extract(extractResult.text);
+        List<ExtractResult> er = config.getNumberExtractor().extract(extractResult.getText());
 
         // Valid extracted results for this type should have one number
         if (er.size() != 1) {
-            er = config.getOrdinalExtractor().extract(extractResult.text);
+            er = config.getOrdinalExtractor().extract(extractResult.getText());
 
             if (er.size() != 1) {
                 return result;
@@ -139,7 +138,7 @@ public class BaseNumberRangeParser implements IParser {
         }
 
         List<Double> nums = er.stream().map(r -> {
-            Object value = config.getNumberParser().parse(r).value;
+            Object value = config.getNumberParser().parse(r).getValue();
             return value == null ? 0 : (Double)value;
         }).collect(Collectors.toList());
 
@@ -148,20 +147,20 @@ public class BaseNumberRangeParser implements IParser {
         String startValueStr = "";
         String endValueStr = "";
 
-        String type = (String)extractResult.data;
+        String type = (String)extractResult.getData();
         if (type.contains(NumberRangeConstants.MORE)) {
             rightBracket = NumberRangeConstants.RIGHT_OPEN;
 
-            Matcher match = config.getMoreOrEqual().matcher(extractResult.text);
+            Matcher match = config.getMoreOrEqual().matcher(extractResult.getText());
             boolean matches = match.find();
 
             if (!matches) {
-                match = config.getMoreOrEqualSuffix().matcher(extractResult.text);
+                match = config.getMoreOrEqualSuffix().matcher(extractResult.getText());
                 matches = match.find();
             }
 
             if (!matches) {
-                match = config.getMoreOrEqualSeparate().matcher(extractResult.text);
+                match = config.getMoreOrEqualSeparate().matcher(extractResult.getText());
                 matches = match.find();
             }
 
@@ -173,20 +172,20 @@ public class BaseNumberRangeParser implements IParser {
 
             startValueStr = config.getCultureInfo() != null ? NumberFormatUtility.format(nums.get(0), config.getCultureInfo()) : nums.get(0).toString();
 
-            result = result.withValue(ImmutableMap.of("StartValue", nums.get(0)));
+            result.setValue(ImmutableMap.of("StartValue", nums.get(0)));
         } else if (type.contains(NumberRangeConstants.LESS)) {
             leftBracket = NumberRangeConstants.LEFT_OPEN;
 
-            Matcher match = config.getLessOrEqual().matcher(extractResult.text);
+            Matcher match = config.getLessOrEqual().matcher(extractResult.getText());
             boolean matches = match.find();
 
             if (!matches) {
-                match = config.getLessOrEqualSuffix().matcher(extractResult.text);
+                match = config.getLessOrEqualSuffix().matcher(extractResult.getText());
                 matches = match.find();
             }
 
             if (!matches) {
-                match = config.getLessOrEqualSeparate().matcher(extractResult.text);
+                match = config.getLessOrEqualSeparate().matcher(extractResult.getText());
                 matches = match.find();
             }
 
@@ -198,7 +197,7 @@ public class BaseNumberRangeParser implements IParser {
 
             endValueStr = config.getCultureInfo() != null ? NumberFormatUtility.format(nums.get(0), config.getCultureInfo()) : nums.get(0).toString();
 
-            result = result.withValue(ImmutableMap.of("EndValue", nums.get(0)));
+            result.setValue(ImmutableMap.of("EndValue", nums.get(0)));
         } else {
             leftBracket = NumberRangeConstants.LEFT_CLOSED;
             rightBracket = NumberRangeConstants.RIGHT_CLOSED;
@@ -206,13 +205,13 @@ public class BaseNumberRangeParser implements IParser {
             startValueStr = config.getCultureInfo() != null ? NumberFormatUtility.format(nums.get(0), config.getCultureInfo()) : nums.get(0).toString();
             endValueStr = startValueStr;
 
-            result = result.withValue(ImmutableMap.of(
+            result.setValue(ImmutableMap.of(
                     "StartValue", nums.get(0),
                     "EndValue", nums.get(0)
             ));
         }
 
-        result = result.withResolutionStr(new StringBuilder()
+        result.setResolutionStr(new StringBuilder()
                 .append(leftBracket)
                 .append(startValueStr)
                 .append(NumberRangeConstants.INTERVAL_SEPARATOR)

--- a/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/parsers/BasePercentageParser.java
+++ b/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/parsers/BasePercentageParser.java
@@ -13,57 +13,53 @@ public class BasePercentageParser extends BaseNumberParser {
     @Override
     @SuppressWarnings("unchecked")
     public ParseResult parse(ExtractResult extractResult) {
-        String originText = extractResult.text;
+        String originText = extractResult.getText();
         ParseResult ret = null;
 
         // replace text & data from extended info
-        if (extractResult.data instanceof List) {
-            List<Pair<String, ExtractResult>> extendedData = (List<Pair<String, ExtractResult>>)extractResult.data;
+        if (extractResult.getData() instanceof List) {
+            List<Pair<String, ExtractResult>> extendedData = (List<Pair<String, ExtractResult>>)extractResult.getData();
             if (extendedData.size() == 2) {
                 // for case like "2 out of 5".
                 String newText = extendedData.get(0).getValue0() + " " + config.getFractionMarkerToken() + " " + extendedData.get(1).getValue0();
-                extractResult = extractResult
-                        .withText(newText)
-                        .withData("Frac" + config.getLangMarker());
+                extractResult.setText(newText);
+                extractResult.setData("Frac" + config.getLangMarker());
 
                 ret = super.parse(extractResult);
-                ret = ret.withValue((double)ret.value * 100);
+                ret.setValue((double)ret.getValue() * 100);
             } else if (extendedData.size() == 1) {
                 // for case like "one third of".
-                extractResult = extractResult
-                        .withText(extendedData.get(0).getValue0())
-                        .withData(extendedData.get(0).getValue1().data);
+                extractResult.setText(extendedData.get(0).getValue0());
+                extractResult.setData(extendedData.get(0).getValue1().getData());
 
                 ret = super.parse(extractResult);
 
-                if (extractResult.data.toString().startsWith("Frac")) {
-                    ret = ret.withValue((double)ret.value * 100);
+                if (extractResult.getData().toString().startsWith("Frac")) {
+                    ret.setValue((double)ret.getValue() * 100);
                 }
             }
 
             String resolutionStr = config.getCultureInfo() != null ?
-                    NumberFormatUtility.format(ret.value, config.getCultureInfo()) + "%" :
-                    ret.value + "%";
-            ret = ret.withResolutionStr(resolutionStr);
+                    NumberFormatUtility.format(ret.getValue(), config.getCultureInfo()) + "%" :
+                    ret.getValue() + "%";
+            ret.setResolutionStr(resolutionStr);
         } else {
             // for case like "one percent" or "1%".
-            Pair<String, ExtractResult> extendedData = (Pair<String, ExtractResult>)extractResult.data;
-            extractResult = extractResult
-                    .withText(extendedData.getValue0())
-                    .withData(extendedData.getValue1().data);
+            Pair<String, ExtractResult> extendedData = (Pair<String, ExtractResult>)extractResult.getData();
+            extractResult.setText(extendedData.getValue0());
+            extractResult.setData(extendedData.getValue1().getData());
 
             ret = super.parse(extractResult);
 
-            if (ret.resolutionStr != null && !ret.resolutionStr.isEmpty()) {
-                if (!ret.resolutionStr.trim().endsWith("%")) {
-                    ret = ret.withResolutionStr(ret.resolutionStr.trim() + "%");
+            if (ret.getResolutionStr() != null && !ret.getResolutionStr().isEmpty()) {
+                if (!ret.getResolutionStr().trim().endsWith("%")) {
+                    ret.setResolutionStr(ret.getResolutionStr().trim() + "%");
                 }
             }
         }
 
-        ret = ret
-                .withText(originText)
-                .withData(extractResult.text);
+        ret.setText(originText);
+        ret.setData(extractResult.getText());
 
         return ret;
 

--- a/Java/libraries/recognizers-text/src/main/java/com/microsoft/recognizers/text/ExtractResult.java
+++ b/Java/libraries/recognizers-text/src/main/java/com/microsoft/recognizers/text/ExtractResult.java
@@ -2,11 +2,11 @@ package com.microsoft.recognizers.text;
 
 public class ExtractResult {
 
-    public final Integer start;
-    public final Integer length;
-    public final Object data;
-    public String type;
-    public String text;
+    private Integer start;
+    private Integer length;
+    private Object data;
+    private String type;
+    private String text;
 
     public ExtractResult() {
         this(null, null, null, null);
@@ -24,54 +24,9 @@ public class ExtractResult {
         this.data = data;
     }
 
-    public ExtractResult withStart(int newStart) {
-        return new ExtractResult(
-                newStart,
-                this.length,
-                this.text,
-                this.type,
-                this.data);
-    }
-
-    public ExtractResult withLength(int newLength) {
-        return new ExtractResult(
-                this.start,
-                newLength,
-                this.text,
-                this.type,
-                this.data);
-    }
-
-    public ExtractResult withText(String newText) {
-        return new ExtractResult(
-                this.start,
-                this.length,
-                newText,
-                this.type,
-                this.data);
-    }
-
-    public ExtractResult withType(String newType) {
-        return new ExtractResult(
-                this.start,
-                this.length,
-                this.text,
-                newType,
-                this.data);
-    }
-
-    public ExtractResult withData(Object newData) {
-        return new ExtractResult(
-                this.start,
-                this.length,
-                this.text,
-                this.type,
-                newData);
-    }
-
     private boolean isOverlap(ExtractResult er1, ExtractResult er2) {
-        return !(er1.start >= er2.start + er2.length) &&
-                !(er2.start >= er1.start + er1.length);
+        return !(er1.getStart() >= er2.getStart() + er2.getLength()) &&
+                !(er2.getStart() >= er1.getStart() + er1.getLength());
     }
 
     public boolean isOverlap(ExtractResult er) {
@@ -79,19 +34,51 @@ public class ExtractResult {
     }
 
     private boolean isCover(ExtractResult er1, ExtractResult er2) {
-        return ((er2.start < er1.start) && ((er2.start + er2.length) >= (er1.start + er1.length))) ||
-                ((er2.start <= er1.start) && ((er2.start + er2.length) > (er1.start + er1.length)));
+        return ((er2.getStart() < er1.getStart()) && ((er2.getStart() + er2.getLength()) >= (er1.getStart() + er1.getLength()))) ||
+                ((er2.getStart() <= er1.getStart()) && ((er2.getStart() + er2.getLength()) > (er1.getStart() + er1.getLength())));
     }
 
     public boolean isCover(ExtractResult er) {
         return isCover(this, er);
     }
 
-    public void setText(String text) {
-        this.text = text;
+    public Integer getStart() {
+        return start;
+    }
+
+    public void setStart(Integer start) {
+        this.start = start;
+    }
+
+    public Integer getLength() {
+        return length;
+    }
+
+    public void setLength(Integer length) {
+        this.length = length;
+    }
+
+    public Object getData() {
+        return data;
+    }
+
+    public void setData(Object data) {
+        this.data = data;
+    }
+
+    public String getType() {
+        return type;
     }
 
     public void setType(String type) {
         this.type = type;
+    }
+
+    public String getText() {
+        return text;
+    }
+
+    public void setText(String text) {
+        this.text = text;
     }
 }

--- a/Java/libraries/recognizers-text/src/main/java/com/microsoft/recognizers/text/ParseResult.java
+++ b/Java/libraries/recognizers-text/src/main/java/com/microsoft/recognizers/text/ParseResult.java
@@ -6,11 +6,11 @@ public class ParseResult extends ExtractResult {
     // e.g. 1000 for "one thousand".
     // The resolutions are different for different parsers.
     // Therefore, we use object here.
-    public final Object value;
+    private Object value;
 
     // Output the value in string format.
     // It is used in some parsers.
-    public final String resolutionStr;
+    private String resolutionStr;
 
     public ParseResult(Integer start, Integer length, String text, String type, Object data, Object value, String resolutionStr) {
         super(start, length, text, type, data);
@@ -19,61 +19,22 @@ public class ParseResult extends ExtractResult {
     }
 
     public ParseResult(ExtractResult er) {
-        this(er.start, er.length, er.text, er.type, er.data, null, null);
+        this(er.getStart(), er.getLength(), er.getText(), er.getType(), er.getData(), null, null);
     }
 
-    public ParseResult withLength(int newLength) {
-        return new ParseResult(
-                this.start,
-                newLength,
-                this.text,
-                this.type,
-                this.data,
-                this.value,
-                this.resolutionStr);
+    public Object getValue() {
+        return value;
     }
 
-    public ParseResult withText(String newText) {
-        return new ParseResult(
-                this.start,
-                this.length,
-                newText,
-                this.type,
-                this.data,
-                this.value,
-                this.resolutionStr);
+    public void setValue(Object value) {
+        this.value = value;
     }
 
-    public ParseResult withData(Object newData) {
-        return new ParseResult(
-                this.start,
-                this.length,
-                this.text,
-                this.type,
-                newData,
-                this.value,
-                this.resolutionStr);
+    public String getResolutionStr() {
+        return resolutionStr;
     }
 
-    public ParseResult withValue(Object newVale) {
-        return new ParseResult(
-                this.start,
-                this.length,
-                this.text,
-                this.type,
-                this.data,
-                newVale,
-                this.resolutionStr);
-    }
-
-    public ParseResult withResolutionStr(String newResolutionStr) {
-        return new ParseResult(
-                this.start,
-                this.length,
-                this.text,
-                this.type,
-                this.data,
-                this.value,
-                newResolutionStr);
+    public void setResolutionStr(String resolutionStr) {
+        this.resolutionStr = resolutionStr;
     }
 }

--- a/Java/tests/src/test/java/com/microsoft/recognizers/text/tests/datetime/DateTimeExtractorTest.java
+++ b/Java/tests/src/test/java/com/microsoft/recognizers/text/tests/datetime/DateTimeExtractorTest.java
@@ -1,21 +1,43 @@
 package com.microsoft.recognizers.text.tests.datetime;
 
-import java.util.Collection;
-import java.util.List;
-import java.util.stream.IntStream;
-
 import com.microsoft.recognizers.text.Culture;
 import com.microsoft.recognizers.text.ExtractResult;
 import com.microsoft.recognizers.text.ModelResult;
 import com.microsoft.recognizers.text.datetime.DateTimeOptions;
 import com.microsoft.recognizers.text.datetime.config.BaseOptionsConfiguration;
 import com.microsoft.recognizers.text.datetime.config.IOptionsConfiguration;
-import com.microsoft.recognizers.text.datetime.english.extractors.*;
-import com.microsoft.recognizers.text.datetime.extractors.*;
+import com.microsoft.recognizers.text.datetime.english.extractors.EnglishDateExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.english.extractors.EnglishDatePeriodExtractorConfiguration;
 import com.microsoft.recognizers.text.datetime.spanish.extractors.SpanishDurationExtractorConfiguration;
 import com.microsoft.recognizers.text.datetime.spanish.extractors.SpanishTimeExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.english.extractors.EnglishDateTimeExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.english.extractors.EnglishDateTimePeriodExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.english.extractors.EnglishDurationExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.english.extractors.EnglishHolidayExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.english.extractors.EnglishMergedExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.english.extractors.EnglishSetExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.english.extractors.EnglishTimeExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.english.extractors.EnglishTimePeriodExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.english.extractors.EnglishTimeZoneExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.extractors.BaseDateExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.BaseDatePeriodExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.BaseDateTimeExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.BaseDateTimePeriodExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.BaseDurationExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.BaseHolidayExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.BaseMergedDateTimeExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.BaseSetExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.BaseTimeExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.BaseTimePeriodExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.BaseTimeZoneExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.IDateTimeExtractor;
 import com.microsoft.recognizers.text.tests.AbstractTest;
 import com.microsoft.recognizers.text.tests.TestCase;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Locale;
+import java.util.stream.IntStream;
 
 import org.javatuples.Pair;
 import org.junit.Assert;
@@ -42,7 +64,7 @@ public class DateTimeExtractorTest extends AbstractTest {
 
     protected List<ExtractResult> extract(TestCase currentCase) {
         IDateTimeExtractor extractor = getExtractor(currentCase);
-        return extractor.extract(currentCase.input, currentCase.getReferenceDateTime());
+        return extractor.extract(currentCase.input.toLowerCase(Locale.ROOT), currentCase.getReferenceDateTime());
     }
 
     @Override
@@ -62,10 +84,10 @@ public class DateTimeExtractorTest extends AbstractTest {
                     ExtractResult expected = t.getValue0();
                     ExtractResult actual = t.getValue1();
 
-                    Assert.assertEquals(getMessage(currentCase, "type"), expected.type, actual.type);
-                    Assert.assertEquals(getMessage(currentCase, "text"), expected.text, actual.text);
-                    Assert.assertEquals(getMessage(currentCase, "start"), expected.start, actual.start);
-                    Assert.assertEquals(getMessage(currentCase, "length"), expected.length, actual.length);
+                    Assert.assertEquals(getMessage(currentCase, "type"), expected.getType(), actual.getType());
+                    Assert.assertTrue(getMessage(currentCase, "text"), expected.getText().equalsIgnoreCase(actual.getText()));
+                    Assert.assertEquals(getMessage(currentCase, "start"), expected.getStart(), actual.getStart());
+                    Assert.assertEquals(getMessage(currentCase, "length"), expected.getLength(), actual.getLength());
                 });
     }
 

--- a/Java/tests/src/test/java/com/microsoft/recognizers/text/tests/datetime/DateTimeExtractorTest.java
+++ b/Java/tests/src/test/java/com/microsoft/recognizers/text/tests/datetime/DateTimeExtractorTest.java
@@ -13,6 +13,7 @@ import com.microsoft.recognizers.text.datetime.config.IOptionsConfiguration;
 import com.microsoft.recognizers.text.datetime.english.extractors.*;
 import com.microsoft.recognizers.text.datetime.extractors.*;
 import com.microsoft.recognizers.text.datetime.spanish.extractors.SpanishDurationExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.spanish.extractors.SpanishTimeExtractorConfiguration;
 import com.microsoft.recognizers.text.tests.AbstractTest;
 import com.microsoft.recognizers.text.tests.TestCase;
 
@@ -149,8 +150,8 @@ public class DateTimeExtractorTest extends AbstractTest {
             //    return new BaseMergedDateTimeExtractor(new SpanishMergedExtractorConfiguration(DateTimeOptions.SkipFromToMerge));
             //case "SetExtractor":
             //    return new BaseSetExtractor(new SpanishSetExtractorConfiguration());
-            //case "TimeExtractor":
-            //    return new BaseTimeExtractor(new SpanishTimeExtractorConfiguration());
+            case "TimeExtractor":
+                return new BaseTimeExtractor(new SpanishTimeExtractorConfiguration());
             //case "TimePeriodExtractor":
             //    return new BaseTimePeriodExtractor(new SpanishTimePeriodExtractorConfiguration());
             //case "TimeZoneExtractor":

--- a/Java/tests/src/test/java/com/microsoft/recognizers/text/tests/datetime/DateTimeExtractorTest.java
+++ b/Java/tests/src/test/java/com/microsoft/recognizers/text/tests/datetime/DateTimeExtractorTest.java
@@ -12,6 +12,7 @@ import com.microsoft.recognizers.text.datetime.config.BaseOptionsConfiguration;
 import com.microsoft.recognizers.text.datetime.config.IOptionsConfiguration;
 import com.microsoft.recognizers.text.datetime.english.extractors.*;
 import com.microsoft.recognizers.text.datetime.extractors.*;
+import com.microsoft.recognizers.text.datetime.spanish.extractors.SpanishDurationExtractorConfiguration;
 import com.microsoft.recognizers.text.tests.AbstractTest;
 import com.microsoft.recognizers.text.tests.TestCase;
 
@@ -78,6 +79,8 @@ public class DateTimeExtractorTest extends AbstractTest {
             switch (culture) {
                 case Culture.English:
                     return getEnglishExtractor(modelName);
+                case Culture.Spanish:
+                    return getSpanishExtractor(modelName);
                 default:
                     throw new AssumptionViolatedException("Extractor Type/Name not supported.");
             }
@@ -116,6 +119,42 @@ public class DateTimeExtractorTest extends AbstractTest {
                 return new BaseTimePeriodExtractor(new EnglishTimePeriodExtractorConfiguration());
             case "TimeZoneExtractor":
                 return new BaseTimeZoneExtractor(new EnglishTimeZoneExtractorConfiguration(DateTimeOptions.EnablePreview));
+
+            default:
+                throw new AssumptionViolatedException("Extractor Type/Name not supported.");
+        }
+    }
+
+    private static IDateTimeExtractor getSpanishExtractor(String name) {
+
+        IOptionsConfiguration config = new BaseOptionsConfiguration();
+        switch (name) {
+            //case "DateExtractor":
+            //    return new BaseDateExtractor(new SpanishDateExtractorConfiguration(config));
+            //case "DatePeriodExtractor":
+            //    return new BaseDatePeriodExtractor(new SpanishDatePeriodExtractorConfiguration());
+            //case "DateTimeAltExtractor":
+            //    return new BaseDateTimeAltExtractor(new SpanishDateTimeAltExtractorConfiguration());
+            //case "DateTimeExtractor":
+            //    return new BaseDateTimeExtractor(new SpanishDateTimeExtractorConfiguration());
+            //case "DateTimePeriodExtractor":
+            //    return new BaseDateTimePeriodExtractor(new SpanishDateTimePeriodExtractorConfiguration());
+            case "DurationExtractor":
+                return new BaseDurationExtractor(new SpanishDurationExtractorConfiguration());
+            //case "HolidayExtractor":
+            //    return new BaseHolidayExtractor(new SpanishHolidayExtractorConfiguration());
+            //case "MergedExtractor":
+            //   return new BaseMergedDateTimeExtractor(new SpanishMergedExtractorConfiguration(DateTimeOptions.None));
+            //case "MergedExtractorSkipFromTo":
+            //    return new BaseMergedDateTimeExtractor(new SpanishMergedExtractorConfiguration(DateTimeOptions.SkipFromToMerge));
+            //case "SetExtractor":
+            //    return new BaseSetExtractor(new SpanishSetExtractorConfiguration());
+            //case "TimeExtractor":
+            //    return new BaseTimeExtractor(new SpanishTimeExtractorConfiguration());
+            //case "TimePeriodExtractor":
+            //    return new BaseTimePeriodExtractor(new SpanishTimePeriodExtractorConfiguration());
+            //case "TimeZoneExtractor":
+            //    return new BaseTimeZoneExtractor(new SpanishTimeZoneExtractorConfiguration(DateTimeOptions.EnablePreview));
 
             default:
                 throw new AssumptionViolatedException("Extractor Type/Name not supported.");

--- a/Java/tests/src/test/java/com/microsoft/recognizers/text/tests/datetime/DateTimeParserTest.java
+++ b/Java/tests/src/test/java/com/microsoft/recognizers/text/tests/datetime/DateTimeParserTest.java
@@ -8,29 +8,54 @@ import com.microsoft.recognizers.text.Culture;
 import com.microsoft.recognizers.text.ExtractResult;
 import com.microsoft.recognizers.text.ModelResult;
 import com.microsoft.recognizers.text.datetime.DateTimeOptions;
-import com.microsoft.recognizers.text.datetime.english.parsers.*;
+import com.microsoft.recognizers.text.datetime.english.parsers.EnglishCommonDateTimeParserConfiguration;
+import com.microsoft.recognizers.text.datetime.english.parsers.EnglishDateParserConfiguration;
+import com.microsoft.recognizers.text.datetime.english.parsers.EnglishDatePeriodParserConfiguration;
+import com.microsoft.recognizers.text.datetime.english.parsers.EnglishDateTimeAltParserConfiguration;
+import com.microsoft.recognizers.text.datetime.english.parsers.EnglishDateTimeParserConfiguration;
+import com.microsoft.recognizers.text.datetime.english.parsers.EnglishDateTimePeriodParserConfiguration;
+import com.microsoft.recognizers.text.datetime.english.parsers.EnglishDurationParserConfiguration;
 import com.microsoft.recognizers.text.datetime.english.parsers.EnglishHolidayParserConfiguration;
+import com.microsoft.recognizers.text.datetime.english.parsers.EnglishMergedParserConfiguration;
+import com.microsoft.recognizers.text.datetime.english.parsers.EnglishSetParserConfiguration;
+import com.microsoft.recognizers.text.datetime.english.parsers.EnglishTimeParserConfiguration;
+import com.microsoft.recognizers.text.datetime.english.parsers.EnglishTimePeriodParserConfiguration;
+import com.microsoft.recognizers.text.datetime.english.parsers.TimeParser;
 import com.microsoft.recognizers.text.datetime.extractors.IDateTimeExtractor;
-import com.microsoft.recognizers.text.datetime.parsers.*;
+import com.microsoft.recognizers.text.datetime.parsers.BaseDateParser;
+import com.microsoft.recognizers.text.datetime.parsers.BaseDatePeriodParser;
+import com.microsoft.recognizers.text.datetime.parsers.BaseDateTimeAltParser;
+import com.microsoft.recognizers.text.datetime.parsers.BaseDateTimeParser;
+import com.microsoft.recognizers.text.datetime.parsers.BaseDateTimePeriodParser;
+import com.microsoft.recognizers.text.datetime.parsers.BaseDurationParser;
+import com.microsoft.recognizers.text.datetime.parsers.BaseHolidayParser;
+import com.microsoft.recognizers.text.datetime.parsers.BaseMergedDateTimeParser;
+import com.microsoft.recognizers.text.datetime.parsers.BaseSetParser;
+import com.microsoft.recognizers.text.datetime.parsers.BaseTimePeriodParser;
+import com.microsoft.recognizers.text.datetime.parsers.BaseTimeZoneParser;
+import com.microsoft.recognizers.text.datetime.parsers.DateTimeParseResult;
+import com.microsoft.recognizers.text.datetime.parsers.IDateTimeParser;
 import com.microsoft.recognizers.text.datetime.utilities.DateTimeResolutionResult;
 import com.microsoft.recognizers.text.datetime.utilities.TimeZoneResolutionResult;
 import com.microsoft.recognizers.text.tests.AbstractTest;
 import com.microsoft.recognizers.text.tests.TestCase;
 import com.microsoft.recognizers.text.tests.helpers.DateTimeResolutionResultMixIn;
 import com.microsoft.recognizers.text.tests.helpers.TimeZoneResolutionResultMixIn;
-import org.javatuples.Pair;
-import org.junit.Assert;
-import org.junit.AssumptionViolatedException;
-import org.junit.runners.Parameterized;
 
 import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+
+import org.javatuples.Pair;
+import org.junit.Assert;
+import org.junit.AssumptionViolatedException;
+import org.junit.runners.Parameterized;
 
 public class DateTimeParserTest extends AbstractTest {
 
@@ -55,7 +80,7 @@ public class DateTimeParserTest extends AbstractTest {
         IDateTimeExtractor extractor = getExtractor(currentCase);
         IDateTimeParser parser = getParser(currentCase);
         LocalDateTime referenceDateTime = currentCase.getReferenceDateTime();
-        List<ExtractResult> extractResult = extractor.extract(currentCase.input, referenceDateTime);
+        List<ExtractResult> extractResult = extractor.extract(currentCase.input.toLowerCase(Locale.ROOT), referenceDateTime);
         return extractResult.stream().map(er -> parser.parse(er, referenceDateTime)).collect(Collectors.toList());
     }
 
@@ -77,10 +102,10 @@ public class DateTimeParserTest extends AbstractTest {
                     DateTimeParseResult expected = t.getValue0();
                     DateTimeParseResult actual = t.getValue1();
 
-                    Assert.assertEquals(getMessage(currentCase, "type"), expected.type, actual.type);
-                    Assert.assertEquals(getMessage(currentCase, "text"), expected.text, actual.text);
-                    Assert.assertEquals(getMessage(currentCase, "start"), expected.start, actual.start);
-                    Assert.assertEquals(getMessage(currentCase, "length"), expected.length, actual.length);
+                    Assert.assertEquals(getMessage(currentCase, "type"), expected.getType(), actual.getType());
+                    Assert.assertTrue(getMessage(currentCase, "text"), expected.getText().equalsIgnoreCase(actual.getText()));
+                    Assert.assertEquals(getMessage(currentCase, "start"), expected.getStart(), actual.getStart());
+                    Assert.assertEquals(getMessage(currentCase, "length"), expected.getLength(), actual.getLength());
 
                     if (currentCase.modelName.equals("MergedParser")) {
                         assertMergedParserResults(currentCase, expected, actual);
@@ -92,9 +117,9 @@ public class DateTimeParserTest extends AbstractTest {
 
     private static void assertParserResults(TestCase currentCase, DateTimeParseResult expected, DateTimeParseResult actual) {
 
-        if (expected.value != null) {
-            DateTimeResolutionResult expectedValue = parseDateTimeResolutionResult(DateTimeResolutionResult.class, expected.value);
-            DateTimeResolutionResult actualValue = (DateTimeResolutionResult) actual.value;
+        if (expected.getValue() != null) {
+            DateTimeResolutionResult expectedValue = parseDateTimeResolutionResult(DateTimeResolutionResult.class, expected.getValue());
+            DateTimeResolutionResult actualValue = (DateTimeResolutionResult)actual.getValue();
 
             Assert.assertEquals(getMessage(currentCase, "timex"), expectedValue.getTimex(), actualValue.getTimex());
             Assert.assertEquals(getMessage(currentCase, "futureResolution"), expectedValue.getFutureResolution(), actualValue.getFutureResolution());
@@ -104,9 +129,9 @@ public class DateTimeParserTest extends AbstractTest {
 
     private static void assertMergedParserResults(TestCase currentCase, DateTimeParseResult expected, DateTimeParseResult actual) {
 
-        if (expected.value != null) {
-            Map<String, List<Map<String, Object>>> expectedValue = parseDateTimeResolutionResult(expected.value);
-            Map<String, List<Map<String, Object>>> actualValue = (Map<String, List<Map<String, Object>>>) actual.value;
+        if (expected.getValue() != null) {
+            Map<String, List<Map<String, Object>>> expectedValue = parseDateTimeResolutionResult(expected.getValue());
+            Map<String, List<Map<String, Object>>> actualValue = (Map<String, List<Map<String, Object>>>)actual.getValue();
 
             List<Map<String, Object>> expectedResults = expectedValue.get("values");
             List<Map<String, Object>> actualResults = actualValue.get("values");
@@ -119,7 +144,8 @@ public class DateTimeParserTest extends AbstractTest {
             IntStream.range(0, expectedResults.size()).mapToObj(i -> new Pair<>(expectedResults.get(i), actualResults.get(i))).forEach(o -> {
                 Map<String, Object> expectedItem = o.getValue0();
                 Map<String, Object> actualItem = o.getValue1();
-                Assert.assertTrue(String.format("Keys error \n\tExpected:\t%s\n\tActual:\t%s", String.join(",", expectedItem.keySet()), String.join(",", actualItem.keySet())), actualItem.keySet().containsAll(expectedItem.keySet()));
+                Assert.assertTrue(String.format("Keys error \n\tExpected:\t%s\n\tActual:\t%s",
+                    String.join(",", expectedItem.keySet()), String.join(",", actualItem.keySet())), actualItem.keySet().containsAll(expectedItem.keySet()));
                 for (String key : expectedItem.keySet()) {
                     if (actualItem.containsKey(key)) {
                         Assert.assertEquals(getMessage(currentCase, "values." + key), expectedItem.get(key), actualItem.get(key));

--- a/Java/tests/src/test/java/com/microsoft/recognizers/text/tests/number/DecimalAndThousandsSeparatorsTest.java
+++ b/Java/tests/src/test/java/com/microsoft/recognizers/text/tests/number/DecimalAndThousandsSeparatorsTest.java
@@ -18,7 +18,7 @@ public class DecimalAndThousandsSeparatorsTest {
                 AgnosticNumberParserType.Double,
                 new LongFormTestConfiguration(decimalSep, nonDecimalSep));
         ParseResult resultJson = parser.parse(new ExtractResult(0, query.length(), query, "builtin.num.double", "Num"));
-        Assert.assertEquals(value, resultJson.resolutionStr);
+        Assert.assertEquals(value, resultJson.getResolutionStr());
     }
 
     @Test


### PR DESCRIPTION
**NOTE**: This PR is based both on PRs #1077 and #1119 . We'll rebase when the respective branches are merged.

---
- Enable `TimeExtractor` tests
- Port `SpanishTimeExtractorConfiguration` from C# to Java
- port `SpanishTimeZoneExtractorConfiguration` from C# to Java

![image](https://user-images.githubusercontent.com/39467613/50660836-ef34f800-0f7f-11e9-9ebe-9c0a0305be85.png)
