### PR TITLE
[Java][Datetime] Port SpanishTimePeriodExtractorConfiguration from C# to Java

### DIFF
--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/extractors/SpanishTimePeriodExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/extractors/SpanishTimePeriodExtractorConfiguration.java
@@ -1,0 +1,154 @@
+package com.microsoft.recognizers.text.datetime.spanish.extractors;
+
+import com.microsoft.recognizers.text.IExtractor;
+import com.microsoft.recognizers.text.datetime.DateTimeOptions;
+import com.microsoft.recognizers.text.datetime.config.BaseOptionsConfiguration;
+import com.microsoft.recognizers.text.datetime.extractors.BaseTimeExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.BaseTimeZoneExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.IDateTimeExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.config.ITimePeriodExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.extractors.config.ResultIndex;
+import com.microsoft.recognizers.text.datetime.resources.SpanishDateTime;
+import com.microsoft.recognizers.text.datetime.spanish.utilities.SpanishDatetimeUtilityConfiguration;
+import com.microsoft.recognizers.text.datetime.utilities.IDateTimeUtilityConfiguration;
+import com.microsoft.recognizers.text.number.spanish.extractors.IntegerExtractor;
+import com.microsoft.recognizers.text.utilities.Match;
+import com.microsoft.recognizers.text.utilities.RegExpUtility;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class SpanishTimePeriodExtractorConfiguration extends BaseOptionsConfiguration implements ITimePeriodExtractorConfiguration {
+
+    private String tokenBeforeDate;
+
+    public final String getTokenBeforeDate() {
+        return tokenBeforeDate;
+    }
+
+    public static final Pattern HourNumRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.HourNumRegex);
+    public static final Pattern PureNumFromTo = RegExpUtility.getSafeRegExp(SpanishDateTime.PureNumFromTo);
+    public static final Pattern PureNumBetweenAnd = RegExpUtility.getSafeRegExp(SpanishDateTime.PureNumBetweenAnd);
+    public static final Pattern SpecificTimeFromTo = RegExpUtility.getSafeRegExp(SpanishDateTime.SpecificTimeFromTo);
+    public static final Pattern SpecificTimeBetweenAnd = RegExpUtility.getSafeRegExp(SpanishDateTime.SpecificTimeBetweenAnd);
+    public static final Pattern UnitRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.UnitRegex);
+    public static final Pattern FollowedUnit = RegExpUtility.getSafeRegExp(SpanishDateTime.FollowedUnit);
+    public static final Pattern NumberCombinedWithUnit = RegExpUtility.getSafeRegExp(SpanishDateTime.TimeNumberCombinedWithUnit);
+
+    private static final Pattern FromRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.FromRegex);
+    private static final Pattern ConnectorAndRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.ConnectorAndRegex);
+    private static final Pattern BetweenRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.BetweenRegex);
+
+    public static final Pattern TimeOfDayRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.TimeOfDayRegex);
+    public static final Pattern GeneralEndingRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.GeneralEndingRegex);
+    public static final Pattern TillRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.TillRegex);
+
+    public SpanishTimePeriodExtractorConfiguration() {
+        this(DateTimeOptions.None);
+    }
+
+    public SpanishTimePeriodExtractorConfiguration(DateTimeOptions options) {
+
+        super(options);
+
+        tokenBeforeDate = SpanishDateTime.TokenBeforeDate;
+        singleTimeExtractor = new BaseTimeExtractor(new SpanishTimeExtractorConfiguration(options));
+        utilityConfiguration = new SpanishDatetimeUtilityConfiguration();
+        integerExtractor = IntegerExtractor.getInstance();
+        timeZoneExtractor = new BaseTimeZoneExtractor(new SpanishTimeZoneExtractorConfiguration(options));
+    }
+
+    private IDateTimeUtilityConfiguration utilityConfiguration;
+
+    public final IDateTimeUtilityConfiguration getUtilityConfiguration() {
+        return utilityConfiguration;
+    }
+
+    private IDateTimeExtractor singleTimeExtractor;
+
+    public final IDateTimeExtractor getSingleTimeExtractor() {
+        return singleTimeExtractor;
+    }
+
+    private IExtractor integerExtractor;
+
+    public final IExtractor getIntegerExtractor() {
+        return integerExtractor;
+    }
+
+    public final IDateTimeExtractor timeZoneExtractor;
+
+    public IDateTimeExtractor getTimeZoneExtractor() {
+        return timeZoneExtractor;
+    }
+
+
+    public Iterable<Pattern> getSimpleCasesRegex() {
+        return getSimpleCasesRegex;
+    }
+
+    public final Iterable<Pattern> getSimpleCasesRegex = new ArrayList<Pattern>() {
+        {
+            add(PureNumFromTo);
+            add(PureNumBetweenAnd);
+        }
+    };
+
+    public Iterable<Pattern> getPureNumberRegex() {
+        return getPureNumberRegex;
+    }
+
+    public final Iterable<Pattern> getPureNumberRegex = new ArrayList<Pattern>() {
+        {
+            add(PureNumFromTo);
+            add(PureNumBetweenAnd);
+        }
+    };
+
+    public final Pattern getTillRegex() {
+        return TillRegex;
+    }
+
+    public final Pattern getTimeOfDayRegex() {
+        return TimeOfDayRegex;
+    }
+
+    public final Pattern getGeneralEndingRegex() {
+        return GeneralEndingRegex;
+    }
+
+    @Override
+    public ResultIndex getFromTokenIndex(String text) {
+        int index = -1;
+        boolean result = false;
+        Matcher matcher = FromRegex.matcher(text);
+        if (matcher.find()) {
+            result = true;
+            index = matcher.start();
+        }
+
+        return new ResultIndex(result, index);
+    }
+
+    @Override
+    public ResultIndex getBetweenTokenIndex(String text) {
+        int index = -1;
+        boolean result = false;
+        Matcher matcher = BetweenRegex.matcher(text);
+        if (matcher.find()) {
+            result = true;
+            index = matcher.start();
+        }
+
+        return new ResultIndex(result, index);
+    }
+
+    @Override
+    public boolean hasConnectorToken(String text) {
+        Optional<Match> match = Arrays.stream(RegExpUtility.getMatches(ConnectorAndRegex, text)).findFirst();
+        return match.isPresent() && match.get().length == text.trim().length();
+    }
+}

--- a/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/spanish/extractors/IntegerExtractor.java
+++ b/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/spanish/extractors/IntegerExtractor.java
@@ -9,6 +9,7 @@ import com.microsoft.recognizers.text.utilities.RegExpUtility;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
 
 public class IntegerExtractor extends BaseNumberExtractor {
@@ -23,6 +24,21 @@ public class IntegerExtractor extends BaseNumberExtractor {
     @Override
     protected String getExtractType() {
         return Constants.SYS_NUM_INTEGER;
+    }
+
+    private static final ConcurrentHashMap<String, IntegerExtractor> instances = new ConcurrentHashMap<>();
+
+    public static IntegerExtractor getInstance() {
+        return getInstance(SpanishNumeric.PlaceHolderDefault);
+    }
+
+    public static IntegerExtractor getInstance(String placeholder) {
+        if (!instances.containsKey(placeholder)) {
+            IntegerExtractor instance = new IntegerExtractor(placeholder);
+            instances.put(placeholder, instance);
+        }
+
+        return instances.get(placeholder);
     }
 
     public IntegerExtractor() {

--- a/Java/tests/src/test/java/com/microsoft/recognizers/text/tests/datetime/DateTimeExtractorTest.java
+++ b/Java/tests/src/test/java/com/microsoft/recognizers/text/tests/datetime/DateTimeExtractorTest.java
@@ -35,6 +35,7 @@ import com.microsoft.recognizers.text.datetime.spanish.extractors.SpanishDatePer
 import com.microsoft.recognizers.text.datetime.spanish.extractors.SpanishDurationExtractorConfiguration;
 import com.microsoft.recognizers.text.datetime.spanish.extractors.SpanishHolidayExtractorConfiguration;
 import com.microsoft.recognizers.text.datetime.spanish.extractors.SpanishTimeExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.spanish.extractors.SpanishTimePeriodExtractorConfiguration;
 import com.microsoft.recognizers.text.tests.AbstractTest;
 import com.microsoft.recognizers.text.tests.TestCase;
 
@@ -178,8 +179,8 @@ public class DateTimeExtractorTest extends AbstractTest {
             //    return new BaseSetExtractor(new SpanishSetExtractorConfiguration());
             case "TimeExtractor":
                 return new BaseTimeExtractor(new SpanishTimeExtractorConfiguration());
-            //case "TimePeriodExtractor":
-            //    return new BaseTimePeriodExtractor(new SpanishTimePeriodExtractorConfiguration());
+            case "TimePeriodExtractor":
+                return new BaseTimePeriodExtractor(new SpanishTimePeriodExtractorConfiguration());
             //case "TimeZoneExtractor":
             //    return new BaseTimeZoneExtractor(new SpanishTimeZoneExtractorConfiguration(DateTimeOptions.EnablePreview));
 


### PR DESCRIPTION
## Description
* Enable SpanishTimePeriodExtractor's tests
* Port spanish IntegerExtractor's getInstance method from [C#](https://github.com/Microsoft/Recognizers-Text/blob/master/.NET/Microsoft.Recognizers.Text.Number/Spanish/Extractors/IntegerExtractor.cs) to Java
* Port SpanishTimePeriodExtractorConfiguration from [C#](https://github.com/Microsoft/Recognizers-Text/blob/master/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishTimePeriodExtractorConfiguration.cs) to Java

## Evidence

![image](https://user-images.githubusercontent.com/42191764/50847407-4526e880-1350-11e9-88fc-b555829f0bf2.png)
