### PR TITLE
[Java][Datetime] Port SpanishTimePeriodParserConfiguration from C# to Java

### DIFF
--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/english/extractors/EnglishTimePeriodExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/english/extractors/EnglishTimePeriodExtractorConfiguration.java
@@ -47,9 +47,6 @@ public class EnglishTimePeriodExtractorConfiguration extends BaseOptionsConfigur
         this(DateTimeOptions.None);
     }
 
-    //C# TO JAVA CONVERTER WARNING: The following constructor is declared outside of its associated class:
-    //ORIGINAL LINE: public EnglishTimePeriodExtractorConfiguration(DateTimeOptions options = DateTimeOptions.None)
-    //C# TO JAVA CONVERTER NOTE: Java does not support optional parameters. Overloaded method(s) are created above:
     public EnglishTimePeriodExtractorConfiguration(DateTimeOptions options) {
 
         super(options);

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/parsers/SpanishCommonDateTimeParserConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/parsers/SpanishCommonDateTimeParserConfiguration.java
@@ -75,9 +75,9 @@ public class SpanishCommonDateTimeParserConfiguration extends BaseDateParserConf
     //private final IDateTimeParser dateParser;
     private final IDateTimeParser timeParser;
     //private final IDateTimeParser dateTimeParser;
-    //private final IDateTimeParser durationParser;
+    private final IDateTimeParser durationParser;
     //private final IDateTimeParser datePeriodParser;
-    //private final IDateTimeParser timePeriodParser;
+    private final IDateTimeParser timePeriodParser;
     //private final IDateTimeParser dateTimePeriodParser;
     //private final IDateTimeParser dateTimeAltParser;
 
@@ -115,9 +115,9 @@ public class SpanishCommonDateTimeParserConfiguration extends BaseDateParserConf
         //dateParser = new BaseDateParser(new SpanishDateParserConfiguration(this));
         timeParser = new TimeParser(new SpanishTimeParserConfiguration(this));
         //dateTimeParser = new BaseDateTimeParser(new SpanishDateTimeParserConfiguration(this));
-        //durationParser = new BaseDurationParser(new SpanishDurationParserConfiguration(this));
+        durationParser = new BaseDurationParser(new SpanishDurationParserConfiguration(this));
         //datePeriodParser = new BaseDatePeriodParser(new SpanishDatePeriodParserConfiguration(this));
-        //timePeriodParser = new BaseTimePeriodParser(new SpanishTimePeriodParserConfiguration(this));
+        timePeriodParser = new BaseTimePeriodParser(new SpanishTimePeriodParserConfiguration(this));
         //dateTimePeriodParser = new BaseDateTimePeriodParser(new SpanishDateTimePeriodParserConfiguration(this));
         //dateTimeAltParser = new BaseDateTimeAltParser(new SpanishDateTimeAltParserConfiguration(this));
     }
@@ -196,8 +196,7 @@ public class SpanishCommonDateTimeParserConfiguration extends BaseDateParserConf
 
     @Override
     public IDateTimeParser getDurationParser() {
-        //return durationParser;
-        return null;
+        return durationParser;
     }
 
     @Override
@@ -208,8 +207,7 @@ public class SpanishCommonDateTimeParserConfiguration extends BaseDateParserConf
 
     @Override
     public IDateTimeParser getTimePeriodParser() {
-        //return timePeriodParser;
-        return null;
+        return timePeriodParser;
     }
 
     @Override

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/parsers/SpanishTimePeriodParserConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/parsers/SpanishTimePeriodParserConfiguration.java
@@ -1,0 +1,152 @@
+package com.microsoft.recognizers.text.datetime.spanish.parsers;
+
+import com.google.common.collect.ImmutableMap;
+import com.microsoft.recognizers.text.IExtractor;
+import com.microsoft.recognizers.text.datetime.Constants;
+import com.microsoft.recognizers.text.datetime.config.BaseOptionsConfiguration;
+import com.microsoft.recognizers.text.datetime.extractors.IDateTimeExtractor;
+import com.microsoft.recognizers.text.datetime.parsers.IDateTimeParser;
+import com.microsoft.recognizers.text.datetime.parsers.config.ICommonDateTimeParserConfiguration;
+import com.microsoft.recognizers.text.datetime.parsers.config.ITimePeriodParserConfiguration;
+import com.microsoft.recognizers.text.datetime.parsers.config.MatchedTimeRangeResult;
+import com.microsoft.recognizers.text.datetime.resources.SpanishDateTime;
+import com.microsoft.recognizers.text.datetime.spanish.extractors.SpanishTimePeriodExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.utilities.IDateTimeUtilityConfiguration;
+import com.microsoft.recognizers.text.datetime.utilities.TimeOfDayResolutionResult;
+import com.microsoft.recognizers.text.datetime.utilities.TimexUtility;
+
+import java.util.regex.Pattern;
+
+public class SpanishTimePeriodParserConfiguration extends BaseOptionsConfiguration implements ITimePeriodParserConfiguration {
+
+    private final IDateTimeExtractor timeExtractor;
+    private final IDateTimeParser timeParser;
+    private final IExtractor integerExtractor;
+    private final IDateTimeParser timeZoneParser;
+
+    private final Pattern pureNumberFromToRegex;
+    private final Pattern pureNumberBetweenAndRegex;
+    private final Pattern specificTimeFromToRegex;
+    private final Pattern specificTimeBetweenAndRegex;
+    private final Pattern timeOfDayRegex;
+    private final Pattern generalEndingRegex;
+    private final Pattern tillRegex;
+
+    private final ImmutableMap<String, Integer> numbers;
+    private final IDateTimeUtilityConfiguration utilityConfiguration;
+
+    public SpanishTimePeriodParserConfiguration(ICommonDateTimeParserConfiguration config) {
+
+        super(config.getOptions());
+
+        timeExtractor = config.getTimeExtractor();
+        integerExtractor = config.getIntegerExtractor();
+        timeParser = config.getTimeParser();
+        timeZoneParser = config.getTimeZoneParser();
+        pureNumberFromToRegex = SpanishTimePeriodExtractorConfiguration.PureNumFromTo;
+        pureNumberBetweenAndRegex = SpanishTimePeriodExtractorConfiguration.PureNumBetweenAnd;
+        specificTimeFromToRegex = SpanishTimePeriodExtractorConfiguration.SpecificTimeFromTo;
+        specificTimeBetweenAndRegex = SpanishTimePeriodExtractorConfiguration.SpecificTimeBetweenAnd;
+        timeOfDayRegex = SpanishTimePeriodExtractorConfiguration.TimeOfDayRegex;
+        generalEndingRegex = SpanishTimePeriodExtractorConfiguration.GeneralEndingRegex;
+        tillRegex = SpanishTimePeriodExtractorConfiguration.TillRegex;
+        numbers = config.getNumbers();
+        utilityConfiguration = config.getUtilityConfiguration();
+    }
+
+    @Override
+    public IDateTimeExtractor getTimeExtractor() {
+        return timeExtractor;
+    }
+
+    @Override
+    public IDateTimeParser getTimeParser() {
+        return timeParser;
+    }
+
+    @Override
+    public IExtractor getIntegerExtractor() {
+        return integerExtractor;
+    }
+
+    @Override
+    public IDateTimeParser getTimeZoneParser() {
+        return timeZoneParser;
+    }
+
+    @Override
+    public Pattern getPureNumberFromToRegex() {
+        return pureNumberFromToRegex;
+    }
+
+    @Override
+    public Pattern getPureNumberBetweenAndRegex() {
+        return pureNumberBetweenAndRegex;
+    }
+
+    @Override
+    public Pattern getSpecificTimeFromToRegex() {
+        return specificTimeFromToRegex;
+    }
+
+    @Override
+    public Pattern getSpecificTimeBetweenAndRegex() {
+        return specificTimeBetweenAndRegex;
+    }
+
+    @Override
+    public Pattern getTimeOfDayRegex() {
+        return timeOfDayRegex;
+    }
+
+    @Override
+    public Pattern getGeneralEndingRegex() {
+        return generalEndingRegex;
+    }
+
+    @Override
+    public Pattern getTillRegex() {
+        return tillRegex;
+    }
+
+    @Override
+    public ImmutableMap<String, Integer> getNumbers() {
+        return numbers;
+    }
+
+    @Override
+    public IDateTimeUtilityConfiguration getUtilityConfiguration() {
+        return utilityConfiguration;
+    }
+
+    @Override
+    public MatchedTimeRangeResult getMatchedTimexRange(String text, String timex, int beginHour, int endHour, int endMin) {
+
+        String trimmedText = text.trim().toLowerCase();
+
+        beginHour = 0;
+        endHour = 0;
+        endMin = 0;
+
+        String timeOfDay = "";
+
+        if (SpanishDateTime.EarlyMorningTermList.stream().anyMatch(trimmedText::endsWith)) {
+            timeOfDay = Constants.EarlyMorning;
+        } else if (SpanishDateTime.MorningTermList.stream().anyMatch(trimmedText::endsWith)) {
+            timeOfDay = Constants.Morning;
+        } else if (SpanishDateTime.AfternoonTermList.stream().anyMatch(trimmedText::endsWith)) {
+            timeOfDay = Constants.Afternoon;
+        } else if (SpanishDateTime.EveningTermList.stream().anyMatch(trimmedText::endsWith)) {
+            timeOfDay = Constants.Evening;
+        } else if (SpanishDateTime.NightTermList.stream().anyMatch(trimmedText::endsWith)) {
+            timeOfDay = Constants.Night;
+        } else {
+            timex = null;
+            return new MatchedTimeRangeResult(false, timex, beginHour, endHour, endMin);
+        }
+
+        TimeOfDayResolutionResult result = TimexUtility.parseTimeOfDay(timeOfDay);
+
+        return new MatchedTimeRangeResult(true, result.getTimex(), result.getBeginHour(), result.getEndHour(), result.getEndMin());
+    }
+}

--- a/Java/tests/src/test/java/com/microsoft/recognizers/text/tests/datetime/DateTimeParserTest.java
+++ b/Java/tests/src/test/java/com/microsoft/recognizers/text/tests/datetime/DateTimeParserTest.java
@@ -36,6 +36,7 @@ import com.microsoft.recognizers.text.datetime.parsers.BaseTimeZoneParser;
 import com.microsoft.recognizers.text.datetime.parsers.DateTimeParseResult;
 import com.microsoft.recognizers.text.datetime.parsers.IDateTimeParser;
 import com.microsoft.recognizers.text.datetime.spanish.parsers.SpanishCommonDateTimeParserConfiguration;
+import com.microsoft.recognizers.text.datetime.spanish.parsers.SpanishTimePeriodParserConfiguration;
 import com.microsoft.recognizers.text.datetime.spanish.parsers.SpanishDurationParserConfiguration;
 import com.microsoft.recognizers.text.datetime.spanish.parsers.SpanishTimeParserConfiguration;
 import com.microsoft.recognizers.text.datetime.utilities.DateTimeResolutionResult;
@@ -233,8 +234,8 @@ public class DateTimeParserTest extends AbstractTest {
             //    return new BaseMergedDateTimeParser(new EnglishMergedParserConfiguration(DateTimeOptions.None));
             case "TimeParser":
                 return new TimeParser(new SpanishTimeParserConfiguration(new SpanishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
-            //case "TimePeriodParser":
-            //    return new BaseTimePeriodParser(new SpanishTimePeriodParserConfiguration(new SpanishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
+            case "TimePeriodParser":
+                return new BaseTimePeriodParser(new SpanishTimePeriodParserConfiguration(new SpanishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
             default:
                 throw new AssumptionViolatedException("Parser Type/Name not supported.");
         }


### PR DESCRIPTION
# Description
- Enable `SpanishTimePeriodParser` tests
- Port `SpanishTimePeriodParserConfiguration` from [C#](https://github.com/Microsoft/Recognizers-Text/blob/master/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishTimePeriodParserConfiguration.cs) to Java

# Evidence

![image](https://user-images.githubusercontent.com/42191764/50975564-b095c500-14cc-11e9-9be9-4b5d742105e3.png)
