### PR TITLE
[Java][Datetime] Fix field name and type in SpanishHolidayExtractorConfiguration

### DIFF
--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/extractors/SpanishHolidayExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/extractors/SpanishHolidayExtractorConfiguration.java
@@ -1,22 +1,36 @@
 package com.microsoft.recognizers.text.datetime.spanish.extractors;
 
+import com.microsoft.recognizers.text.datetime.DateTimeOptions;
 import com.microsoft.recognizers.text.datetime.config.BaseOptionsConfiguration;
 import com.microsoft.recognizers.text.datetime.extractors.config.IHolidayExtractorConfiguration;
 import com.microsoft.recognizers.text.datetime.resources.SpanishDateTime;
 import com.microsoft.recognizers.text.utilities.RegExpUtility;
 
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.regex.Pattern;
 
 public class SpanishHolidayExtractorConfiguration extends BaseOptionsConfiguration implements IHolidayExtractorConfiguration {
 
-    public static Pattern[] HolidayRegexes = {
-    RegExpUtility.getSafeRegExp(SpanishDateTime.HolidayRegex1),
-    RegExpUtility.getSafeRegExp(SpanishDateTime.HolidayRegex2),
-    RegExpUtility.getSafeRegExp(SpanishDateTime.HolidayRegex3)};
+    public static final Pattern H1 = RegExpUtility.getSafeRegExp(SpanishDateTime.HolidayRegex1);
+
+    public static final Pattern H2 = RegExpUtility.getSafeRegExp(SpanishDateTime.HolidayRegex2);
+
+    public static final Pattern H3 = RegExpUtility.getSafeRegExp(SpanishDateTime.HolidayRegex3);
+
+    public static final Iterable<Pattern> HolidayRegexList = new ArrayList<Pattern>() {
+        {
+            add(H1);
+            add(H2);
+            add(H3);
+        }
+    };
+
+    public SpanishHolidayExtractorConfiguration() {
+        super(DateTimeOptions.None);
+    }
 
     @Override
     public Iterable<Pattern> getHolidayRegexes() {
-        return Arrays.asList(HolidayRegexes);
+        return HolidayRegexList;
     }
 }


### PR DESCRIPTION
## Description
* Change HolidayRegexes type from Array to ArrayList to match Java base implementation([BaseHolidayParserConfiguration](https://github.com/Microsoft/Recognizers-Text/blob/master/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/parsers/BaseHolidayParserConfiguration.java))
* Renamed HolidayRegexes to HolidayRegexList to match [C#](https://github.com/Microsoft/Recognizers-Text/blob/master/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishHolidayExtractorConfiguration.cs) implementation