### PR TITLE
[StyleCop] Fix all the warnings in SequenceEnglish

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.Sequence/English/Extractors/EmailExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Sequence/English/Extractors/EmailExtractor.cs
@@ -2,6 +2,5 @@
 {
     public class EmailExtractor : BaseEmailExtractor
     {
-
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.Sequence/English/Extractors/GUIDExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Sequence/English/Extractors/GUIDExtractor.cs
@@ -2,6 +2,5 @@
 {
     public class GUIDExtractor : BaseGUIDExtractor
     {
-
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.Sequence/English/Extractors/HashTagExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Sequence/English/Extractors/HashTagExtractor.cs
@@ -2,6 +2,5 @@
 {
     public class HashtagExtractor : BaseHashtagExtractor
     {
-
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.Sequence/English/Extractors/IpExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Sequence/English/Extractors/IpExtractor.cs
@@ -2,6 +2,5 @@
 {
     public class IpExtractor : BaseIpExtractor
     {
-       
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.Sequence/English/Extractors/MentionExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Sequence/English/Extractors/MentionExtractor.cs
@@ -2,6 +2,5 @@
 {
     public class MentionExtractor : BaseMentionExtractor
     {
-
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.Sequence/English/Extractors/PhoneNumberExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Sequence/English/Extractors/PhoneNumberExtractor.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
-using System.Text.RegularExpressions;
 using System.Linq;
+using System.Text.RegularExpressions;
 using Microsoft.Recognizers.Definitions;
 
 namespace Microsoft.Recognizers.Text.Sequence.English
@@ -24,6 +24,7 @@ namespace Microsoft.Recognizers.Text.Sequence.English
                     }
                 }
             }
+
             return result;
         }
     }

--- a/.NET/Microsoft.Recognizers.Text.Sequence/English/Extractors/URLExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Sequence/English/Extractors/URLExtractor.cs
@@ -2,6 +2,5 @@
 {
     public class URLExtractor : BaseURLExtractor
     {
-
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.Sequence/English/Parsers/EmailParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.Sequence/English/Parsers/EmailParser.cs
@@ -4,7 +4,6 @@
     {
         public EmailParser()
         {
-
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.Sequence/English/Parsers/GUIDParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.Sequence/English/Parsers/GUIDParser.cs
@@ -17,19 +17,19 @@ namespace Microsoft.Recognizers.Text.Sequence.English
 
         private static readonly Regex GuidElementRegex = new Regex(BaseGUID.GUIDRegexElement, RegexOptions.Compiled);
 
-        double ScoreGUID(string GUIDText)
+        public double ScoreGUID(string TextGUID)
         {
             double score = baseScore;
 
-            
-            Match elementMatch = GuidElementRegex.Match(GUIDText);
+
+            Match elementMatch = GuidElementRegex.Match(TextGUID);
             if (elementMatch.Success)
             {
                 int startIndex = elementMatch.Groups[1].Index;
                 string guidElement = elementMatch.Groups[1].Value;
                 score -= startIndex == 0 ? noBoundaryPenalty : 0;
                 score -= Regex.IsMatch(guidElement, formatRegex) ? 0 : noFormatPenalty;
-                score -= Regex.IsMatch(GUIDText, pureDigitRegex) ? pureDigitPenalty : 0;
+                score -= Regex.IsMatch(TextGUID, pureDigitRegex) ? pureDigitPenalty : 0;
             }
 
             return Math.Max(Math.Min(score, scoreUpperLimit), scoreLowerLimit) / (scoreUpperLimit - scoreLowerLimit);
@@ -44,7 +44,7 @@ namespace Microsoft.Recognizers.Text.Sequence.English
                 Text = extResult.Text,
                 Type = extResult.Type,
                 ResolutionStr = extResult.Text,
-                Value = ScoreGUID(extResult.Text)
+                Value = ScoreGUID(extResult.Text),
             };
 
             return result;

--- a/.NET/Microsoft.Recognizers.Text.Sequence/English/Parsers/HashTagParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.Sequence/English/Parsers/HashTagParser.cs
@@ -4,7 +4,6 @@
     {
         public HashtagParser()
         {
-
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.Sequence/English/Parsers/IpParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.Sequence/English/Parsers/IpParser.cs
@@ -4,7 +4,6 @@
     { 
         public IpParser()
         {
-
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.Sequence/English/Parsers/MentionParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.Sequence/English/Parsers/MentionParser.cs
@@ -4,7 +4,6 @@
     {
         public MentionParser()
         {
-
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.Sequence/English/Parsers/PhoneNumberParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.Sequence/English/Parsers/PhoneNumberParser.cs
@@ -37,11 +37,11 @@ namespace Microsoft.Recognizers.Text.Sequence.English
         private static readonly Regex AreaCodeRegex = new Regex(BasePhoneNumbers.AreaCodeIndicatorRegex);
         private static readonly Regex FormatIndicatorRegex = new Regex(BasePhoneNumbers.FormatIndicatorRegex);
 
-        double ScorePhoneNumber(string phoneNumberText)
+        public double ScorePhoneNumber(string phoneNumberText)
         {
             double score = baseScore;
 
-            // Country code score or area code score 
+            // Country code score or area code score
             score += CountryCodeRegex.IsMatch(phoneNumberText) ?
                                     countryCodeAward : AreaCodeRegex.IsMatch(phoneNumberText) ? areaCodeAward : 0;
 
@@ -52,7 +52,7 @@ namespace Microsoft.Recognizers.Text.Sequence.English
                 int formatIndicatorCount = formatMatches.Count;
                 score += Math.Min(formatIndicatorCount, maxFormatIndicatorNum) * formattedAward;
                 score -= formatMatches.Cast<Match>().Any(o => o.Value.Length > 1) ? continueFormatIndicatorDeductionScore : 0;
-                if (Regex.IsMatch(phoneNumberText, singleBracketRegex) && 
+                if (Regex.IsMatch(phoneNumberText, singleBracketRegex) &&
                     !Regex.IsMatch(phoneNumberText, completeBracketRegex))
                 {
                     score -= wrongFormatDeductionScore;
@@ -60,7 +60,7 @@ namespace Microsoft.Recognizers.Text.Sequence.English
             }
 
             // Length score
-            score += Math.Min((Regex.Matches(phoneNumberText, digitRegex).Count - phoneNumberLengthBase), maxLengthAwardNum) * lengthAward;
+            score += Math.Min(Regex.Matches(phoneNumberText, digitRegex).Count - phoneNumberLengthBase, maxLengthAwardNum) * lengthAward;
 
             // Same tailing digit deduction
             if (Regex.IsMatch(phoneNumberText, tailSameDigitRegex))
@@ -83,7 +83,7 @@ namespace Microsoft.Recognizers.Text.Sequence.English
 
             return Math.Max(Math.Min(score, scoreUpperLimit), scoreLowerLimit) / (scoreUpperLimit - scoreLowerLimit);
         }
-        
+
         public override ParseResult Parse(ExtractResult extResult)
         {
             var result = new ParseResult

--- a/.NET/Microsoft.Recognizers.Text.Sequence/English/Parsers/URLParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.Sequence/English/Parsers/URLParser.cs
@@ -4,7 +4,6 @@
     {
         public URLParser()
         {
-
         }
     }
 }


### PR DESCRIPTION
Files:
Extractors/EmailExtractor.cs
Extractors/GUIDExtractor.cs
Extractors/HashTagExtractor.cs
Extractors/IpExtractor.cs
Extractors/MentionExtractor.cs
Extractors/PhoneNumberExtractor.cs
Extractors/URLExtractor.cs
Parsers/EmailParser.cs
Parsers/GUIDParser.cs
Parsers/HashTagParser.cs
Parsers/IpParser.cs
Parsers/MentionParser.cs
Parsers/PhoneNumberParser.cs
Parsers/URLParser.cs

Warnings:
Spacing
Accessors
Variables names