### PR TITLE
[Java][Datetime] Port SpanishSetExtractorConfiguration from C# to Java

### DIFF
--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/extractors/BaseSetExtractor.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/extractors/BaseSetExtractor.java
@@ -99,8 +99,8 @@ public class BaseSetExtractor implements IDateTimeExtractor {
             String afterStr = text.substring(er.getStart() + er.getLength());
             if (StringUtility.isNullOrEmpty(afterStr) && this.config.getBeforeEachDayRegex() != null) {
                 String beforeStr = text.substring(0, er.getStart());
-                Pattern eachPrefixRegex = this.config.getEachPrefixRegex();
-                Optional<Match> match = Arrays.stream(RegExpUtility.getMatches(eachPrefixRegex, beforeStr)).findFirst();
+                Pattern beforeEachDayRegex = this.config.getBeforeEachDayRegex();
+                Optional<Match> match = Arrays.stream(RegExpUtility.getMatches(beforeEachDayRegex, beforeStr)).findFirst();
                 if (match.isPresent()) {
                     ret.add(new Token(match.get().index, er.getStart() + er.getLength()));
                 }

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/extractors/SpanishDateTimePeriodExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/extractors/SpanishDateTimePeriodExtractorConfiguration.java
@@ -1,0 +1,275 @@
+package com.microsoft.recognizers.text.datetime.spanish.extractors;
+
+import com.microsoft.recognizers.text.IExtractor;
+import com.microsoft.recognizers.text.datetime.DateTimeOptions;
+import com.microsoft.recognizers.text.datetime.config.BaseOptionsConfiguration;
+import com.microsoft.recognizers.text.datetime.extractors.BaseDateExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.BaseDateTimeExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.BaseDurationExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.BaseTimeExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.BaseTimePeriodExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.IDateTimeExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.config.IDateTimePeriodExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.extractors.config.ResultIndex;
+import com.microsoft.recognizers.text.datetime.resources.SpanishDateTime;
+import com.microsoft.recognizers.text.number.spanish.extractors.CardinalExtractor;
+import com.microsoft.recognizers.text.utilities.Match;
+import com.microsoft.recognizers.text.utilities.RegExpUtility;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class SpanishDateTimePeriodExtractorConfiguration extends BaseOptionsConfiguration
+    implements IDateTimePeriodExtractorConfiguration {
+
+    public static final Pattern weekDayRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.WeekDayRegex);
+    public static final Pattern TimeNumberCombinedWithUnit = RegExpUtility.getSafeRegExp(SpanishDateTime.TimeNumberCombinedWithUnit);
+    public static final Pattern RestOfDateTimeRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.RestOfDateTimeRegex);
+    public static final Pattern PeriodTimeOfDayWithDateRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.PeriodTimeOfDayWithDateRegex);
+    public static final Pattern RelativeTimeUnitRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.RelativeTimeUnitRegex);
+    public static final Pattern GeneralEndingRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.GeneralEndingRegex);
+    public static final Pattern MiddlePauseRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.MiddlePauseRegex);
+    public static final Pattern AmDescRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.AmDescRegex);
+    public static final Pattern PmDescRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.PmDescRegex);
+    public static final Pattern WithinNextPrefixRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.WithinNextPrefixRegex);
+    public static final Pattern DateUnitRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.DateUnitRegex);
+    public static final Pattern PrefixDayRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.PrefixDayRegex);
+    public static final Pattern SuffixRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.SuffixRegex);
+    public static final Pattern BeforeRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.BeforeRegex);
+    public static final Pattern AfterRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.AfterRegex);
+    public static final Pattern FromRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.FromRegex);
+    public static final Pattern ConnectorAndRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.ConnectorAndRegex);
+    public static final Pattern BetweenRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.BetweenRegex);
+    public static final Pattern TimeOfDayRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.TimeOfDayRegex);
+    public static final Pattern TimeUnitRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.TimeUnitRegex);
+    public static final Pattern TimeFollowedUnit = RegExpUtility.getSafeRegExp(SpanishDateTime.TimeFollowedUnit);
+
+    private final String tokenBeforeDate;
+
+    private final IExtractor cardinalExtractor;
+    private final IDateTimeExtractor singleDateExtractor;
+    private final IDateTimeExtractor singleTimeExtractor;
+    private final IDateTimeExtractor singleDateTimeExtractor;
+    private final IDateTimeExtractor durationExtractor;
+    private final IDateTimeExtractor timePeriodExtractor;
+
+    public static final Iterable<Pattern> SimpleCases = new ArrayList<Pattern>() {
+        {
+            add(SpanishTimePeriodExtractorConfiguration.PureNumFromTo);
+            add(SpanishTimePeriodExtractorConfiguration.PureNumBetweenAnd);
+        }
+    };
+
+    public SpanishDateTimePeriodExtractorConfiguration() {
+        this(DateTimeOptions.None);
+    }
+
+    public SpanishDateTimePeriodExtractorConfiguration(DateTimeOptions options) {
+
+        super(options);
+        tokenBeforeDate = SpanishDateTime.TokenBeforeDate;
+
+        cardinalExtractor = CardinalExtractor.getInstance();
+
+        singleDateExtractor = new BaseDateExtractor(new SpanishDateExtractorConfiguration(this));
+        singleTimeExtractor = new BaseTimeExtractor(new SpanishTimeExtractorConfiguration(options));
+        singleDateTimeExtractor = new BaseDateTimeExtractor(new SpanishDateTimeExtractorConfiguration(options));
+        durationExtractor = new BaseDurationExtractor(new SpanishDurationExtractorConfiguration(options));
+        timePeriodExtractor = new BaseTimePeriodExtractor(new SpanishTimePeriodExtractorConfiguration(options));
+    }
+
+    @Override
+    public String getTokenBeforeDate() {
+        return tokenBeforeDate;
+    }
+
+    @Override
+    public IExtractor getCardinalExtractor() {
+        return cardinalExtractor;
+    }
+
+    @Override
+    public IDateTimeExtractor getSingleDateExtractor() {
+        return singleDateExtractor;
+    }
+
+    @Override
+    public IDateTimeExtractor getSingleTimeExtractor() {
+        return singleTimeExtractor;
+    }
+
+    @Override
+    public IDateTimeExtractor getSingleDateTimeExtractor() {
+        return singleDateTimeExtractor;
+    }
+
+    @Override
+    public IDateTimeExtractor getDurationExtractor() {
+        return durationExtractor;
+    }
+
+    @Override
+    public IDateTimeExtractor getTimePeriodExtractor() {
+        return timePeriodExtractor;
+    }
+
+    @Override
+    public Iterable<Pattern> getSimpleCasesRegex() {
+        return SimpleCases;
+    }
+
+    @Override
+    public Pattern getPrepositionRegex() {
+        return SpanishDateTimeExtractorConfiguration.PrepositionRegex;
+    }
+
+    @Override
+    public Pattern getTillRegex() {
+        return SpanishTimePeriodExtractorConfiguration.TillRegex;
+    }
+
+    @Override
+    public Pattern getTimeOfDayRegex() {
+        return SpanishDateTimeExtractorConfiguration.TimeOfDayRegex;
+    }
+
+    @Override
+    public Pattern getFollowedUnit() {
+        return TimeFollowedUnit;
+    }
+
+    @Override
+    public Pattern getTimeUnitRegex() {
+        return TimeUnitRegex;
+    }
+
+    @Override
+    public Pattern getPastPrefixRegex() {
+        return SpanishDatePeriodExtractorConfiguration.PastRegex;
+    }
+
+    @Override
+    public Pattern getNextPrefixRegex() {
+        return SpanishDatePeriodExtractorConfiguration.FutureRegex;
+    }
+
+    @Override
+    public Pattern getFutureSuffixRegex() {
+        return SpanishDatePeriodExtractorConfiguration.FutureSuffixRegex;
+    }
+
+    @Override
+    public Pattern getPrefixDayRegex() {
+        return PrefixDayRegex;
+    }
+
+    @Override
+    public Pattern getDateUnitRegex() {
+        return DateUnitRegex;
+    }
+
+    @Override
+    public Pattern getNumberCombinedWithUnit() {
+        return TimeNumberCombinedWithUnit;
+    }
+
+    @Override
+    public Pattern getWeekDayRegex() {
+        return weekDayRegex;
+    }
+
+    @Override
+    public Pattern getPeriodTimeOfDayWithDateRegex() {
+        return PeriodTimeOfDayWithDateRegex;
+    }
+
+    @Override
+    public Pattern getRelativeTimeUnitRegex() {
+        return RelativeTimeUnitRegex;
+    }
+
+    @Override
+    public Pattern getRestOfDateTimeRegex() {
+        return RestOfDateTimeRegex;
+    }
+
+    @Override
+    public Pattern getGeneralEndingRegex() {
+        return GeneralEndingRegex;
+    }
+
+    @Override
+    public Pattern getMiddlePauseRegex() {
+        return MiddlePauseRegex;
+    }
+
+    @Override
+    public Pattern getAmDescRegex() {
+        return AmDescRegex;
+    }
+
+    @Override
+    public Pattern getPmDescRegex() {
+        return PmDescRegex;
+    }
+
+    @Override
+    public Pattern getWithinNextPrefixRegex() {
+        return WithinNextPrefixRegex;
+    }
+
+    @Override
+    public Pattern getSuffixRegex() {
+        return SuffixRegex;
+    }
+
+    @Override
+    public Pattern getBeforeRegex() {
+        return BeforeRegex;
+    }
+
+    @Override
+    public Pattern getAfterRegex() {
+        return AfterRegex;
+    }
+
+    @Override
+    public Pattern getSpecificTimeOfDayRegex() {
+        return SpanishDateTimeExtractorConfiguration.SpecificTimeOfDayRegex;
+    }
+
+    @Override
+    public ResultIndex getFromTokenIndex(String text) {
+        int index = -1;
+        boolean result = false;
+        Matcher matcher = FromRegex.matcher(text);
+        if (matcher.find()) {
+            result = true;
+            index = matcher.start();
+        }
+
+        return new ResultIndex(result, index);
+    }
+
+    @Override
+    public ResultIndex getBetweenTokenIndex(String text) {
+        int index = -1;
+        boolean result = false;
+        Matcher matcher = BetweenRegex.matcher(text);
+        if (matcher.find()) {
+            result = true;
+            index = matcher.start();
+        }
+
+        return new ResultIndex(result, index);
+    }
+
+    @Override
+    public boolean hasConnectorToken(String text) {
+        Optional<Match> match = Arrays.stream(RegExpUtility.getMatches(ConnectorAndRegex, text)).findFirst();
+        return match.isPresent() && match.get().length == text.trim().length();
+    }
+}

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/extractors/SpanishSetExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/extractors/SpanishSetExtractorConfiguration.java
@@ -1,0 +1,119 @@
+package com.microsoft.recognizers.text.datetime.spanish.extractors;
+
+import com.microsoft.recognizers.text.datetime.DateTimeOptions;
+import com.microsoft.recognizers.text.datetime.config.BaseOptionsConfiguration;
+import com.microsoft.recognizers.text.datetime.extractors.BaseDateExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.BaseDatePeriodExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.BaseDateTimeExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.BaseDateTimePeriodExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.BaseDurationExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.BaseTimeExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.BaseTimePeriodExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.IDateExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.IDateTimeExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.config.ISetExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.resources.SpanishDateTime;
+import com.microsoft.recognizers.text.utilities.RegExpUtility;
+
+import java.util.regex.Pattern;
+
+public class SpanishSetExtractorConfiguration extends BaseOptionsConfiguration implements ISetExtractorConfiguration {
+
+    public static final Pattern PeriodicRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.PeriodicRegex);
+    public static final Pattern EachUnitRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.EachUnitRegex);
+    public static final Pattern EachPrefixRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.EachPrefixRegex);
+    public static final Pattern EachDayRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.EachDayRegex);
+    public static final Pattern BeforeEachDayRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.BeforeEachDayRegex);
+    public static final Pattern SetWeekDayRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.SetWeekDayRegex);
+    public static final Pattern SetEachRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.SetEachRegex);
+
+    public SpanishSetExtractorConfiguration() {
+        this(DateTimeOptions.None);
+    }
+
+    public SpanishSetExtractorConfiguration(DateTimeOptions options) {
+        super(options);
+
+        durationExtractor = new BaseDurationExtractor(new SpanishDurationExtractorConfiguration());
+        timeExtractor = new BaseTimeExtractor(new SpanishTimeExtractorConfiguration(options));
+        dateExtractor = new BaseDateExtractor(new SpanishDateExtractorConfiguration(this));
+        dateTimeExtractor = new BaseDateTimeExtractor(new SpanishDateTimeExtractorConfiguration(options));
+        datePeriodExtractor = new BaseDatePeriodExtractor(new SpanishDatePeriodExtractorConfiguration(this));
+        timePeriodExtractor = new BaseTimePeriodExtractor(new SpanishTimePeriodExtractorConfiguration(options));
+        dateTimePeriodExtractor = new BaseDateTimePeriodExtractor(new SpanishDateTimePeriodExtractorConfiguration(options));
+    }
+
+    private IDateTimeExtractor durationExtractor;
+
+    public final IDateTimeExtractor getDurationExtractor() {
+        return durationExtractor;
+    }
+
+    private IDateTimeExtractor timeExtractor;
+
+    public final IDateTimeExtractor getTimeExtractor() {
+        return timeExtractor;
+    }
+
+    private IDateExtractor dateExtractor;
+
+    public final IDateTimeExtractor getDateExtractor() {
+        return dateExtractor;
+    }
+
+    private IDateTimeExtractor dateTimeExtractor;
+
+    public final IDateTimeExtractor getDateTimeExtractor() {
+        return dateTimeExtractor;
+    }
+
+    private IDateTimeExtractor datePeriodExtractor;
+
+    public final IDateTimeExtractor getDatePeriodExtractor() {
+        return datePeriodExtractor;
+    }
+
+    private IDateTimeExtractor timePeriodExtractor;
+
+    public final IDateTimeExtractor getTimePeriodExtractor() {
+        return timePeriodExtractor;
+    }
+
+    private IDateTimeExtractor dateTimePeriodExtractor;
+
+    public final IDateTimeExtractor getDateTimePeriodExtractor() {
+        return dateTimePeriodExtractor;
+    }
+
+    public final Pattern getLastRegex() {
+        return SpanishDateExtractorConfiguration.LastDateRegex;
+    }
+
+    public final Pattern getEachPrefixRegex() {
+        return EachPrefixRegex;
+    }
+
+    public final Pattern getPeriodicRegex() {
+        return PeriodicRegex;
+    }
+
+    public final Pattern getEachUnitRegex() {
+        return EachUnitRegex;
+    }
+
+    public final Pattern getEachDayRegex() {
+        return EachDayRegex;
+    }
+
+    public final Pattern getBeforeEachDayRegex() {
+        return BeforeEachDayRegex;
+    }
+
+    public final Pattern getSetWeekDayRegex() {
+        return SetWeekDayRegex;
+    }
+
+    public final Pattern getSetEachRegex() {
+        return SetEachRegex;
+    }
+}

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/extractors/SpanishTimePeriodExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/extractors/SpanishTimePeriodExtractorConfiguration.java
@@ -1,0 +1,154 @@
+package com.microsoft.recognizers.text.datetime.spanish.extractors;
+
+import com.microsoft.recognizers.text.IExtractor;
+import com.microsoft.recognizers.text.datetime.DateTimeOptions;
+import com.microsoft.recognizers.text.datetime.config.BaseOptionsConfiguration;
+import com.microsoft.recognizers.text.datetime.extractors.BaseTimeExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.BaseTimeZoneExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.IDateTimeExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.config.ITimePeriodExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.extractors.config.ResultIndex;
+import com.microsoft.recognizers.text.datetime.resources.SpanishDateTime;
+import com.microsoft.recognizers.text.datetime.spanish.utilities.SpanishDatetimeUtilityConfiguration;
+import com.microsoft.recognizers.text.datetime.utilities.IDateTimeUtilityConfiguration;
+import com.microsoft.recognizers.text.number.spanish.extractors.IntegerExtractor;
+import com.microsoft.recognizers.text.utilities.Match;
+import com.microsoft.recognizers.text.utilities.RegExpUtility;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class SpanishTimePeriodExtractorConfiguration extends BaseOptionsConfiguration implements ITimePeriodExtractorConfiguration {
+
+    private String tokenBeforeDate;
+
+    public final String getTokenBeforeDate() {
+        return tokenBeforeDate;
+    }
+
+    public static final Pattern HourNumRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.HourNumRegex);
+    public static final Pattern PureNumFromTo = RegExpUtility.getSafeRegExp(SpanishDateTime.PureNumFromTo);
+    public static final Pattern PureNumBetweenAnd = RegExpUtility.getSafeRegExp(SpanishDateTime.PureNumBetweenAnd);
+    public static final Pattern SpecificTimeFromTo = RegExpUtility.getSafeRegExp(SpanishDateTime.SpecificTimeFromTo);
+    public static final Pattern SpecificTimeBetweenAnd = RegExpUtility.getSafeRegExp(SpanishDateTime.SpecificTimeBetweenAnd);
+    public static final Pattern UnitRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.UnitRegex);
+    public static final Pattern FollowedUnit = RegExpUtility.getSafeRegExp(SpanishDateTime.FollowedUnit);
+    public static final Pattern NumberCombinedWithUnit = RegExpUtility.getSafeRegExp(SpanishDateTime.TimeNumberCombinedWithUnit);
+
+    private static final Pattern FromRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.FromRegex);
+    private static final Pattern ConnectorAndRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.ConnectorAndRegex);
+    private static final Pattern BetweenRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.BetweenRegex);
+
+    public static final Pattern TimeOfDayRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.TimeOfDayRegex);
+    public static final Pattern GeneralEndingRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.GeneralEndingRegex);
+    public static final Pattern TillRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.TillRegex);
+
+    public SpanishTimePeriodExtractorConfiguration() {
+        this(DateTimeOptions.None);
+    }
+
+    public SpanishTimePeriodExtractorConfiguration(DateTimeOptions options) {
+
+        super(options);
+
+        tokenBeforeDate = SpanishDateTime.TokenBeforeDate;
+        singleTimeExtractor = new BaseTimeExtractor(new SpanishTimeExtractorConfiguration(options));
+        utilityConfiguration = new SpanishDatetimeUtilityConfiguration();
+        integerExtractor = IntegerExtractor.getInstance();
+        timeZoneExtractor = new BaseTimeZoneExtractor(new SpanishTimeZoneExtractorConfiguration(options));
+    }
+
+    private IDateTimeUtilityConfiguration utilityConfiguration;
+
+    public final IDateTimeUtilityConfiguration getUtilityConfiguration() {
+        return utilityConfiguration;
+    }
+
+    private IDateTimeExtractor singleTimeExtractor;
+
+    public final IDateTimeExtractor getSingleTimeExtractor() {
+        return singleTimeExtractor;
+    }
+
+    private IExtractor integerExtractor;
+
+    public final IExtractor getIntegerExtractor() {
+        return integerExtractor;
+    }
+
+    public final IDateTimeExtractor timeZoneExtractor;
+
+    public IDateTimeExtractor getTimeZoneExtractor() {
+        return timeZoneExtractor;
+    }
+
+
+    public Iterable<Pattern> getSimpleCasesRegex() {
+        return getSimpleCasesRegex;
+    }
+
+    public final Iterable<Pattern> getSimpleCasesRegex = new ArrayList<Pattern>() {
+        {
+            add(PureNumFromTo);
+            add(PureNumBetweenAnd);
+        }
+    };
+
+    public Iterable<Pattern> getPureNumberRegex() {
+        return getPureNumberRegex;
+    }
+
+    public final Iterable<Pattern> getPureNumberRegex = new ArrayList<Pattern>() {
+        {
+            add(PureNumFromTo);
+            add(PureNumBetweenAnd);
+        }
+    };
+
+    public final Pattern getTillRegex() {
+        return TillRegex;
+    }
+
+    public final Pattern getTimeOfDayRegex() {
+        return TimeOfDayRegex;
+    }
+
+    public final Pattern getGeneralEndingRegex() {
+        return GeneralEndingRegex;
+    }
+
+    @Override
+    public ResultIndex getFromTokenIndex(String text) {
+        int index = -1;
+        boolean result = false;
+        Matcher matcher = FromRegex.matcher(text);
+        if (matcher.find()) {
+            result = true;
+            index = matcher.start();
+        }
+
+        return new ResultIndex(result, index);
+    }
+
+    @Override
+    public ResultIndex getBetweenTokenIndex(String text) {
+        int index = -1;
+        boolean result = false;
+        Matcher matcher = BetweenRegex.matcher(text);
+        if (matcher.find()) {
+            result = true;
+            index = matcher.start();
+        }
+
+        return new ResultIndex(result, index);
+    }
+
+    @Override
+    public boolean hasConnectorToken(String text) {
+        Optional<Match> match = Arrays.stream(RegExpUtility.getMatches(ConnectorAndRegex, text)).findFirst();
+        return match.isPresent() && match.get().length == text.trim().length();
+    }
+}

--- a/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/spanish/extractors/IntegerExtractor.java
+++ b/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/spanish/extractors/IntegerExtractor.java
@@ -9,6 +9,7 @@ import com.microsoft.recognizers.text.utilities.RegExpUtility;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
 
 public class IntegerExtractor extends BaseNumberExtractor {
@@ -23,6 +24,21 @@ public class IntegerExtractor extends BaseNumberExtractor {
     @Override
     protected String getExtractType() {
         return Constants.SYS_NUM_INTEGER;
+    }
+
+    private static final ConcurrentHashMap<String, IntegerExtractor> instances = new ConcurrentHashMap<>();
+
+    public static IntegerExtractor getInstance() {
+        return getInstance(SpanishNumeric.PlaceHolderDefault);
+    }
+
+    public static IntegerExtractor getInstance(String placeholder) {
+        if (!instances.containsKey(placeholder)) {
+            IntegerExtractor instance = new IntegerExtractor(placeholder);
+            instances.put(placeholder, instance);
+        }
+
+        return instances.get(placeholder);
     }
 
     public IntegerExtractor() {

--- a/Java/tests/src/test/java/com/microsoft/recognizers/text/tests/datetime/DateTimeExtractorTest.java
+++ b/Java/tests/src/test/java/com/microsoft/recognizers/text/tests/datetime/DateTimeExtractorTest.java
@@ -29,7 +29,15 @@ import com.microsoft.recognizers.text.datetime.extractors.BaseTimeExtractor;
 import com.microsoft.recognizers.text.datetime.extractors.BaseTimePeriodExtractor;
 import com.microsoft.recognizers.text.datetime.extractors.BaseTimeZoneExtractor;
 import com.microsoft.recognizers.text.datetime.extractors.IDateTimeExtractor;
-import com.microsoft.recognizers.text.datetime.spanish.extractors.*;
+import com.microsoft.recognizers.text.datetime.spanish.extractors.SpanishDateExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.spanish.extractors.SpanishDatePeriodExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.spanish.extractors.SpanishDateTimeExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.spanish.extractors.SpanishDateTimePeriodExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.spanish.extractors.SpanishDurationExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.spanish.extractors.SpanishHolidayExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.spanish.extractors.SpanishSetExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.spanish.extractors.SpanishTimeExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.spanish.extractors.SpanishTimePeriodExtractorConfiguration;
 import com.microsoft.recognizers.text.tests.AbstractTest;
 import com.microsoft.recognizers.text.tests.TestCase;
 
@@ -169,8 +177,8 @@ public class DateTimeExtractorTest extends AbstractTest {
             //   return new BaseMergedDateTimeExtractor(new SpanishMergedExtractorConfiguration(DateTimeOptions.None));
             //case "MergedExtractorSkipFromTo":
             //    return new BaseMergedDateTimeExtractor(new SpanishMergedExtractorConfiguration(DateTimeOptions.SkipFromToMerge));
-            //case "SetExtractor":
-            //    return new BaseSetExtractor(new SpanishSetExtractorConfiguration());
+            case "SetExtractor":
+                return new BaseSetExtractor(new SpanishSetExtractorConfiguration());
             case "TimeExtractor":
                 return new BaseTimeExtractor(new SpanishTimeExtractorConfiguration());
             case "TimePeriodExtractor":

--- a/Java/tests/src/test/java/com/microsoft/recognizers/text/tests/datetime/DateTimeExtractorTest.java
+++ b/Java/tests/src/test/java/com/microsoft/recognizers/text/tests/datetime/DateTimeExtractorTest.java
@@ -35,6 +35,7 @@ import com.microsoft.recognizers.text.datetime.spanish.extractors.SpanishDatePer
 import com.microsoft.recognizers.text.datetime.spanish.extractors.SpanishDurationExtractorConfiguration;
 import com.microsoft.recognizers.text.datetime.spanish.extractors.SpanishHolidayExtractorConfiguration;
 import com.microsoft.recognizers.text.datetime.spanish.extractors.SpanishTimeExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.spanish.extractors.SpanishTimePeriodExtractorConfiguration;
 import com.microsoft.recognizers.text.tests.AbstractTest;
 import com.microsoft.recognizers.text.tests.TestCase;
 
@@ -178,8 +179,8 @@ public class DateTimeExtractorTest extends AbstractTest {
             //    return new BaseSetExtractor(new SpanishSetExtractorConfiguration());
             case "TimeExtractor":
                 return new BaseTimeExtractor(new SpanishTimeExtractorConfiguration());
-            //case "TimePeriodExtractor":
-            //    return new BaseTimePeriodExtractor(new SpanishTimePeriodExtractorConfiguration());
+            case "TimePeriodExtractor":
+                return new BaseTimePeriodExtractor(new SpanishTimePeriodExtractorConfiguration());
             //case "TimeZoneExtractor":
             //    return new BaseTimeZoneExtractor(new SpanishTimeZoneExtractorConfiguration(DateTimeOptions.EnablePreview));
 

--- a/Java/tests/src/test/java/com/microsoft/recognizers/text/tests/datetime/DateTimeExtractorTest.java
+++ b/Java/tests/src/test/java/com/microsoft/recognizers/text/tests/datetime/DateTimeExtractorTest.java
@@ -29,13 +29,7 @@ import com.microsoft.recognizers.text.datetime.extractors.BaseTimeExtractor;
 import com.microsoft.recognizers.text.datetime.extractors.BaseTimePeriodExtractor;
 import com.microsoft.recognizers.text.datetime.extractors.BaseTimeZoneExtractor;
 import com.microsoft.recognizers.text.datetime.extractors.IDateTimeExtractor;
-import com.microsoft.recognizers.text.datetime.spanish.extractors.SpanishDateTimeExtractorConfiguration;
-import com.microsoft.recognizers.text.datetime.spanish.extractors.SpanishDateExtractorConfiguration;
-import com.microsoft.recognizers.text.datetime.spanish.extractors.SpanishDatePeriodExtractorConfiguration;
-import com.microsoft.recognizers.text.datetime.spanish.extractors.SpanishDurationExtractorConfiguration;
-import com.microsoft.recognizers.text.datetime.spanish.extractors.SpanishHolidayExtractorConfiguration;
-import com.microsoft.recognizers.text.datetime.spanish.extractors.SpanishTimeExtractorConfiguration;
-import com.microsoft.recognizers.text.datetime.spanish.extractors.SpanishTimePeriodExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.spanish.extractors.*;
 import com.microsoft.recognizers.text.tests.AbstractTest;
 import com.microsoft.recognizers.text.tests.TestCase;
 
@@ -165,8 +159,8 @@ public class DateTimeExtractorTest extends AbstractTest {
             //    return new BaseDateTimeAltExtractor(new SpanishDateTimeAltExtractorConfiguration());
             case "DateTimeExtractor":
                 return new BaseDateTimeExtractor(new SpanishDateTimeExtractorConfiguration());
-            //case "DateTimePeriodExtractor":
-            //    return new BaseDateTimePeriodExtractor(new SpanishDateTimePeriodExtractorConfiguration());
+            case "DateTimePeriodExtractor":
+                return new BaseDateTimePeriodExtractor(new SpanishDateTimePeriodExtractorConfiguration());
             case "DurationExtractor":
                 return new BaseDurationExtractor(new SpanishDurationExtractorConfiguration());
             case "HolidayExtractor":


### PR DESCRIPTION
**Note:** This branch is based on PR [#60](https://github.com/southworkscom/Recognizers-Text/pull/60). We will rebase once it is merged with master.

---
## Description
* Enable SpanishSetExtractor's tests
* Port SpanishSetExtractorConfiguration from [C#](https://github.com/Microsoft/Recognizers-Text/blob/master/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishSetExtractorConfiguration.cs) to Java
* Fix BaseSetExtractor's TimeEveryDay method using the wrong regex

## Evidence

![image](https://user-images.githubusercontent.com/42191764/50856563-cdfe4e00-1369-11e9-96a7-e35bb4764867.png)
