### PR TITLE
[Java][Datetime] Port SpanishDateParserConfiguration from C# to Java

### DIFF
--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/english/parsers/EnglishDateParserConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/english/parsers/EnglishDateParserConfiguration.java
@@ -5,6 +5,7 @@ import com.microsoft.recognizers.text.IExtractor;
 import com.microsoft.recognizers.text.IParser;
 import com.microsoft.recognizers.text.datetime.config.BaseOptionsConfiguration;
 import com.microsoft.recognizers.text.datetime.english.extractors.EnglishDateExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.extractors.IDateExtractor;
 import com.microsoft.recognizers.text.datetime.extractors.IDateTimeExtractor;
 import com.microsoft.recognizers.text.datetime.parsers.IDateTimeParser;
 import com.microsoft.recognizers.text.datetime.parsers.config.ICommonDateTimeParserConfiguration;
@@ -78,7 +79,7 @@ public class EnglishDateParserConfiguration extends BaseOptionsConfiguration imp
     private final IExtractor cardinalExtractor;
     private final IParser numberParser;
     private final IDateTimeExtractor durationExtractor;
-    private final IDateTimeExtractor dateExtractor;
+    private final IDateExtractor dateExtractor;
     private final IDateTimeParser durationParser;
     private final Iterable<Pattern> dateRegexes;
 
@@ -149,7 +150,7 @@ public class EnglishDateParserConfiguration extends BaseOptionsConfiguration imp
     }
 
     @Override
-    public IDateTimeExtractor getDateExtractor() {
+    public IDateExtractor getDateExtractor() {
         return dateExtractor;
     }
 
@@ -306,31 +307,6 @@ public class EnglishDateParserConfiguration extends BaseOptionsConfiguration imp
     @Override
     public IDateTimeUtilityConfiguration getUtilityConfiguration() {
         return utilityConfiguration;
-    }
-
-    @Override
-    public Integer getSwiftDay(String text) {
-
-        String trimmedText = text.trim().toLowerCase();
-        Integer swift = 0;
-
-        Optional<Match> match = Arrays.stream(RegExpUtility.getMatches(relativeDayRegex, text)).findFirst();
-
-        if (trimmedText.equals("today")) {
-            swift = 0;
-        } else if (trimmedText.equals("tomorrow") || trimmedText.equals("tmr")) {
-            swift = 1;
-        } else if (trimmedText.equals("yesterday")) {
-            swift = -1;
-        } else if (trimmedText.endsWith("day after tomorrow") || trimmedText.endsWith("day after tmr")) {
-            swift = 2;
-        } else if (trimmedText.endsWith("day before yesterday")) {
-            swift = -2;
-        } else if (match.isPresent()) {
-            swift = getSwift(text);
-        }
-
-        return swift;
     }
 
     @Override

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/parsers/BaseDateParser.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/parsers/BaseDateParser.java
@@ -444,7 +444,7 @@ public class BaseDateParser implements IDateTimeParser {
 
         return AgoLaterUtil.parseDurationWithAgoAndLater(text, referenceDate,
                 config.getDurationExtractor(), config.getDurationParser(), config.getUnitMap(), config.getUnitRegex(),
-                config.getUtilityConfiguration(), config::getSwiftDay);
+                config.getUtilityConfiguration(), this::getSwiftDay);
     }
 
     // handle cases like "January first", "twenty-two of August"

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/parsers/config/IDateParserConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/parsers/config/IDateParserConfiguration.java
@@ -5,6 +5,7 @@ import com.google.common.collect.ImmutableMap;
 import com.microsoft.recognizers.text.IExtractor;
 import com.microsoft.recognizers.text.IParser;
 import com.microsoft.recognizers.text.datetime.config.IOptionsConfiguration;
+import com.microsoft.recognizers.text.datetime.extractors.IDateExtractor;
 import com.microsoft.recognizers.text.datetime.extractors.IDateTimeExtractor;
 import com.microsoft.recognizers.text.datetime.parsers.IDateTimeParser;
 import com.microsoft.recognizers.text.datetime.utilities.IDateTimeUtilityConfiguration;
@@ -25,7 +26,7 @@ public interface IDateParserConfiguration extends IOptionsConfiguration {
 
     IDateTimeExtractor getDurationExtractor();
 
-    IDateTimeExtractor getDateExtractor();
+    IDateExtractor getDateExtractor();
 
     IDateTimeParser getDurationParser();
 
@@ -67,7 +68,6 @@ public interface IDateParserConfiguration extends IOptionsConfiguration {
 
     Pattern getPastPrefixRegex();
 
-
     ImmutableMap<String, String> getUnitMap();
 
     ImmutableMap<String, Integer> getDayOfMonth();
@@ -88,13 +88,11 @@ public interface IDateParserConfiguration extends IOptionsConfiguration {
 
     List<String> getMinusTwoDayTerms();
 
-    Integer getSwiftDay(String text);
+    IDateTimeUtilityConfiguration getUtilityConfiguration();
 
     Integer getSwiftMonth(String text);
 
     Boolean isCardinalLast(String text);
 
     String normalize(String text);
-
-    IDateTimeUtilityConfiguration getUtilityConfiguration();
 }

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/extractors/SpanishDateExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/extractors/SpanishDateExtractorConfiguration.java
@@ -3,6 +3,7 @@ package com.microsoft.recognizers.text.datetime.spanish.extractors;
 import com.google.common.collect.ImmutableMap;
 import com.microsoft.recognizers.text.IExtractor;
 import com.microsoft.recognizers.text.IParser;
+import com.microsoft.recognizers.text.datetime.Constants;
 import com.microsoft.recognizers.text.datetime.config.BaseOptionsConfiguration;
 import com.microsoft.recognizers.text.datetime.config.IOptionsConfiguration;
 import com.microsoft.recognizers.text.datetime.extractors.BaseDurationExtractor;
@@ -17,9 +18,13 @@ import com.microsoft.recognizers.text.number.spanish.extractors.IntegerExtractor
 import com.microsoft.recognizers.text.number.spanish.extractors.OrdinalExtractor;
 import com.microsoft.recognizers.text.number.spanish.parsers.SpanishNumberParserConfiguration;
 import com.microsoft.recognizers.text.utilities.RegExpUtility;
+import com.sun.nio.sctp.PeerAddressChangeNotification;
 
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
 import java.util.List;
+import java.util.ListIterator;
 import java.util.regex.Pattern;
 
 
@@ -71,6 +76,8 @@ public class SpanishDateExtractorConfiguration extends BaseOptionsConfiguration 
     public static final ImmutableMap<String, Integer> DayOfWeek = SpanishDateTime.DayOfWeek;
     public static final ImmutableMap<String, Integer> MonthOfYear = SpanishDateTime.MonthOfYear;
 
+    public static List<Pattern> DateRegexList;
+
     public SpanishDateExtractorConfiguration(IOptionsConfiguration config) {
         super(config.getOptions());
         integerExtractor = new IntegerExtractor(); // in other languages (english) has a method named get instance
@@ -79,22 +86,34 @@ public class SpanishDateExtractorConfiguration extends BaseOptionsConfiguration 
         durationExtractor = new BaseDurationExtractor(new SpanishDurationExtractorConfiguration());
         utilityConfiguration = new SpanishDatetimeUtilityConfiguration();
 
-    }
+        DateRegexList = new ArrayList<Pattern>() {
+            {
+                add(RegExpUtility.getSafeRegExp(SpanishDateTime.DateExtractor1));
+                add(RegExpUtility.getSafeRegExp(SpanishDateTime.DateExtractor2));
+                add(RegExpUtility.getSafeRegExp(SpanishDateTime.DateExtractor3));
+            }
+        };
 
-    public static final List<Pattern> DateRegexList = new ArrayList<Pattern>() {
-        {
-            add(RegExpUtility.getSafeRegExp(SpanishDateTime.DateExtractor1));
-            add(RegExpUtility.getSafeRegExp(SpanishDateTime.DateExtractor2));
-            add(RegExpUtility.getSafeRegExp(SpanishDateTime.DateExtractor3));
-            add(RegExpUtility.getSafeRegExp(SpanishDateTime.DateExtractor4));
-            add(RegExpUtility.getSafeRegExp(SpanishDateTime.DateExtractor5));
-            add(RegExpUtility.getSafeRegExp(SpanishDateTime.DateExtractor6));
-            add(RegExpUtility.getSafeRegExp(SpanishDateTime.DateExtractor7));
-            add(RegExpUtility.getSafeRegExp(SpanishDateTime.DateExtractor8));
-            add(RegExpUtility.getSafeRegExp(SpanishDateTime.DateExtractor9));
-            add(RegExpUtility.getSafeRegExp(SpanishDateTime.DateExtractor10));
+        boolean enableDmy = getDmyDateFormat() || SpanishDateTime.DefaultLanguageFallback == Constants.DefaultLanguageFallback_DMY;
+
+        if (enableDmy) {
+            DateRegexList.add(RegExpUtility.getSafeRegExp(SpanishDateTime.DateExtractor5));
+            DateRegexList.add(RegExpUtility.getSafeRegExp(SpanishDateTime.DateExtractor8));
+            DateRegexList.add(RegExpUtility.getSafeRegExp(SpanishDateTime.DateExtractor9));
+            DateRegexList.add(RegExpUtility.getSafeRegExp(SpanishDateTime.DateExtractor4));
+            DateRegexList.add(RegExpUtility.getSafeRegExp(SpanishDateTime.DateExtractor6));
+            DateRegexList.add(RegExpUtility.getSafeRegExp(SpanishDateTime.DateExtractor7));
+            DateRegexList.add(RegExpUtility.getSafeRegExp(SpanishDateTime.DateExtractor10));
+        } else {
+            DateRegexList.add(RegExpUtility.getSafeRegExp(SpanishDateTime.DateExtractor4));
+            DateRegexList.add(RegExpUtility.getSafeRegExp(SpanishDateTime.DateExtractor6));
+            DateRegexList.add(RegExpUtility.getSafeRegExp(SpanishDateTime.DateExtractor7));
+            DateRegexList.add(RegExpUtility.getSafeRegExp(SpanishDateTime.DateExtractor5));
+            DateRegexList.add(RegExpUtility.getSafeRegExp(SpanishDateTime.DateExtractor8));
+            DateRegexList.add(RegExpUtility.getSafeRegExp(SpanishDateTime.DateExtractor9));
+            DateRegexList.add(RegExpUtility.getSafeRegExp(SpanishDateTime.DateExtractor10));
         }
-    };
+    }
 
     private final IExtractor integerExtractor;
     private final IExtractor ordinalExtractor;

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/parsers/SpanishCommonDateTimeParserConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/parsers/SpanishCommonDateTimeParserConfiguration.java
@@ -1,0 +1,291 @@
+package com.microsoft.recognizers.text.datetime.spanish.parsers;
+
+import com.google.common.collect.ImmutableMap;
+import com.microsoft.recognizers.text.IExtractor;
+import com.microsoft.recognizers.text.IParser;
+import com.microsoft.recognizers.text.datetime.DateTimeOptions;
+import com.microsoft.recognizers.text.datetime.english.parsers.TimeParser;
+import com.microsoft.recognizers.text.datetime.extractors.BaseDateExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.BaseDatePeriodExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.BaseDateTimeExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.BaseDateTimePeriodExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.BaseDurationExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.BaseTimeExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.BaseTimePeriodExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.IDateExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.IDateTimeExtractor;
+import com.microsoft.recognizers.text.datetime.parsers.BaseDateParser;
+import com.microsoft.recognizers.text.datetime.parsers.BaseDatePeriodParser;
+import com.microsoft.recognizers.text.datetime.parsers.BaseDateTimeAltParser;
+import com.microsoft.recognizers.text.datetime.parsers.BaseDateTimeParser;
+import com.microsoft.recognizers.text.datetime.parsers.BaseDateTimePeriodParser;
+import com.microsoft.recognizers.text.datetime.parsers.BaseDurationParser;
+import com.microsoft.recognizers.text.datetime.parsers.BaseTimePeriodParser;
+import com.microsoft.recognizers.text.datetime.parsers.BaseTimeZoneParser;
+import com.microsoft.recognizers.text.datetime.parsers.IDateTimeParser;
+import com.microsoft.recognizers.text.datetime.parsers.config.BaseDateParserConfiguration;
+import com.microsoft.recognizers.text.datetime.parsers.config.ICommonDateTimeParserConfiguration;
+import com.microsoft.recognizers.text.datetime.resources.SpanishDateTime;
+import com.microsoft.recognizers.text.datetime.spanish.extractors.SpanishDateExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.spanish.extractors.SpanishDatePeriodExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.spanish.extractors.SpanishDateTimeExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.spanish.extractors.SpanishDateTimePeriodExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.spanish.extractors.SpanishDurationExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.spanish.extractors.SpanishTimeExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.spanish.extractors.SpanishTimePeriodExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.spanish.utilities.SpanishDatetimeUtilityConfiguration;
+import com.microsoft.recognizers.text.datetime.utilities.IDateTimeUtilityConfiguration;
+import com.microsoft.recognizers.text.number.parsers.BaseNumberParser;
+import com.microsoft.recognizers.text.number.spanish.extractors.CardinalExtractor;
+import com.microsoft.recognizers.text.number.spanish.extractors.IntegerExtractor;
+import com.microsoft.recognizers.text.number.spanish.extractors.OrdinalExtractor;
+import com.microsoft.recognizers.text.number.spanish.parsers.SpanishNumberParserConfiguration;
+import com.microsoft.recognizers.text.utilities.RegExpUtility;
+
+import java.util.regex.Pattern;
+
+public class SpanishCommonDateTimeParserConfiguration extends BaseDateParserConfiguration implements ICommonDateTimeParserConfiguration {
+
+    private final IDateTimeUtilityConfiguration utilityConfiguration;
+
+    private final ImmutableMap<String, String> unitMap;
+    private final ImmutableMap<String, Long> unitValueMap;
+    private final ImmutableMap<String, String> seasonMap;
+    private final ImmutableMap<String, Integer> cardinalMap;
+    private final ImmutableMap<String, Integer> dayOfWeek;
+    private final ImmutableMap<String, Integer> monthOfYear;
+    private final ImmutableMap<String, Integer> numbers;
+    private final ImmutableMap<String, Double> doubleNumbers;
+    private final ImmutableMap<String, Integer> writtenDecades;
+    private final ImmutableMap<String, Integer> specialDecadeCases;
+
+    private final IExtractor cardinalExtractor;
+    private final IExtractor integerExtractor;
+    private final IExtractor ordinalExtractor;
+    private final IParser numberParser;
+
+    private final IDateTimeExtractor durationExtractor;
+    private final IDateExtractor dateExtractor;
+    private final IDateTimeExtractor timeExtractor;
+    private final IDateTimeExtractor dateTimeExtractor;
+    private final IDateTimeExtractor datePeriodExtractor;
+    private final IDateTimeExtractor timePeriodExtractor;
+    private final IDateTimeExtractor dateTimePeriodExtractor;
+
+    //private final IDateTimeParser dateParser;
+    //private final IDateTimeParser timeParser;
+    //private final IDateTimeParser dateTimeParser;
+    //private final IDateTimeParser durationParser;
+    //private final IDateTimeParser datePeriodParser;
+    //private final IDateTimeParser timePeriodParser;
+    //private final IDateTimeParser dateTimePeriodParser;
+    //private final IDateTimeParser dateTimeAltParser;
+
+    public SpanishCommonDateTimeParserConfiguration(DateTimeOptions options) {
+
+        super(options);
+
+        utilityConfiguration = new SpanishDatetimeUtilityConfiguration();
+
+        unitMap = SpanishDateTime.UnitMap;
+        unitValueMap = SpanishDateTime.UnitValueMap;
+        seasonMap = SpanishDateTime.SeasonMap;
+        cardinalMap = SpanishDateTime.CardinalMap;
+        dayOfWeek = SpanishDateTime.DayOfWeek;
+        monthOfYear = SpanishDateTime.MonthOfYear;
+        numbers = SpanishDateTime.Numbers;
+        doubleNumbers = SpanishDateTime.DoubleNumbers;
+        writtenDecades = SpanishDateTime.WrittenDecades;
+        specialDecadeCases = SpanishDateTime.SpecialDecadeCases;
+
+        cardinalExtractor = CardinalExtractor.getInstance();
+        integerExtractor = IntegerExtractor.getInstance();
+        ordinalExtractor = OrdinalExtractor.getInstance();
+
+        numberParser = new BaseNumberParser(new SpanishNumberParserConfiguration());
+
+        dateExtractor = new BaseDateExtractor(new SpanishDateExtractorConfiguration(this));
+        timeExtractor = new BaseTimeExtractor(new SpanishTimeExtractorConfiguration(options));
+        dateTimeExtractor = new BaseDateTimeExtractor(new SpanishDateTimeExtractorConfiguration(options));
+        durationExtractor = new BaseDurationExtractor(new SpanishDurationExtractorConfiguration());
+        datePeriodExtractor = new BaseDatePeriodExtractor(new SpanishDatePeriodExtractorConfiguration(this));
+        timePeriodExtractor = new BaseTimePeriodExtractor(new SpanishTimePeriodExtractorConfiguration(options));
+        dateTimePeriodExtractor = new BaseDateTimePeriodExtractor(new SpanishDateTimePeriodExtractorConfiguration(options));
+
+        //dateParser = new BaseDateParser(new SpanishDateParserConfiguration(this));
+        //timeParser = new TimeParser(new SpanishTimeParserConfiguration(this));
+        //dateTimeParser = new BaseDateTimeParser(new SpanishDateTimeParserConfiguration(this));
+        //durationParser = new BaseDurationParser(new SpanishDurationParserConfiguration(this));
+        //datePeriodParser = new BaseDatePeriodParser(new SpanishDatePeriodParserConfiguration(this));
+        //timePeriodParser = new BaseTimePeriodParser(new SpanishTimePeriodParserConfiguration(this));
+        //dateTimePeriodParser = new BaseDateTimePeriodParser(new SpanishDateTimePeriodParserConfiguration(this));
+        //dateTimeAltParser = new BaseDateTimeAltParser(new SpanishDateTimeAltParserConfiguration(this));
+    }
+
+    @Override
+    public IExtractor getCardinalExtractor() {
+        return cardinalExtractor;
+    }
+
+    @Override
+    public IExtractor getIntegerExtractor() {
+        return integerExtractor;
+    }
+
+    @Override
+    public IExtractor getOrdinalExtractor() {
+        return ordinalExtractor;
+    }
+
+    @Override
+    public IParser getNumberParser() {
+        return numberParser;
+    }
+
+    @Override
+    public IDateExtractor getDateExtractor() {
+        return dateExtractor;
+    }
+
+    @Override
+    public IDateTimeExtractor getTimeExtractor() {
+        return timeExtractor;
+    }
+
+    @Override
+    public IDateTimeExtractor getDateTimeExtractor() {
+        return dateTimeExtractor;
+    }
+
+    @Override
+    public IDateTimeExtractor getDurationExtractor() {
+        return durationExtractor;
+    }
+
+    @Override
+    public IDateTimeExtractor getDatePeriodExtractor() {
+        return datePeriodExtractor;
+    }
+
+    @Override
+    public IDateTimeExtractor getTimePeriodExtractor() {
+        return timePeriodExtractor;
+    }
+
+    @Override
+    public IDateTimeExtractor getDateTimePeriodExtractor() {
+        return dateTimePeriodExtractor;
+    }
+
+    @Override
+    public IDateTimeParser getDateParser() {
+        //return dateParser;
+        return null;
+    }
+
+    @Override
+    public IDateTimeParser getTimeParser() {
+        //return timeParser;
+        return null;
+    }
+
+    @Override
+    public IDateTimeParser getDateTimeParser() {
+        //return dateTimeParser;
+        return null;
+    }
+
+    @Override
+    public IDateTimeParser getDurationParser() {
+        //return durationParser;
+        return null;
+    }
+
+    @Override
+    public IDateTimeParser getDatePeriodParser() {
+        //return datePeriodParser;
+        return null;
+    }
+
+    @Override
+    public IDateTimeParser getTimePeriodParser() {
+        //return timePeriodParser;
+        return null;
+    }
+
+    @Override
+    public IDateTimeParser getDateTimePeriodParser() {
+        //return dateTimePeriodParser;
+        return null;
+    }
+
+    @Override
+    public IDateTimeParser getDateTimeAltParser() {
+        //return dateTimeAltParser;
+        return null;
+    }
+
+    @Override public IDateTimeParser getTimeZoneParser() {
+        return null;
+    }
+
+    @Override
+    public Pattern getAmbiguousMonthP0Regex() {
+        return null;
+    }
+
+    @Override
+    public ImmutableMap<String, Integer> getMonthOfYear() {
+        return monthOfYear;
+    }
+
+    @Override
+    public ImmutableMap<String, Integer> getNumbers() {
+        return numbers;
+    }
+
+    @Override
+    public ImmutableMap<String, Long> getUnitValueMap() {
+        return unitValueMap;
+    }
+
+    @Override
+    public ImmutableMap<String, String> getSeasonMap() {
+        return seasonMap;
+    }
+
+    @Override
+    public ImmutableMap<String, String> getUnitMap() {
+        return unitMap;
+    }
+
+    @Override
+    public ImmutableMap<String, Integer> getCardinalMap() {
+        return cardinalMap;
+    }
+
+    @Override
+    public ImmutableMap<String, Integer> getDayOfWeek() {
+        return dayOfWeek;
+    }
+
+    @Override
+    public ImmutableMap<String, Double> getDoubleNumbers() {
+        return doubleNumbers;
+    }
+
+    @Override
+    public ImmutableMap<String, Integer> getWrittenDecades() {
+        return writtenDecades;
+    }
+
+    @Override
+    public ImmutableMap<String, Integer> getSpecialDecadeCases() {
+        return specialDecadeCases;
+    }
+
+    @Override
+    public IDateTimeUtilityConfiguration getUtilityConfiguration() {
+        return utilityConfiguration;
+    }
+}

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/parsers/SpanishDateParserConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/parsers/SpanishDateParserConfiguration.java
@@ -1,0 +1,331 @@
+package com.microsoft.recognizers.text.datetime.spanish.parsers;
+
+import com.google.common.collect.ImmutableMap;
+import com.microsoft.recognizers.text.IExtractor;
+import com.microsoft.recognizers.text.IParser;
+import com.microsoft.recognizers.text.datetime.config.BaseOptionsConfiguration;
+import com.microsoft.recognizers.text.datetime.extractors.IDateExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.IDateTimeExtractor;
+import com.microsoft.recognizers.text.datetime.parsers.IDateTimeParser;
+import com.microsoft.recognizers.text.datetime.parsers.config.ICommonDateTimeParserConfiguration;
+import com.microsoft.recognizers.text.datetime.parsers.config.IDateParserConfiguration;
+import com.microsoft.recognizers.text.datetime.resources.SpanishDateTime;
+import com.microsoft.recognizers.text.datetime.spanish.extractors.SpanishDateExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.utilities.IDateTimeUtilityConfiguration;
+import com.microsoft.recognizers.text.utilities.RegExpUtility;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class SpanishDateParserConfiguration  extends BaseOptionsConfiguration implements IDateParserConfiguration {
+
+    private final String dateTokenPrefix;
+    private final IExtractor integerExtractor;
+    private final IExtractor ordinalExtractor;
+    private final IExtractor cardinalExtractor;
+    private final IParser numberParser;
+    private final IDateTimeExtractor durationExtractor;
+    private final IDateExtractor dateExtractor;
+    private final IDateTimeParser durationParser;
+    private final ImmutableMap<String, String> unitMap;
+    private final Iterable<Pattern> dateRegexes;
+    private final Pattern onRegex;
+    private final Pattern specialDayRegex;
+    private final Pattern specialDayWithNumRegex;
+    private final Pattern nextRegex;
+    private final Pattern thisRegex;
+    private final Pattern lastRegex;
+    private final Pattern unitRegex;
+    private final Pattern weekDayRegex;
+    private final Pattern monthRegex;
+    private final Pattern weekDayOfMonthRegex;
+    private final Pattern forTheRegex;
+    private final Pattern weekDayAndDayOfMonthRegex;
+    private final Pattern relativeMonthRegex;
+    private final Pattern yearSuffix;
+    private final Pattern relativeWeekDayRegex;
+    private final Pattern relativeDayRegex;
+    private final Pattern nextPrefixRegex;
+    private final Pattern pastPrefixRegex;
+
+    private final ImmutableMap<String, Integer> dayOfMonth;
+    private final ImmutableMap<String, Integer> dayOfWeek;
+    private final ImmutableMap<String, Integer> monthOfYear;
+    private final ImmutableMap<String, Integer> cardinalMap;
+    private final List<String> sameDayTerms;
+    private final List<String> plusOneDayTerms;
+    private final List<String> plusTwoDayTerms;
+    private final List<String> minusOneDayTerms;
+    private final List<String> minusTwoDayTerms;
+    private final IDateTimeUtilityConfiguration utilityConfiguration;
+
+    public SpanishDateParserConfiguration(ICommonDateTimeParserConfiguration config) {
+
+        super(config.getOptions());
+
+        dateTokenPrefix = SpanishDateTime.DateTokenPrefix;
+        integerExtractor = config.getIntegerExtractor();
+        ordinalExtractor = config.getOrdinalExtractor();
+        cardinalExtractor = config.getCardinalExtractor();
+        numberParser = config.getNumberParser();
+        durationExtractor = config.getDurationExtractor();
+        dateExtractor = config.getDateExtractor();
+        durationParser = config.getDurationParser();
+        dateRegexes = Collections.unmodifiableList(SpanishDateExtractorConfiguration.DateRegexList);
+        onRegex = SpanishDateExtractorConfiguration.OnRegex;
+        specialDayRegex = SpanishDateExtractorConfiguration.SpecialDayRegex;
+        specialDayWithNumRegex = SpanishDateExtractorConfiguration.SpecialDayWithNumRegex;
+        nextRegex = SpanishDateExtractorConfiguration.NextDateRegex;
+        thisRegex = SpanishDateExtractorConfiguration.ThisRegex;
+        lastRegex = SpanishDateExtractorConfiguration.LastDateRegex;
+        unitRegex = SpanishDateExtractorConfiguration.DateUnitRegex;
+        weekDayRegex = SpanishDateExtractorConfiguration.WeekDayRegex;
+        monthRegex = SpanishDateExtractorConfiguration.MonthRegex;
+        weekDayOfMonthRegex = SpanishDateExtractorConfiguration.WeekDayOfMonthRegex;
+        forTheRegex = SpanishDateExtractorConfiguration.ForTheRegex;
+        weekDayAndDayOfMonthRegex = SpanishDateExtractorConfiguration.WeekDayAndDayOfMonthRegex;
+        relativeMonthRegex = SpanishDateExtractorConfiguration.RelativeMonthRegex;
+        yearSuffix = SpanishDateExtractorConfiguration.YearSuffix;
+        relativeWeekDayRegex = SpanishDateExtractorConfiguration.RelativeWeekDayRegex;
+        relativeDayRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.RelativeDayRegex);
+        nextPrefixRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.NextPrefixRegex);
+        pastPrefixRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.PastPrefixRegex);
+        dayOfMonth = config.getDayOfMonth();
+        dayOfWeek = config.getDayOfWeek();
+        monthOfYear = config.getMonthOfYear();
+        cardinalMap = config.getCardinalMap();
+        unitMap = config.getUnitMap();
+        utilityConfiguration = config.getUtilityConfiguration();
+        sameDayTerms = Collections.unmodifiableList(SpanishDateTime.SameDayTerms);
+        plusOneDayTerms = Collections.unmodifiableList(SpanishDateTime.PlusOneDayTerms);
+        plusTwoDayTerms = Collections.unmodifiableList(SpanishDateTime.PlusTwoDayTerms);
+        minusOneDayTerms = Collections.unmodifiableList(SpanishDateTime.MinusOneDayTerms);
+        minusTwoDayTerms = Collections.unmodifiableList(SpanishDateTime.MinusTwoDayTerms);
+    }
+
+    @Override
+    public String getDateTokenPrefix() {
+        return dateTokenPrefix;
+    }
+
+    @Override
+    public IExtractor getIntegerExtractor() {
+        return integerExtractor;
+    }
+
+    @Override
+    public IExtractor getOrdinalExtractor() {
+        return ordinalExtractor;
+    }
+
+    @Override
+    public IExtractor getCardinalExtractor() {
+        return cardinalExtractor;
+    }
+
+    @Override
+    public IParser getNumberParser() {
+        return numberParser;
+    }
+
+    @Override
+    public IDateTimeExtractor getDurationExtractor() {
+        return durationExtractor;
+    }
+
+    @Override
+    public IDateExtractor getDateExtractor() {
+        return dateExtractor;
+    }
+
+    @Override
+    public IDateTimeParser getDurationParser() {
+        return durationParser;
+    }
+
+    @Override
+    public Iterable<Pattern> getDateRegexes() {
+        return dateRegexes;
+    }
+
+    @Override
+    public Pattern getOnRegex() {
+        return onRegex;
+    }
+
+    @Override
+    public Pattern getSpecialDayRegex() {
+        return specialDayRegex;
+    }
+
+    @Override
+    public Pattern getSpecialDayWithNumRegex() {
+        return specialDayWithNumRegex;
+    }
+
+    @Override
+    public Pattern getNextRegex() {
+        return nextRegex;
+    }
+
+    @Override
+    public Pattern getThisRegex() {
+        return thisRegex;
+    }
+
+    @Override
+    public Pattern getLastRegex() {
+        return lastRegex;
+    }
+
+    @Override
+    public Pattern getUnitRegex() {
+        return unitRegex;
+    }
+
+    @Override
+    public Pattern getWeekDayRegex() {
+        return weekDayRegex;
+    }
+
+    @Override
+    public Pattern getMonthRegex() {
+        return monthRegex;
+    }
+
+    @Override
+    public Pattern getWeekDayOfMonthRegex() {
+        return weekDayOfMonthRegex;
+    }
+
+    @Override
+    public Pattern getForTheRegex() {
+        return forTheRegex;
+    }
+
+    @Override
+    public Pattern getWeekDayAndDayOfMonthRegex() {
+        return weekDayAndDayOfMonthRegex;
+    }
+
+    @Override
+    public Pattern getRelativeMonthRegex() {
+        return relativeMonthRegex;
+    }
+
+    @Override
+    public Pattern getYearSuffix() {
+        return yearSuffix;
+    }
+
+    @Override
+    public Pattern getRelativeWeekDayRegex() {
+        return relativeWeekDayRegex;
+    }
+
+    @Override
+    public Pattern getRelativeDayRegex() {
+        return relativeDayRegex;
+    }
+
+    @Override
+    public Pattern getNextPrefixRegex() {
+        return nextPrefixRegex;
+    }
+
+    @Override
+    public Pattern getPastPrefixRegex() {
+        return pastPrefixRegex;
+    }
+
+    @Override
+    public ImmutableMap<String, String> getUnitMap() {
+        return unitMap;
+    }
+
+    @Override
+    public ImmutableMap<String, Integer> getDayOfMonth() {
+        return dayOfMonth;
+    }
+
+    @Override
+    public ImmutableMap<String, Integer> getDayOfWeek() {
+        return dayOfWeek;
+    }
+
+    @Override
+    public ImmutableMap<String, Integer> getMonthOfYear() {
+        return monthOfYear;
+    }
+
+    @Override
+    public ImmutableMap<String, Integer> getCardinalMap() {
+        return cardinalMap;
+    }
+
+    @Override
+    public List<String> getSameDayTerms() {
+        return sameDayTerms;
+    }
+
+    @Override
+    public List<String> getPlusOneDayTerms() {
+        return plusOneDayTerms;
+    }
+
+    @Override
+    public List<String> getMinusOneDayTerms() {
+        return minusOneDayTerms;
+    }
+
+    @Override
+    public List<String> getPlusTwoDayTerms() {
+        return plusTwoDayTerms;
+    }
+
+    @Override
+    public List<String> getMinusTwoDayTerms() {
+        return minusTwoDayTerms;
+    }
+
+    @Override
+    public IDateTimeUtilityConfiguration getUtilityConfiguration() {
+        return utilityConfiguration;
+    }
+
+    @Override
+    public Integer getSwiftMonth(String text) {
+        String trimmedText = text.trim().toLowerCase(Locale.ROOT);
+        int swift = 0;
+
+        Matcher regexMatcher = nextPrefixRegex.matcher(trimmedText);
+        if (regexMatcher.find()) {
+            swift = 1;
+        }
+
+        regexMatcher = pastPrefixRegex.matcher(trimmedText);
+        if (regexMatcher.find()) {
+            swift = -1;
+        }
+
+        return swift;
+    }
+
+    @Override
+    public Boolean isCardinalLast(String text) {
+        String trimmedText = text.trim().toLowerCase();
+        return trimmedText.equals("last");
+    }
+
+    @Override
+    public String normalize(String text) {
+        return text.replace('á', 'a')
+                .replace('é', 'e')
+                .replace('í', 'i')
+                .replace('ó', 'o')
+                .replace('ú', 'u');
+    }
+}

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/parsers/SpanishDurationParserConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/parsers/SpanishDurationParserConfiguration.java
@@ -1,0 +1,145 @@
+package com.microsoft.recognizers.text.datetime.spanish.parsers;
+
+import com.google.common.collect.ImmutableMap;
+import com.microsoft.recognizers.text.IExtractor;
+import com.microsoft.recognizers.text.IParser;
+import com.microsoft.recognizers.text.datetime.config.BaseOptionsConfiguration;
+import com.microsoft.recognizers.text.datetime.extractors.BaseDurationExtractor;
+import com.microsoft.recognizers.text.datetime.parsers.config.ICommonDateTimeParserConfiguration;
+import com.microsoft.recognizers.text.datetime.parsers.config.IDurationParserConfiguration;
+import com.microsoft.recognizers.text.datetime.spanish.extractors.SpanishDurationExtractorConfiguration;
+
+import java.util.regex.Pattern;
+
+public class SpanishDurationParserConfiguration extends BaseOptionsConfiguration implements IDurationParserConfiguration {
+
+    private final IExtractor cardinalExtractor;
+    private final IExtractor durationExtractor;
+    private final IParser numberParser;
+
+    private final Pattern numberCombinedWithUnit;
+    private final Pattern anUnitRegex;
+    private final Pattern duringRegex;
+    private final Pattern allDateUnitRegex;
+    private final Pattern halfDateUnitRegex;
+    private final Pattern suffixAndRegex;
+    private final Pattern followedUnit;
+    private final Pattern conjunctionRegex;
+    private final Pattern inexactNumberRegex;
+    private final Pattern inexactNumberUnitRegex;
+    private final Pattern durationUnitRegex;
+
+    private final ImmutableMap<String, String> unitMap;
+    private final ImmutableMap<String, Long> unitValueMap;
+    private final ImmutableMap<String, Double> doubleNumbers;
+
+    public SpanishDurationParserConfiguration(ICommonDateTimeParserConfiguration config) {
+
+        super(config.getOptions());
+
+        cardinalExtractor = config.getCardinalExtractor();
+        numberParser = config.getNumberParser();
+        durationExtractor = new BaseDurationExtractor(new SpanishDurationExtractorConfiguration(), false);
+        numberCombinedWithUnit = SpanishDurationExtractorConfiguration.NumberCombinedWithUnit;
+
+        anUnitRegex = SpanishDurationExtractorConfiguration.AnUnitRegex;
+        duringRegex = SpanishDurationExtractorConfiguration.DuringRegex;
+        allDateUnitRegex = SpanishDurationExtractorConfiguration.AllRegex;
+        halfDateUnitRegex = SpanishDurationExtractorConfiguration.HalfRegex;
+        suffixAndRegex = SpanishDurationExtractorConfiguration.SuffixAndRegex;
+        followedUnit = SpanishDurationExtractorConfiguration.FollowedUnit;
+        conjunctionRegex = SpanishDurationExtractorConfiguration.ConjunctionRegex;
+        inexactNumberRegex = SpanishDurationExtractorConfiguration.InexactNumberRegex;
+        inexactNumberUnitRegex = SpanishDurationExtractorConfiguration.InexactNumberUnitRegex;
+        durationUnitRegex = SpanishDurationExtractorConfiguration.DurationUnitRegex;
+
+        unitMap = config.getUnitMap();
+        unitValueMap = config.getUnitValueMap();
+        doubleNumbers = config.getDoubleNumbers();
+    }
+
+    @Override
+    public IExtractor getCardinalExtractor() {
+        return cardinalExtractor;
+    }
+
+    @Override
+    public IExtractor getDurationExtractor() {
+        return durationExtractor;
+    }
+
+    @Override
+    public IParser getNumberParser() {
+        return numberParser;
+    }
+
+    @Override
+    public Pattern getNumberCombinedWithUnit() {
+        return numberCombinedWithUnit;
+    }
+
+    @Override
+    public Pattern getAnUnitRegex() {
+        return anUnitRegex;
+    }
+
+    @Override
+    public Pattern getDuringRegex() {
+        return duringRegex;
+    }
+
+    @Override
+    public Pattern getAllDateUnitRegex() {
+        return allDateUnitRegex;
+    }
+
+    @Override
+    public Pattern getHalfDateUnitRegex() {
+        return halfDateUnitRegex;
+    }
+
+    @Override
+    public Pattern getSuffixAndRegex() {
+        return suffixAndRegex;
+    }
+
+    @Override
+    public Pattern getFollowedUnit() {
+        return followedUnit;
+    }
+
+    @Override
+    public Pattern getConjunctionRegex() {
+        return conjunctionRegex;
+    }
+
+    @Override
+    public Pattern getInexactNumberRegex() {
+        return inexactNumberRegex;
+    }
+
+    @Override
+    public Pattern getInexactNumberUnitRegex() {
+        return inexactNumberUnitRegex;
+    }
+
+    @Override
+    public Pattern getDurationUnitRegex() {
+        return durationUnitRegex;
+    }
+
+    @Override
+    public ImmutableMap<String, String> getUnitMap() {
+        return unitMap;
+    }
+
+    @Override
+    public ImmutableMap<String, Long> getUnitValueMap() {
+        return unitValueMap;
+    }
+
+    @Override
+    public ImmutableMap<String, Double> getDoubleNumbers() {
+        return doubleNumbers;
+    }
+}

--- a/Java/tests/src/test/java/com/microsoft/recognizers/text/tests/datetime/DateTimeParserTest.java
+++ b/Java/tests/src/test/java/com/microsoft/recognizers/text/tests/datetime/DateTimeParserTest.java
@@ -36,6 +36,7 @@ import com.microsoft.recognizers.text.datetime.parsers.BaseTimeZoneParser;
 import com.microsoft.recognizers.text.datetime.parsers.DateTimeParseResult;
 import com.microsoft.recognizers.text.datetime.parsers.IDateTimeParser;
 import com.microsoft.recognizers.text.datetime.spanish.parsers.SpanishCommonDateTimeParserConfiguration;
+import com.microsoft.recognizers.text.datetime.spanish.parsers.SpanishDateParserConfiguration;
 import com.microsoft.recognizers.text.datetime.spanish.parsers.SpanishDurationParserConfiguration;
 import com.microsoft.recognizers.text.datetime.utilities.DateTimeResolutionResult;
 import com.microsoft.recognizers.text.datetime.utilities.TimeZoneResolutionResult;
@@ -212,8 +213,8 @@ public class DateTimeParserTest extends AbstractTest {
     private static IDateTimeParser getSpanishParser(String name) {
 
         switch (name) {
-            //case "DateParser":
-            //    return new BaseDateParser(new SpanishDateParserConfiguration(new SpanishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
+            case "DateParser":
+                return new BaseDateParser(new SpanishDateParserConfiguration(new SpanishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
             //case "DatePeriodParser":
             //    return new BaseDatePeriodParser(new SpanishDatePeriodParserConfiguration(new SpanishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
             //case "DateTimeAltParser":

--- a/Java/tests/src/test/java/com/microsoft/recognizers/text/tests/datetime/DateTimeParserTest.java
+++ b/Java/tests/src/test/java/com/microsoft/recognizers/text/tests/datetime/DateTimeParserTest.java
@@ -165,6 +165,8 @@ public class DateTimeParserTest extends AbstractTest {
             switch (culture) {
                 case Culture.English:
                     return getEnglishParser(name);
+                case Culture.Spanish:
+                    return getSpanishParser(name);
                 default:
                     throw new AssumptionViolatedException("Parser Type/Name not supported.");
             }

--- a/Java/tests/src/test/java/com/microsoft/recognizers/text/tests/datetime/DateTimeParserTest.java
+++ b/Java/tests/src/test/java/com/microsoft/recognizers/text/tests/datetime/DateTimeParserTest.java
@@ -35,6 +35,8 @@ import com.microsoft.recognizers.text.datetime.parsers.BaseTimePeriodParser;
 import com.microsoft.recognizers.text.datetime.parsers.BaseTimeZoneParser;
 import com.microsoft.recognizers.text.datetime.parsers.DateTimeParseResult;
 import com.microsoft.recognizers.text.datetime.parsers.IDateTimeParser;
+import com.microsoft.recognizers.text.datetime.spanish.parsers.SpanishCommonDateTimeParserConfiguration;
+import com.microsoft.recognizers.text.datetime.spanish.parsers.SpanishDurationParserConfiguration;
 import com.microsoft.recognizers.text.datetime.utilities.DateTimeResolutionResult;
 import com.microsoft.recognizers.text.datetime.utilities.TimeZoneResolutionResult;
 import com.microsoft.recognizers.text.tests.AbstractTest;
@@ -220,8 +222,8 @@ public class DateTimeParserTest extends AbstractTest {
             //    return new BaseDateTimeParser(new SpanishDateTimeParserConfiguration(new SpanishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
             //case "DateTimePeriodParser":
             //    return new BaseDateTimePeriodParser(new SpanishDateTimePeriodParserConfiguration(new SpanishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
-            //case "DurationParser":
-            //    return new BaseDurationParser(new SpanishDurationParserConfiguration(new SpanishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
+            case "DurationParser":
+                return new BaseDurationParser(new SpanishDurationParserConfiguration(new SpanishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
             //case "HolidayParser":
             //    return new BaseHolidayParser(new SpanishHolidayParserConfiguration());
             //case "SetParser":

--- a/Java/tests/src/test/java/com/microsoft/recognizers/text/tests/datetime/DateTimeParserTest.java
+++ b/Java/tests/src/test/java/com/microsoft/recognizers/text/tests/datetime/DateTimeParserTest.java
@@ -205,6 +205,36 @@ public class DateTimeParserTest extends AbstractTest {
         }
     }
 
+    private static IDateTimeParser getSpanishParser(String name) {
+
+        switch (name) {
+            //case "DateParser":
+            //    return new BaseDateParser(new SpanishDateParserConfiguration(new SpanishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
+            //case "DatePeriodParser":
+            //    return new BaseDatePeriodParser(new SpanishDatePeriodParserConfiguration(new SpanishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
+            //case "DateTimeAltParser":
+            //    return new BaseDateTimeAltParser(new EnglishDateTimeAltParserConfiguration(new EnglishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
+            //case "DateTimeParser":
+            //    return new BaseDateTimeParser(new SpanishDateTimeParserConfiguration(new SpanishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
+            //case "DateTimePeriodParser":
+            //    return new BaseDateTimePeriodParser(new SpanishDateTimePeriodParserConfiguration(new SpanishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
+            //case "DurationParser":
+            //    return new BaseDurationParser(new SpanishDurationParserConfiguration(new SpanishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
+            //case "HolidayParser":
+            //    return new BaseHolidayParser(new SpanishHolidayParserConfiguration());
+            //case "SetParser":
+            //    return new BaseSetParser(new SpanishSetParserConfiguration(new SpanishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
+            //case "MergedParser":
+            //    return new BaseMergedDateTimeParser(new EnglishMergedParserConfiguration(DateTimeOptions.None));
+            //case "TimeParser":
+            //    return new TimeParser(new SpanishTimeParserConfiguration(new SpanishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
+            //case "TimePeriodParser":
+            //    return new BaseTimePeriodParser(new SpanishTimePeriodParserConfiguration(new SpanishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
+            default:
+                throw new AssumptionViolatedException("Parser Type/Name not supported.");
+        }
+    }
+
     private IDateTimeExtractor getExtractor(TestCase currentCase) {
 
         String extractorName = currentCase.modelName.replace("Parser", "Extractor");


### PR DESCRIPTION
**Note:** This branch is based on #67, also includes changes changes in #69. We will rebase once they are merged with master. 

---
# Description
- Enable `DateParser` tests
- Port `SpanishDateParserConfiguration` from C# to Java
- Fix `DateRegexList` values assignation

# Passing Tests
![image](https://user-images.githubusercontent.com/39467613/50922540-89d28280-1429-11e9-911b-578a940acb32.png)
