### PR TITLE
[Java][Datetime] Port SpanishDateExtractorConfiguration from C# to Java

### DIFF
--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/extractors/SpanishDateExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/extractors/SpanishDateExtractorConfiguration.java
@@ -1,0 +1,224 @@
+package com.microsoft.recognizers.text.datetime.spanish.extractors;
+
+import com.google.common.collect.ImmutableMap;
+import com.microsoft.recognizers.text.IExtractor;
+import com.microsoft.recognizers.text.IParser;
+import com.microsoft.recognizers.text.datetime.config.BaseOptionsConfiguration;
+import com.microsoft.recognizers.text.datetime.config.IOptionsConfiguration;
+import com.microsoft.recognizers.text.datetime.extractors.BaseDurationExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.IDateTimeExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.config.IDateExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.resources.BaseDateTime;
+import com.microsoft.recognizers.text.datetime.resources.SpanishDateTime;
+import com.microsoft.recognizers.text.datetime.spanish.utilities.SpanishDatetimeUtilityConfiguration;
+import com.microsoft.recognizers.text.datetime.utilities.IDateTimeUtilityConfiguration;
+import com.microsoft.recognizers.text.number.parsers.BaseNumberParser;
+import com.microsoft.recognizers.text.number.spanish.extractors.IntegerExtractor;
+import com.microsoft.recognizers.text.number.spanish.extractors.OrdinalExtractor;
+import com.microsoft.recognizers.text.number.spanish.parsers.SpanishNumberParserConfiguration;
+import com.microsoft.recognizers.text.utilities.RegExpUtility;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+
+public class SpanishDateExtractorConfiguration extends BaseOptionsConfiguration implements IDateExtractorConfiguration {
+
+    public static final Pattern MonthRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.MonthRegex);
+    public static final Pattern DayRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.DayRegex);
+    public static final Pattern MonthNumRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.MonthNumRegex);
+    public static final Pattern YearRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.YearRegex);
+    public static final Pattern WeekDayRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.WeekDayRegex);
+    public static final Pattern OnRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.OnRegex);
+    public static final Pattern RelaxedOnRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.RelaxedOnRegex);
+    public static final Pattern ThisRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.ThisRegex);
+    public static final Pattern LastDateRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.LastDateRegex);
+    public static final Pattern NextDateRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.NextDateRegex);
+    public static final Pattern SpecialDayRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.SpecialDayRegex);
+    public static final Pattern SpecialDayWithNumRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.SpecialDayWithNumRegex);
+    public static final Pattern DateUnitRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.DateUnitRegex);
+    public static final Pattern WeekDayOfMonthRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.WeekDayOfMonthRegex);
+    public static final Pattern SpecialDateRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.SpecialDateRegex);
+    public static final Pattern RelativeWeekDayRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.RelativeWeekDayRegex);
+    public static final Pattern ForTheRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.ForTheRegex);
+    public static final Pattern WeekDayAndDayOfMonthRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.WeekDayAndDayOfMonthRegex);
+    public static final Pattern RelativeMonthRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.RelativeMonthRegex);
+    public static final Pattern PrefixArticleRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.PrefixArticleRegex);
+    public static final Pattern RangeConnectorSymbolRegex = RegExpUtility.getSafeRegExp(BaseDateTime.RangeConnectorSymbolRegex);
+    public static final List<Pattern> ImplicitDateList = new ArrayList<Pattern>() {
+        {
+            add(OnRegex);
+            add(RelaxedOnRegex);
+            add(SpecialDayRegex);
+            add(ThisRegex);
+            add(LastDateRegex);
+            add(NextDateRegex);
+            add(WeekDayRegex);
+            add(WeekDayOfMonthRegex);
+            add(SpecialDateRegex);
+        }
+    };
+
+    public static final Pattern OfMonth = RegExpUtility.getSafeRegExp(SpanishDateTime.OfMonthRegex);
+    public static final Pattern MonthEnd = RegExpUtility.getSafeRegExp(SpanishDateTime.MonthEndRegex);
+    public static final Pattern WeekDayEnd = RegExpUtility.getSafeRegExp(SpanishDateTime.WeekDayEnd);
+    public static final Pattern YearSuffix = RegExpUtility.getSafeRegExp(SpanishDateTime.YearSuffix);
+    public static final Pattern LessThanRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.LessThanRegex);
+    public static final Pattern MoreThanRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.MoreThanRegex);
+    public static final Pattern InConnectorRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.InConnectorRegex);
+    public static final Pattern RangeUnitRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.RangeUnitRegex);
+    public static final ImmutableMap<String, Integer> DayOfWeek = SpanishDateTime.DayOfWeek;
+    public static final ImmutableMap<String, Integer> MonthOfYear = SpanishDateTime.MonthOfYear;
+
+    public SpanishDateExtractorConfiguration(IOptionsConfiguration config) {
+        super(config.getOptions());
+        integerExtractor = new IntegerExtractor(); // in other languages (english) has a method named get instance
+        ordinalExtractor = new OrdinalExtractor(); // in other languages (english) has a method named get instance
+        numberParser = new BaseNumberParser(new SpanishNumberParserConfiguration());
+        durationExtractor = new BaseDurationExtractor(new SpanishDurationExtractorConfiguration());
+        utilityConfiguration = new SpanishDatetimeUtilityConfiguration();
+
+    }
+
+    public static final List<Pattern> DateRegexList = new ArrayList<Pattern>() {
+        {
+            add(RegExpUtility.getSafeRegExp(SpanishDateTime.DateExtractor1));
+            add(RegExpUtility.getSafeRegExp(SpanishDateTime.DateExtractor2));
+            add(RegExpUtility.getSafeRegExp(SpanishDateTime.DateExtractor3));
+            add(RegExpUtility.getSafeRegExp(SpanishDateTime.DateExtractor4));
+            add(RegExpUtility.getSafeRegExp(SpanishDateTime.DateExtractor5));
+            add(RegExpUtility.getSafeRegExp(SpanishDateTime.DateExtractor6));
+            add(RegExpUtility.getSafeRegExp(SpanishDateTime.DateExtractor7));
+            add(RegExpUtility.getSafeRegExp(SpanishDateTime.DateExtractor8));
+            add(RegExpUtility.getSafeRegExp(SpanishDateTime.DateExtractor9));
+            add(RegExpUtility.getSafeRegExp(SpanishDateTime.DateExtractor10));
+        }
+    };
+
+    private final IExtractor integerExtractor;
+    private final IExtractor ordinalExtractor;
+    private final IParser numberParser;
+    private final IDateTimeExtractor durationExtractor;
+    private final IDateTimeUtilityConfiguration utilityConfiguration;
+
+    @Override
+    public Pattern getOfMonth() {
+        return OfMonth;
+    }
+
+    @Override
+    public Pattern getMonthEnd() {
+        return MonthEnd;
+    }
+
+    @Override
+    public Pattern getWeekDayEnd() {
+        return WeekDayEnd;
+    }
+
+    @Override
+    public Pattern getDateUnitRegex() {
+        return DateUnitRegex;
+    }
+
+    @Override
+    public Pattern getForTheRegex() {
+        return ForTheRegex;
+    }
+
+    @Override
+    public Pattern getWeekDayAndDayOfMonthRegex() {
+        return WeekDayAndDayOfMonthRegex;
+    }
+
+    @Override
+    public Pattern getRelativeMonthRegex() {
+        return RelativeMonthRegex;
+    }
+
+    @Override
+    public Pattern getWeekDayRegex() {
+        return WeekDayRegex;
+    }
+
+    @Override
+    public Pattern getPrefixArticleRegex() {
+        return PrefixArticleRegex;
+    }
+
+    @Override
+    public Pattern getYearSuffix() {
+        return YearSuffix;
+    }
+
+    @Override
+    public Pattern getLessThanRegex() {
+        return LessThanRegex;
+    }
+
+    @Override
+    public Pattern getMoreThanRegex() {
+        return MoreThanRegex;
+    }
+
+    @Override
+    public Pattern getInConnectorRegex() {
+        return InConnectorRegex;
+    }
+
+    @Override
+    public Pattern getRangeUnitRegex() {
+        return RangeUnitRegex;
+    }
+
+    @Override
+    public Pattern getRangeConnectorSymbolRegex() {
+        return RangeConnectorSymbolRegex;
+    }
+
+    @Override
+    public Iterable<Pattern> getDateRegexList() {
+        return DateRegexList;
+    }
+
+    @Override
+    public Iterable<Pattern> getImplicitDateList() {
+        return ImplicitDateList;
+    }
+
+    @Override
+    public IExtractor getIntegerExtractor() {
+        return integerExtractor;
+    }
+
+    @Override
+    public IExtractor getOrdinalExtractor() {
+        return ordinalExtractor;
+    }
+
+    @Override
+    public IParser getNumberParser() {
+        return numberParser;
+    }
+
+    @Override
+    public IDateTimeExtractor getDurationExtractor() {
+        return durationExtractor;
+    }
+
+    @Override
+    public IDateTimeUtilityConfiguration getUtilityConfiguration() {
+        return utilityConfiguration;
+    }
+
+    @Override
+    public ImmutableMap<String, Integer> getDayOfWeek() {
+        return DayOfWeek;
+    }
+
+    @Override
+    public ImmutableMap<String, Integer> getMonthOfYear() {
+        return MonthOfYear;
+    }
+}

--- a/Java/tests/src/test/java/com/microsoft/recognizers/text/tests/datetime/DateTimeExtractorTest.java
+++ b/Java/tests/src/test/java/com/microsoft/recognizers/text/tests/datetime/DateTimeExtractorTest.java
@@ -9,6 +9,7 @@ import com.microsoft.recognizers.text.datetime.config.IOptionsConfiguration;
 import com.microsoft.recognizers.text.datetime.english.extractors.EnglishDateExtractorConfiguration;
 import com.microsoft.recognizers.text.datetime.english.extractors.EnglishDatePeriodExtractorConfiguration;
 import com.microsoft.recognizers.text.datetime.english.extractors.EnglishDateTimeExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.spanish.extractors.SpanishDateExtractorConfiguration;
 import com.microsoft.recognizers.text.datetime.english.extractors.EnglishDateTimePeriodExtractorConfiguration;
 import com.microsoft.recognizers.text.datetime.english.extractors.EnglishDurationExtractorConfiguration;
 import com.microsoft.recognizers.text.datetime.english.extractors.EnglishHolidayExtractorConfiguration;
@@ -152,8 +153,8 @@ public class DateTimeExtractorTest extends AbstractTest {
 
         IOptionsConfiguration config = new BaseOptionsConfiguration();
         switch (name) {
-            //case "DateExtractor":
-            //    return new BaseDateExtractor(new SpanishDateExtractorConfiguration(config));
+            case "DateExtractor":
+                return new BaseDateExtractor(new SpanishDateExtractorConfiguration(config));
             //case "DatePeriodExtractor":
             //    return new BaseDatePeriodExtractor(new SpanishDatePeriodExtractorConfiguration());
             //case "DateTimeAltExtractor":


### PR DESCRIPTION
## Description
* Enable SpanishDateExtractor's tests
* Port SpanishDateExtractorConfiguration from [C#](https://github.com/Microsoft/Recognizers-Text/blob/master/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishDateExtractorConfiguration.cs) to Java


## Evidence
![image](https://user-images.githubusercontent.com/42191764/50694302-4a1a2e00-1018-11e9-918a-2a4bb3cec6ea.png)
