### PR TITLE
[Java][Datetime] Port SpanishTimeParserConfiguration from C# to Java

### DIFF
--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/parsers/SpanishCommonDateTimeParserConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/parsers/SpanishCommonDateTimeParserConfiguration.java
@@ -73,7 +73,7 @@ public class SpanishCommonDateTimeParserConfiguration extends BaseDateParserConf
     private final IDateTimeExtractor dateTimePeriodExtractor;
 
     //private final IDateTimeParser dateParser;
-    //private final IDateTimeParser timeParser;
+    private final IDateTimeParser timeParser;
     //private final IDateTimeParser dateTimeParser;
     //private final IDateTimeParser durationParser;
     //private final IDateTimeParser datePeriodParser;
@@ -113,7 +113,7 @@ public class SpanishCommonDateTimeParserConfiguration extends BaseDateParserConf
         dateTimePeriodExtractor = new BaseDateTimePeriodExtractor(new SpanishDateTimePeriodExtractorConfiguration(options));
 
         //dateParser = new BaseDateParser(new SpanishDateParserConfiguration(this));
-        //timeParser = new TimeParser(new SpanishTimeParserConfiguration(this));
+        timeParser = new TimeParser(new SpanishTimeParserConfiguration(this));
         //dateTimeParser = new BaseDateTimeParser(new SpanishDateTimeParserConfiguration(this));
         //durationParser = new BaseDurationParser(new SpanishDurationParserConfiguration(this));
         //datePeriodParser = new BaseDatePeriodParser(new SpanishDatePeriodParserConfiguration(this));
@@ -185,8 +185,7 @@ public class SpanishCommonDateTimeParserConfiguration extends BaseDateParserConf
 
     @Override
     public IDateTimeParser getTimeParser() {
-        //return timeParser;
-        return null;
+        return timeParser;
     }
 
     @Override

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/parsers/SpanishCommonDateTimeParserConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/parsers/SpanishCommonDateTimeParserConfiguration.java
@@ -1,0 +1,291 @@
+package com.microsoft.recognizers.text.datetime.spanish.parsers;
+
+import com.google.common.collect.ImmutableMap;
+import com.microsoft.recognizers.text.IExtractor;
+import com.microsoft.recognizers.text.IParser;
+import com.microsoft.recognizers.text.datetime.DateTimeOptions;
+import com.microsoft.recognizers.text.datetime.english.parsers.TimeParser;
+import com.microsoft.recognizers.text.datetime.extractors.BaseDateExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.BaseDatePeriodExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.BaseDateTimeExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.BaseDateTimePeriodExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.BaseDurationExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.BaseTimeExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.BaseTimePeriodExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.IDateExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.IDateTimeExtractor;
+import com.microsoft.recognizers.text.datetime.parsers.BaseDateParser;
+import com.microsoft.recognizers.text.datetime.parsers.BaseDatePeriodParser;
+import com.microsoft.recognizers.text.datetime.parsers.BaseDateTimeAltParser;
+import com.microsoft.recognizers.text.datetime.parsers.BaseDateTimeParser;
+import com.microsoft.recognizers.text.datetime.parsers.BaseDateTimePeriodParser;
+import com.microsoft.recognizers.text.datetime.parsers.BaseDurationParser;
+import com.microsoft.recognizers.text.datetime.parsers.BaseTimePeriodParser;
+import com.microsoft.recognizers.text.datetime.parsers.BaseTimeZoneParser;
+import com.microsoft.recognizers.text.datetime.parsers.IDateTimeParser;
+import com.microsoft.recognizers.text.datetime.parsers.config.BaseDateParserConfiguration;
+import com.microsoft.recognizers.text.datetime.parsers.config.ICommonDateTimeParserConfiguration;
+import com.microsoft.recognizers.text.datetime.resources.SpanishDateTime;
+import com.microsoft.recognizers.text.datetime.spanish.extractors.SpanishDateExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.spanish.extractors.SpanishDatePeriodExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.spanish.extractors.SpanishDateTimeExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.spanish.extractors.SpanishDateTimePeriodExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.spanish.extractors.SpanishDurationExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.spanish.extractors.SpanishTimeExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.spanish.extractors.SpanishTimePeriodExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.spanish.utilities.SpanishDatetimeUtilityConfiguration;
+import com.microsoft.recognizers.text.datetime.utilities.IDateTimeUtilityConfiguration;
+import com.microsoft.recognizers.text.number.parsers.BaseNumberParser;
+import com.microsoft.recognizers.text.number.spanish.extractors.CardinalExtractor;
+import com.microsoft.recognizers.text.number.spanish.extractors.IntegerExtractor;
+import com.microsoft.recognizers.text.number.spanish.extractors.OrdinalExtractor;
+import com.microsoft.recognizers.text.number.spanish.parsers.SpanishNumberParserConfiguration;
+import com.microsoft.recognizers.text.utilities.RegExpUtility;
+
+import java.util.regex.Pattern;
+
+public class SpanishCommonDateTimeParserConfiguration extends BaseDateParserConfiguration implements ICommonDateTimeParserConfiguration {
+
+    private final IDateTimeUtilityConfiguration utilityConfiguration;
+
+    private final ImmutableMap<String, String> unitMap;
+    private final ImmutableMap<String, Long> unitValueMap;
+    private final ImmutableMap<String, String> seasonMap;
+    private final ImmutableMap<String, Integer> cardinalMap;
+    private final ImmutableMap<String, Integer> dayOfWeek;
+    private final ImmutableMap<String, Integer> monthOfYear;
+    private final ImmutableMap<String, Integer> numbers;
+    private final ImmutableMap<String, Double> doubleNumbers;
+    private final ImmutableMap<String, Integer> writtenDecades;
+    private final ImmutableMap<String, Integer> specialDecadeCases;
+
+    private final IExtractor cardinalExtractor;
+    private final IExtractor integerExtractor;
+    private final IExtractor ordinalExtractor;
+    private final IParser numberParser;
+
+    private final IDateTimeExtractor durationExtractor;
+    private final IDateExtractor dateExtractor;
+    private final IDateTimeExtractor timeExtractor;
+    private final IDateTimeExtractor dateTimeExtractor;
+    private final IDateTimeExtractor datePeriodExtractor;
+    private final IDateTimeExtractor timePeriodExtractor;
+    private final IDateTimeExtractor dateTimePeriodExtractor;
+
+    //private final IDateTimeParser dateParser;
+    //private final IDateTimeParser timeParser;
+    //private final IDateTimeParser dateTimeParser;
+    //private final IDateTimeParser durationParser;
+    //private final IDateTimeParser datePeriodParser;
+    //private final IDateTimeParser timePeriodParser;
+    //private final IDateTimeParser dateTimePeriodParser;
+    //private final IDateTimeParser dateTimeAltParser;
+
+    public SpanishCommonDateTimeParserConfiguration(DateTimeOptions options) {
+
+        super(options);
+
+        utilityConfiguration = new SpanishDatetimeUtilityConfiguration();
+
+        unitMap = SpanishDateTime.UnitMap;
+        unitValueMap = SpanishDateTime.UnitValueMap;
+        seasonMap = SpanishDateTime.SeasonMap;
+        cardinalMap = SpanishDateTime.CardinalMap;
+        dayOfWeek = SpanishDateTime.DayOfWeek;
+        monthOfYear = SpanishDateTime.MonthOfYear;
+        numbers = SpanishDateTime.Numbers;
+        doubleNumbers = SpanishDateTime.DoubleNumbers;
+        writtenDecades = SpanishDateTime.WrittenDecades;
+        specialDecadeCases = SpanishDateTime.SpecialDecadeCases;
+
+        cardinalExtractor = CardinalExtractor.getInstance();
+        integerExtractor = IntegerExtractor.getInstance();
+        ordinalExtractor = OrdinalExtractor.getInstance();
+
+        numberParser = new BaseNumberParser(new SpanishNumberParserConfiguration());
+
+        dateExtractor = new BaseDateExtractor(new SpanishDateExtractorConfiguration(this));
+        timeExtractor = new BaseTimeExtractor(new SpanishTimeExtractorConfiguration(options));
+        dateTimeExtractor = new BaseDateTimeExtractor(new SpanishDateTimeExtractorConfiguration(options));
+        durationExtractor = new BaseDurationExtractor(new SpanishDurationExtractorConfiguration());
+        datePeriodExtractor = new BaseDatePeriodExtractor(new SpanishDatePeriodExtractorConfiguration(this));
+        timePeriodExtractor = new BaseTimePeriodExtractor(new SpanishTimePeriodExtractorConfiguration(options));
+        dateTimePeriodExtractor = new BaseDateTimePeriodExtractor(new SpanishDateTimePeriodExtractorConfiguration(options));
+
+        //dateParser = new BaseDateParser(new SpanishDateParserConfiguration(this));
+        //timeParser = new TimeParser(new SpanishTimeParserConfiguration(this));
+        //dateTimeParser = new BaseDateTimeParser(new SpanishDateTimeParserConfiguration(this));
+        //durationParser = new BaseDurationParser(new SpanishDurationParserConfiguration(this));
+        //datePeriodParser = new BaseDatePeriodParser(new SpanishDatePeriodParserConfiguration(this));
+        //timePeriodParser = new BaseTimePeriodParser(new SpanishTimePeriodParserConfiguration(this));
+        //dateTimePeriodParser = new BaseDateTimePeriodParser(new SpanishDateTimePeriodParserConfiguration(this));
+        //dateTimeAltParser = new BaseDateTimeAltParser(new SpanishDateTimeAltParserConfiguration(this));
+    }
+
+    @Override
+    public IExtractor getCardinalExtractor() {
+        return cardinalExtractor;
+    }
+
+    @Override
+    public IExtractor getIntegerExtractor() {
+        return integerExtractor;
+    }
+
+    @Override
+    public IExtractor getOrdinalExtractor() {
+        return ordinalExtractor;
+    }
+
+    @Override
+    public IParser getNumberParser() {
+        return numberParser;
+    }
+
+    @Override
+    public IDateExtractor getDateExtractor() {
+        return dateExtractor;
+    }
+
+    @Override
+    public IDateTimeExtractor getTimeExtractor() {
+        return timeExtractor;
+    }
+
+    @Override
+    public IDateTimeExtractor getDateTimeExtractor() {
+        return dateTimeExtractor;
+    }
+
+    @Override
+    public IDateTimeExtractor getDurationExtractor() {
+        return durationExtractor;
+    }
+
+    @Override
+    public IDateTimeExtractor getDatePeriodExtractor() {
+        return datePeriodExtractor;
+    }
+
+    @Override
+    public IDateTimeExtractor getTimePeriodExtractor() {
+        return timePeriodExtractor;
+    }
+
+    @Override
+    public IDateTimeExtractor getDateTimePeriodExtractor() {
+        return dateTimePeriodExtractor;
+    }
+
+    @Override
+    public IDateTimeParser getDateParser() {
+        //return dateParser;
+        return null;
+    }
+
+    @Override
+    public IDateTimeParser getTimeParser() {
+        //return timeParser;
+        return null;
+    }
+
+    @Override
+    public IDateTimeParser getDateTimeParser() {
+        //return dateTimeParser;
+        return null;
+    }
+
+    @Override
+    public IDateTimeParser getDurationParser() {
+        //return durationParser;
+        return null;
+    }
+
+    @Override
+    public IDateTimeParser getDatePeriodParser() {
+        //return datePeriodParser;
+        return null;
+    }
+
+    @Override
+    public IDateTimeParser getTimePeriodParser() {
+        //return timePeriodParser;
+        return null;
+    }
+
+    @Override
+    public IDateTimeParser getDateTimePeriodParser() {
+        //return dateTimePeriodParser;
+        return null;
+    }
+
+    @Override
+    public IDateTimeParser getDateTimeAltParser() {
+        //return dateTimeAltParser;
+        return null;
+    }
+
+    @Override public IDateTimeParser getTimeZoneParser() {
+        return null;
+    }
+
+    @Override
+    public Pattern getAmbiguousMonthP0Regex() {
+        return null;
+    }
+
+    @Override
+    public ImmutableMap<String, Integer> getMonthOfYear() {
+        return monthOfYear;
+    }
+
+    @Override
+    public ImmutableMap<String, Integer> getNumbers() {
+        return numbers;
+    }
+
+    @Override
+    public ImmutableMap<String, Long> getUnitValueMap() {
+        return unitValueMap;
+    }
+
+    @Override
+    public ImmutableMap<String, String> getSeasonMap() {
+        return seasonMap;
+    }
+
+    @Override
+    public ImmutableMap<String, String> getUnitMap() {
+        return unitMap;
+    }
+
+    @Override
+    public ImmutableMap<String, Integer> getCardinalMap() {
+        return cardinalMap;
+    }
+
+    @Override
+    public ImmutableMap<String, Integer> getDayOfWeek() {
+        return dayOfWeek;
+    }
+
+    @Override
+    public ImmutableMap<String, Double> getDoubleNumbers() {
+        return doubleNumbers;
+    }
+
+    @Override
+    public ImmutableMap<String, Integer> getWrittenDecades() {
+        return writtenDecades;
+    }
+
+    @Override
+    public ImmutableMap<String, Integer> getSpecialDecadeCases() {
+        return specialDecadeCases;
+    }
+
+    @Override
+    public IDateTimeUtilityConfiguration getUtilityConfiguration() {
+        return utilityConfiguration;
+    }
+}

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/parsers/SpanishTimeParserConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/parsers/SpanishTimeParserConfiguration.java
@@ -1,0 +1,160 @@
+package com.microsoft.recognizers.text.datetime.spanish.parsers;
+
+import com.google.common.collect.ImmutableMap;
+import com.microsoft.recognizers.text.datetime.Constants;
+import com.microsoft.recognizers.text.datetime.config.BaseOptionsConfiguration;
+import com.microsoft.recognizers.text.datetime.parsers.BaseTimeZoneParser;
+import com.microsoft.recognizers.text.datetime.parsers.IDateTimeParser;
+import com.microsoft.recognizers.text.datetime.parsers.config.ICommonDateTimeParserConfiguration;
+import com.microsoft.recognizers.text.datetime.parsers.config.ITimeParserConfiguration;
+import com.microsoft.recognizers.text.datetime.parsers.config.PrefixAdjustResult;
+import com.microsoft.recognizers.text.datetime.parsers.config.SuffixAdjustResult;
+import com.microsoft.recognizers.text.datetime.resources.SpanishDateTime;
+import com.microsoft.recognizers.text.datetime.spanish.extractors.SpanishTimeExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.utilities.IDateTimeUtilityConfiguration;
+import com.microsoft.recognizers.text.utilities.Match;
+import com.microsoft.recognizers.text.utilities.RegExpUtility;
+import com.microsoft.recognizers.text.utilities.StringUtility;
+
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+public class SpanishTimeParserConfiguration extends BaseOptionsConfiguration implements ITimeParserConfiguration {
+
+    public String timeTokenPrefix = SpanishDateTime.TimeTokenPrefix;
+
+    public final Pattern atRegex;
+    public Pattern mealTimeRegex;
+
+    private final Iterable<Pattern> timeRegexes;
+    private final ImmutableMap<String, Integer> numbers;
+    private final IDateTimeUtilityConfiguration utilityConfiguration;
+    private final IDateTimeParser timeZoneParser;
+
+    public SpanishTimeParserConfiguration(ICommonDateTimeParserConfiguration config) {
+
+        super(config.getOptions());
+
+        numbers = config.getNumbers();
+        utilityConfiguration = config.getUtilityConfiguration();
+        timeZoneParser = new BaseTimeZoneParser();
+
+        atRegex = SpanishTimeExtractorConfiguration.AtRegex;
+        timeRegexes = SpanishTimeExtractorConfiguration.TimeRegexList;
+    }
+
+    @Override
+    public String getTimeTokenPrefix() {
+        return timeTokenPrefix;
+    }
+
+    @Override
+    public Pattern getAtRegex() {
+        return atRegex;
+    }
+
+    @Override
+    public Iterable<Pattern> getTimeRegexes() {
+        return timeRegexes;
+    }
+
+    @Override
+    public ImmutableMap<String, Integer> getNumbers() {
+        return numbers;
+    }
+
+    @Override
+    public IDateTimeUtilityConfiguration getUtilityConfiguration() {
+        return utilityConfiguration;
+    }
+
+    @Override
+    public IDateTimeParser getTimeZoneParser() {
+        return timeZoneParser;
+    }
+
+    @Override
+    public PrefixAdjustResult adjustByPrefix(String prefix, int hour, int min, boolean hasMin) {
+
+        int deltaMin = 0;
+        String trimmedPrefix = prefix.trim().toLowerCase();
+
+        if (trimmedPrefix.startsWith("cuarto") || trimmedPrefix.startsWith("y cuarto")) {
+            deltaMin = 15;
+        } else if (trimmedPrefix.startsWith("menos cuarto")) {
+            deltaMin = -15;
+        } else if (trimmedPrefix.startsWith("media") || trimmedPrefix.startsWith("y media")) {
+            deltaMin = 30;
+        } else {
+            Optional<Match> match = Arrays.stream(RegExpUtility.getMatches(SpanishTimeExtractorConfiguration.LessThanOneHour, trimmedPrefix)).findFirst();
+            if (match.isPresent()) {
+                String minStr = match.get().getGroup("deltamin").value;
+                if (!StringUtility.isNullOrWhiteSpace(minStr)) {
+                    deltaMin = Integer.parseInt(minStr);
+                } else {
+                    minStr = match.get().getGroup("deltaminnum").value.toLowerCase();
+                    deltaMin = numbers.getOrDefault(minStr, 0);
+                }
+            }
+        }
+
+        if (trimmedPrefix.endsWith("pasadas") || trimmedPrefix.endsWith("pasados") || trimmedPrefix.endsWith("pasadas las") ||
+            trimmedPrefix.endsWith("pasados las") || trimmedPrefix.endsWith("pasadas de las") || trimmedPrefix.endsWith("pasados de las")) {
+            //deltaMin is positive
+        } else if (trimmedPrefix.endsWith("para la") || trimmedPrefix.endsWith("para las") ||
+            trimmedPrefix.endsWith("antes de la") || trimmedPrefix.endsWith("antes de las")) {
+            deltaMin = -deltaMin;
+        }
+
+        min += deltaMin;
+        if (min < 0) {
+            min += 60;
+            hour -= 1;
+        }
+
+        hasMin = hasMin || (min != 0);
+
+        return new PrefixAdjustResult(hour, min, hasMin);
+    }
+
+    @Override
+    public SuffixAdjustResult adjustBySuffix(String suffix, int hour, int min, boolean hasMin, boolean hasAm, boolean hasPm) {
+
+        String trimmedSuffix = suffix.trim().toLowerCase();
+        PrefixAdjustResult prefixAdjustResult = adjustByPrefix(trimmedSuffix,hour, min, hasMin);
+        hour = prefixAdjustResult.hour;
+        min = prefixAdjustResult.minute;
+        hasMin = prefixAdjustResult.hasMin;
+
+        int deltaHour = 0;
+        Optional<Match> match = Arrays.stream(RegExpUtility.getMatches(SpanishTimeExtractorConfiguration.TimeSuffix, trimmedSuffix)).findFirst();
+
+        if (match.isPresent() && match.get().index == 0 && match.get().length == trimmedSuffix.length()) {
+
+            String oclockStr = match.get().getGroup("oclock").value;
+            if (StringUtility.isNullOrEmpty(oclockStr)) {
+
+                String amStr = match.get().getGroup(Constants.AmGroupName).value;
+                if (!StringUtility.isNullOrEmpty(amStr)) {
+                    if (hour >= Constants.HalfDayHourCount) {
+                        deltaHour = -Constants.HalfDayHourCount;
+                    }
+                    hasAm = true;
+                }
+
+                String pmStr = match.get().getGroup(Constants.PmGroupName).value;
+                if (!StringUtility.isNullOrEmpty(pmStr)) {
+                    if (hour < Constants.HalfDayHourCount) {
+                        deltaHour = Constants.HalfDayHourCount;
+                    }
+                    hasPm = true;
+                }
+            }
+        }
+
+        hour = (hour + deltaHour) % 24;
+
+        return new SuffixAdjustResult(hour, min, hasMin, hasAm, hasPm);
+    }
+}

--- a/Java/tests/src/test/java/com/microsoft/recognizers/text/tests/datetime/DateTimeParserTest.java
+++ b/Java/tests/src/test/java/com/microsoft/recognizers/text/tests/datetime/DateTimeParserTest.java
@@ -165,6 +165,8 @@ public class DateTimeParserTest extends AbstractTest {
             switch (culture) {
                 case Culture.English:
                     return getEnglishParser(name);
+                case Culture.Spanish:
+                    return getSpanishParser(name);
                 default:
                     throw new AssumptionViolatedException("Parser Type/Name not supported.");
             }

--- a/Java/tests/src/test/java/com/microsoft/recognizers/text/tests/datetime/DateTimeParserTest.java
+++ b/Java/tests/src/test/java/com/microsoft/recognizers/text/tests/datetime/DateTimeParserTest.java
@@ -35,6 +35,8 @@ import com.microsoft.recognizers.text.datetime.parsers.BaseTimePeriodParser;
 import com.microsoft.recognizers.text.datetime.parsers.BaseTimeZoneParser;
 import com.microsoft.recognizers.text.datetime.parsers.DateTimeParseResult;
 import com.microsoft.recognizers.text.datetime.parsers.IDateTimeParser;
+import com.microsoft.recognizers.text.datetime.spanish.parsers.SpanishCommonDateTimeParserConfiguration;
+import com.microsoft.recognizers.text.datetime.spanish.parsers.SpanishTimeParserConfiguration;
 import com.microsoft.recognizers.text.datetime.utilities.DateTimeResolutionResult;
 import com.microsoft.recognizers.text.datetime.utilities.TimeZoneResolutionResult;
 import com.microsoft.recognizers.text.tests.AbstractTest;
@@ -228,8 +230,8 @@ public class DateTimeParserTest extends AbstractTest {
             //    return new BaseSetParser(new SpanishSetParserConfiguration(new SpanishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
             //case "MergedParser":
             //    return new BaseMergedDateTimeParser(new EnglishMergedParserConfiguration(DateTimeOptions.None));
-            //case "TimeParser":
-            //    return new TimeParser(new SpanishTimeParserConfiguration(new SpanishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
+            case "TimeParser":
+                return new TimeParser(new SpanishTimeParserConfiguration(new SpanishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
             //case "TimePeriodParser":
             //    return new BaseTimePeriodParser(new SpanishTimePeriodParserConfiguration(new SpanishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
             default:

--- a/Java/tests/src/test/java/com/microsoft/recognizers/text/tests/datetime/DateTimeParserTest.java
+++ b/Java/tests/src/test/java/com/microsoft/recognizers/text/tests/datetime/DateTimeParserTest.java
@@ -205,6 +205,36 @@ public class DateTimeParserTest extends AbstractTest {
         }
     }
 
+    private static IDateTimeParser getSpanishParser(String name) {
+
+        switch (name) {
+            //case "DateParser":
+            //    return new BaseDateParser(new SpanishDateParserConfiguration(new SpanishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
+            //case "DatePeriodParser":
+            //    return new BaseDatePeriodParser(new SpanishDatePeriodParserConfiguration(new SpanishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
+            //case "DateTimeAltParser":
+            //    return new BaseDateTimeAltParser(new EnglishDateTimeAltParserConfiguration(new EnglishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
+            //case "DateTimeParser":
+            //    return new BaseDateTimeParser(new SpanishDateTimeParserConfiguration(new SpanishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
+            //case "DateTimePeriodParser":
+            //    return new BaseDateTimePeriodParser(new SpanishDateTimePeriodParserConfiguration(new SpanishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
+            //case "DurationParser":
+            //    return new BaseDurationParser(new SpanishDurationParserConfiguration(new SpanishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
+            //case "HolidayParser":
+            //    return new BaseHolidayParser(new SpanishHolidayParserConfiguration());
+            //case "SetParser":
+            //    return new BaseSetParser(new SpanishSetParserConfiguration(new SpanishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
+            //case "MergedParser":
+            //    return new BaseMergedDateTimeParser(new EnglishMergedParserConfiguration(DateTimeOptions.None));
+            //case "TimeParser":
+            //    return new TimeParser(new SpanishTimeParserConfiguration(new SpanishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
+            //case "TimePeriodParser":
+            //    return new BaseTimePeriodParser(new SpanishTimePeriodParserConfiguration(new SpanishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
+            default:
+                throw new AssumptionViolatedException("Parser Type/Name not supported.");
+        }
+    }
+
     private IDateTimeExtractor getExtractor(TestCase currentCase) {
 
         String extractorName = currentCase.modelName.replace("Parser", "Extractor");


### PR DESCRIPTION
**Note:** This branch is based on #66. We will rebase once it's merged.

---
# Description
- Enable `SpanishTimeParser` tests
- Port `SpanishTimeParserConfiguration` from [C#](https://github.com/Microsoft/Recognizers-Text/blob/master/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishTimeParserConfiguration.cs) to Java

# Evidence

![image](https://user-images.githubusercontent.com/42191764/50918381-dd8b9e80-141e-11e9-95ad-2c3524e20682.png)


