### PR TITLE
[StyleCop] Fix all warnings in DateTime project's files (Reordered methods and using)

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/ChineseDateTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/ChineseDateTimeParserConfiguration.cs
@@ -8,7 +8,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
 {
     public class ChineseDateTimeParserConfiguration : BaseOptionsConfiguration, IFullDateTimeParserConfiguration
     {
-        public ChineseDateTimeParserConfiguration(DateTimeOptions options = DateTimeOptions.None) : base(options)
+        public ChineseDateTimeParserConfiguration(DateTimeOptions options = DateTimeOptions.None)
+            : base(options)
         {
             DateParser = new DateParser(this);
             TimeParser = new TimeParserChs(this);
@@ -51,8 +52,6 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
 
         public string DatePrefix => DateTimeDefinitions.ParserConfigurationDatePrefix;
 
-        #region internalParsers
-
         public IDateTimeParser DateParser { get; }
 
         public IDateTimeParser TimeParser { get; }
@@ -71,10 +70,6 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
 
         public IDateTimeParser HolidayParser { get; }
 
-        #endregion
-
-        #region Dictionaries
-
         public ImmutableDictionary<string, string> UnitMap { get; }
 
         public ImmutableDictionary<string, long> UnitValueMap { get; }
@@ -92,10 +87,6 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
         public ImmutableDictionary<string, int> MonthOfYear { get; }
 
         public ImmutableDictionary<string, int> Numbers { get; }
-
-        #endregion
-
-        #region Regexes
 
         public IEnumerable<Regex> DateRegexList { get; }
 
@@ -118,15 +109,6 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
         public Regex SincePrefixRegex { get; }
 
         public Regex SinceSuffixRegex { get; }
-
-        #endregion
-
-        private static ImmutableDictionary<string, int> InitNumbers()
-        {
-            return new Dictionary<string, int>
-            {
-            }.ToImmutableDictionary();
-        }
 
         public int GetSwiftDay(string text)
         {
@@ -162,6 +144,13 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
             }
 
             return value;
+        }
+
+        private static ImmutableDictionary<string, int> InitNumbers()
+        {
+            return new Dictionary<string, int>
+            {
+            }.ToImmutableDictionary();
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/DateTimeRecognizer.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/DateTimeRecognizer.cs
@@ -6,8 +6,6 @@ using Microsoft.Recognizers.Text.DateTime.French;
 using Microsoft.Recognizers.Text.DateTime.German;
 using Microsoft.Recognizers.Text.DateTime.Portuguese;
 using Microsoft.Recognizers.Text.DateTime.Spanish;
-using Microsoft.Recognizers.Text.DateTime.Italian;
-using Microsoft.Recognizers.Text.DateTime.Japanese;
 
 namespace Microsoft.Recognizers.Text.DateTime
 {
@@ -33,16 +31,16 @@ namespace Microsoft.Recognizers.Text.DateTime
         {
         }
 
-        public DateTimeModel GetDateTimeModel(string culture = null, bool fallbackToDefaultCulture = true)
-        {
-            return GetModel<DateTimeModel>(culture, fallbackToDefaultCulture);
-        }
-
         public static List<ModelResult> RecognizeDateTime(string query, string culture, DateTimeOptions options = DateTimeOptions.None, System.DateTime? refTime = null, bool fallbackToDefaultCulture = true)
         {
             var recognizer = new DateTimeRecognizer(options);
             var model = recognizer.GetDateTimeModel(culture, fallbackToDefaultCulture);
             return model.Parse(query, refTime ?? System.DateTime.Now);
+        }
+
+        public DateTimeModel GetDateTimeModel(string culture = null, bool fallbackToDefaultCulture = true)
+        {
+            return GetModel<DateTimeModel>(culture, fallbackToDefaultCulture);
         }
 
         protected override void InitializeConfiguration()
@@ -98,11 +96,11 @@ namespace Microsoft.Recognizers.Text.DateTime
                     new BaseMergedDateTimeExtractor(new GermanMergedExtractorConfiguration(options))));
 
             // TODO to be uncommented when all tests for Japanese are green.
-            //RegisterModel<DateTimeModel>(
+            // RegisterModel<DateTimeModel>(
             //    Culture.Japanese,
             //    options => new DateTimeModel(
             //      new FullDateTimeParser(new JapaneseDateTimeParserConfiguration(options)),
-            //      new JapaneseMergedExtractor(options))); 
+            //      new JapaneseMergedExtractor(options)));
     }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishDateParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishDateParserConfiguration.cs
@@ -1,14 +1,56 @@
 ﻿using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Text.RegularExpressions;
-
-using Microsoft.Recognizers.Text.DateTime.Utilities;
 using Microsoft.Recognizers.Definitions.English;
+using Microsoft.Recognizers.Text.DateTime.Utilities;
 
 namespace Microsoft.Recognizers.Text.DateTime.English
 {
     public class EnglishDateParserConfiguration : BaseOptionsConfiguration, IDateParserConfiguration
     {
+        public EnglishDateParserConfiguration(ICommonDateTimeParserConfiguration config)
+             : base(config)
+        {
+            DateTokenPrefix = DateTimeDefinitions.DateTokenPrefix;
+            IntegerExtractor = config.IntegerExtractor;
+            OrdinalExtractor = config.OrdinalExtractor;
+            CardinalExtractor = config.CardinalExtractor;
+            NumberParser = config.NumberParser;
+            DurationExtractor = config.DurationExtractor;
+            DateExtractor = config.DateExtractor;
+            DurationParser = config.DurationParser;
+            DateRegexes = new EnglishDateExtractorConfiguration(this).DateRegexList;
+            OnRegex = EnglishDateExtractorConfiguration.OnRegex;
+            SpecialDayRegex = EnglishDateExtractorConfiguration.SpecialDayRegex;
+            SpecialDayWithNumRegex = EnglishDateExtractorConfiguration.SpecialDayWithNumRegex;
+            NextRegex = EnglishDateExtractorConfiguration.NextDateRegex;
+            ThisRegex = EnglishDateExtractorConfiguration.ThisRegex;
+            LastRegex = EnglishDateExtractorConfiguration.LastDateRegex;
+            UnitRegex = EnglishDateExtractorConfiguration.DateUnitRegex;
+            WeekDayRegex = EnglishDateExtractorConfiguration.WeekDayRegex;
+            MonthRegex = EnglishDateExtractorConfiguration.MonthRegex;
+            WeekDayOfMonthRegex = EnglishDateExtractorConfiguration.WeekDayOfMonthRegex;
+            ForTheRegex = EnglishDateExtractorConfiguration.ForTheRegex;
+            WeekDayAndDayOfMothRegex = EnglishDateExtractorConfiguration.WeekDayAndDayOfMothRegex;
+            RelativeMonthRegex = EnglishDateExtractorConfiguration.RelativeMonthRegex;
+            YearSuffix = EnglishDateExtractorConfiguration.YearSuffix;
+            RelativeWeekDayRegex = EnglishDateExtractorConfiguration.RelativeWeekDayRegex;
+            RelativeDayRegex = new Regex(DateTimeDefinitions.RelativeDayRegex, RegexOptions.Singleline);
+            NextPrefixRegex = new Regex(DateTimeDefinitions.NextPrefixRegex, RegexOptions.Singleline);
+            PastPrefixRegex = new Regex(DateTimeDefinitions.PastPrefixRegex, RegexOptions.Singleline);
+            DayOfMonth = config.DayOfMonth;
+            DayOfWeek = config.DayOfWeek;
+            MonthOfYear = config.MonthOfYear;
+            CardinalMap = config.CardinalMap;
+            UnitMap = config.UnitMap;
+            UtilityConfiguration = config.UtilityConfiguration;
+            SameDayTerms = DateTimeDefinitions.SameDayTerms.ToImmutableList();
+            PlusOneDayTerms = DateTimeDefinitions.PlusOneDayTerms.ToImmutableList();
+            PlusTwoDayTerms = DateTimeDefinitions.PlusTwoDayTerms.ToImmutableList();
+            MinusOneDayTerms = DateTimeDefinitions.MinusOneDayTerms.ToImmutableList();
+            MinusTwoDayTerms = DateTimeDefinitions.MinusTwoDayTerms.ToImmutableList();
+        }
+
         public string DateTokenPrefix { get; }
 
         public IExtractor IntegerExtractor { get; }
@@ -84,48 +126,6 @@ namespace Microsoft.Recognizers.Text.DateTime.English
         public IImmutableList<string> MinusTwoDayTerms { get; }
 
         public IDateTimeUtilityConfiguration UtilityConfiguration { get; }
-
-        public EnglishDateParserConfiguration(ICommonDateTimeParserConfiguration config) : base(config)
-        {
-            DateTokenPrefix = DateTimeDefinitions.DateTokenPrefix;
-            IntegerExtractor = config.IntegerExtractor;
-            OrdinalExtractor = config.OrdinalExtractor;
-            CardinalExtractor = config.CardinalExtractor;
-            NumberParser = config.NumberParser;
-            DurationExtractor = config.DurationExtractor;
-            DateExtractor = config.DateExtractor;
-            DurationParser = config.DurationParser;
-            DateRegexes = new EnglishDateExtractorConfiguration(this).DateRegexList;
-            OnRegex = EnglishDateExtractorConfiguration.OnRegex;
-            SpecialDayRegex = EnglishDateExtractorConfiguration.SpecialDayRegex;
-            SpecialDayWithNumRegex = EnglishDateExtractorConfiguration.SpecialDayWithNumRegex;
-            NextRegex = EnglishDateExtractorConfiguration.NextDateRegex;
-            ThisRegex = EnglishDateExtractorConfiguration.ThisRegex;
-            LastRegex = EnglishDateExtractorConfiguration.LastDateRegex;
-            UnitRegex = EnglishDateExtractorConfiguration.DateUnitRegex;
-            WeekDayRegex = EnglishDateExtractorConfiguration.WeekDayRegex;
-            MonthRegex = EnglishDateExtractorConfiguration.MonthRegex;
-            WeekDayOfMonthRegex = EnglishDateExtractorConfiguration.WeekDayOfMonthRegex;
-            ForTheRegex = EnglishDateExtractorConfiguration.ForTheRegex;
-            WeekDayAndDayOfMothRegex = EnglishDateExtractorConfiguration.WeekDayAndDayOfMothRegex;
-            RelativeMonthRegex = EnglishDateExtractorConfiguration.RelativeMonthRegex;
-            YearSuffix = EnglishDateExtractorConfiguration.YearSuffix;
-            RelativeWeekDayRegex = EnglishDateExtractorConfiguration.RelativeWeekDayRegex;
-            RelativeDayRegex = new Regex(DateTimeDefinitions.RelativeDayRegex, RegexOptions.Singleline);
-            NextPrefixRegex = new Regex(DateTimeDefinitions.NextPrefixRegex, RegexOptions.Singleline);
-            PastPrefixRegex = new Regex(DateTimeDefinitions.PastPrefixRegex, RegexOptions.Singleline);
-            DayOfMonth = config.DayOfMonth;
-            DayOfWeek = config.DayOfWeek;
-            MonthOfYear = config.MonthOfYear;
-            CardinalMap = config.CardinalMap;
-            UnitMap = config.UnitMap;
-            UtilityConfiguration = config.UtilityConfiguration;
-            SameDayTerms = DateTimeDefinitions.SameDayTerms.ToImmutableList();
-            PlusOneDayTerms = DateTimeDefinitions.PlusOneDayTerms.ToImmutableList();
-            PlusTwoDayTerms = DateTimeDefinitions.PlusTwoDayTerms.ToImmutableList();
-            MinusOneDayTerms = DateTimeDefinitions.MinusOneDayTerms.ToImmutableList();
-            MinusTwoDayTerms = DateTimeDefinitions.MinusTwoDayTerms.ToImmutableList();
-        }
 
         public int GetSwiftMonth(string text)
         {

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/BaseDateTimeExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/BaseDateTimeExtractor.cs
@@ -1,5 +1,5 @@
-﻿using System.Linq;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
+using System.Linq;
 using System.Text.RegularExpressions;
 using DateObject = System.DateTime;
 
@@ -84,10 +84,11 @@ namespace Microsoft.Recognizers.Text.DateTime
                         Start = match.Index,
                         Length = match.Length,
                         Text = match.Value,
-                        Type = Number.Constants.SYS_NUM_INTEGER
+                        Type = Number.Constants.SYS_NUM_INTEGER,
                     };
                     numErs.Add(node);
                 }
+
                 ers.AddRange(numErs);
             }
 
@@ -107,9 +108,9 @@ namespace Microsoft.Recognizers.Text.DateTime
                     break;
                 }
 
-                if (ers[i].Type.Equals(Constants.SYS_DATETIME_DATE) && ers[j].Type.Equals(Constants.SYS_DATETIME_TIME) ||
-                    ers[i].Type.Equals(Constants.SYS_DATETIME_TIME) && ers[j].Type.Equals(Constants.SYS_DATETIME_DATE) ||
-                    ers[i].Type.Equals(Constants.SYS_DATETIME_DATE) && ers[j].Type.Equals(Number.Constants.SYS_NUM_INTEGER))
+                if ((ers[i].Type.Equals(Constants.SYS_DATETIME_DATE) && ers[j].Type.Equals(Constants.SYS_DATETIME_TIME)) ||
+                    (ers[i].Type.Equals(Constants.SYS_DATETIME_TIME) && ers[j].Type.Equals(Constants.SYS_DATETIME_DATE)) ||
+                    (ers[i].Type.Equals(Constants.SYS_DATETIME_DATE) && ers[j].Type.Equals(Number.Constants.SYS_NUM_INTEGER)))
                 {
                     var middleBegin = ers[i].Start + ers[i].Length ?? 0;
                     var middleEnd = ers[j].Start ?? 0;
@@ -121,6 +122,7 @@ namespace Microsoft.Recognizers.Text.DateTime
 
                     var middleStr = text.Substring(middleBegin, middleEnd - middleBegin).Trim().ToLower();
                     var valid = false;
+
                     // for cases like "tomorrow 3",  "tomorrow at 3"
                     if (ers[j].Type.Equals(Number.Constants.SYS_NUM_INTEGER))
                     {
@@ -148,6 +150,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                     i = j + 1;
                     continue;
                 }
+
                 i = j;
             }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/BaseTimeExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/BaseTimeExtractor.cs
@@ -1,23 +1,22 @@
 ﻿using System.Collections.Generic;
 using System.Text.RegularExpressions;
-using DateObject = System.DateTime;
-
 using Microsoft.Recognizers.Definitions;
+using DateObject = System.DateTime;
 
 namespace Microsoft.Recognizers.Text.DateTime
 {
     public class BaseTimeExtractor : IDateTimeExtractor
     {
-        private static readonly string ExtractorName = Constants.SYS_DATETIME_TIME; // "Time";
-
-        public static readonly Regex HourRegex = 
+        public static readonly Regex HourRegex =
             new Regex(BaseDateTime.HourRegex, RegexOptions.Singleline);
 
-        public static readonly Regex MinuteRegex = 
+        public static readonly Regex MinuteRegex =
             new Regex(BaseDateTime.MinuteRegex, RegexOptions.Singleline);
 
-        public static readonly Regex SecondRegex = 
+        public static readonly Regex SecondRegex =
             new Regex(BaseDateTime.SecondRegex, RegexOptions.Singleline);
+
+        private static readonly string ExtractorName = Constants.SYS_DATETIME_TIME; // "Time";
 
         private readonly ITimeExtractorConfiguration config;
 
@@ -48,7 +47,7 @@ namespace Microsoft.Recognizers.Text.DateTime
 
             return timeErs;
         }
-        
+
         private List<Token> BasicRegexMatch(string text)
         {
             var result = new List<Token>();
@@ -80,6 +79,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                     {
                         continue;
                     }
+
                     result.Add(new Token(match.Index, match.Index + match.Length));
                 }
             }
@@ -105,6 +105,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                     }
                 }
             }
+
             return result;
         }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/IDatePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/IDatePeriodExtractorConfiguration.cs
@@ -65,12 +65,12 @@ namespace Microsoft.Recognizers.Text.DateTime
 
         IParser NumberParser { get; }
 
+        string[] DurationDateRestrictions { get; }
+
         bool GetFromTokenIndex(string text, out int index);
 
         bool HasConnectorToken(string text);
 
         bool GetBetweenTokenIndex(string text, out int index);
-
-        string[] DurationDateRestrictions { get; }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/IDateTimeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/IDateTimeExtractorConfiguration.cs
@@ -38,8 +38,8 @@ namespace Microsoft.Recognizers.Text.DateTime
 
         IExtractor IntegerExtractor { get; }
 
-        bool IsConnector(string text);
-
         IDateTimeUtilityConfiguration UtilityConfiguration { get; }
+
+        bool IsConnector(string text);
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchDateTimeAltExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchDateTimeAltExtractorConfiguration.cs
@@ -1,28 +1,11 @@
-﻿using System.Text.RegularExpressions;
-using System.Collections.Generic;
-
+﻿using System.Collections.Generic;
+using System.Text.RegularExpressions;
 using Microsoft.Recognizers.Definitions.French;
 
 namespace Microsoft.Recognizers.Text.DateTime.French
 {
     public class FrenchDateTimeAltExtractorConfiguration : BaseOptionsConfiguration, IDateTimeAltExtractorConfiguration
     {
-        public FrenchDateTimeAltExtractorConfiguration(IOptionsConfiguration config) : base(config)
-        {
-            DateExtractor = new BaseDateExtractor(new FrenchDateExtractorConfiguration(this));
-            DatePeriodExtractor = new BaseDatePeriodExtractor(new FrenchDatePeriodExtractorConfiguration(this));
-        }
-
-        public IDateExtractor DateExtractor { get; }
-
-        public IDateTimeExtractor DatePeriodExtractor { get; }
-
-        private static readonly Regex OrRegex =
-            new Regex(DateTimeDefinitions.OrRegex, RegexOptions.Singleline);
-
-        private static readonly Regex DayRegex =
-            new Regex(DateTimeDefinitions.DayRegex, RegexOptions.Singleline);
-
         public static readonly Regex ThisPrefixRegex =
             new Regex(DateTimeDefinitions.ThisPrefixRegex, RegexOptions.Singleline);
 
@@ -37,13 +20,26 @@ namespace Microsoft.Recognizers.Text.DateTime.French
 
         public static readonly Regex[] RelativePrefixList =
         {
-            ThisPrefixRegex
+            ThisPrefixRegex,
         };
 
         public static readonly Regex[] AmPmRegexList =
         {
             AmRegex, PmRegex,
         };
+
+        private static readonly Regex OrRegex =
+            new Regex(DateTimeDefinitions.OrRegex, RegexOptions.Singleline);
+
+        private static readonly Regex DayRegex =
+            new Regex(DateTimeDefinitions.DayRegex, RegexOptions.Singleline);
+
+        public FrenchDateTimeAltExtractorConfiguration(IOptionsConfiguration config)
+            : base(config)
+        {
+            DateExtractor = new BaseDateExtractor(new FrenchDateExtractorConfiguration(this));
+            DatePeriodExtractor = new BaseDatePeriodExtractor(new FrenchDatePeriodExtractorConfiguration(this));
+        }
 
         IEnumerable<Regex> IDateTimeAltExtractorConfiguration.RelativePrefixList => RelativePrefixList;
 
@@ -54,5 +50,9 @@ namespace Microsoft.Recognizers.Text.DateTime.French
         Regex IDateTimeAltExtractorConfiguration.DayRegex => DayRegex;
 
         Regex IDateTimeAltExtractorConfiguration.RangePrefixRegex => RangePrefixRegex;
+
+        public IDateExtractor DateExtractor { get; }
+
+        public IDateTimeExtractor DatePeriodExtractor { get; }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchCommonDateTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchCommonDateTimeParserConfiguration.cs
@@ -1,16 +1,16 @@
 ﻿using System.Collections.Immutable;
-
 using Microsoft.Recognizers.Definitions;
-using Microsoft.Recognizers.Text.DateTime.French.Utilities;
 using Microsoft.Recognizers.Definitions.French;
-using Microsoft.Recognizers.Text.Number.French;
+using Microsoft.Recognizers.Text.DateTime.French.Utilities;
 using Microsoft.Recognizers.Text.Number;
+using Microsoft.Recognizers.Text.Number.French;
 
 namespace Microsoft.Recognizers.Text.DateTime.French
 {
     public class FrenchCommonDateTimeParserConfiguration : BaseDateParserConfiguration
     {
-        public FrenchCommonDateTimeParserConfiguration(IOptionsConfiguration config) : base(config)
+        public FrenchCommonDateTimeParserConfiguration(IOptionsConfiguration config)
+            : base(config)
         {
             UtilityConfiguration = new FrenchDatetimeUtilityConfiguration();
 
@@ -37,6 +37,7 @@ namespace Microsoft.Recognizers.Text.DateTime.French
             DatePeriodExtractor = new BaseDatePeriodExtractor(new FrenchDatePeriodExtractorConfiguration(this));
             TimePeriodExtractor = new BaseTimePeriodExtractor(new FrenchTimePeriodExtractorConfiguration(this));
             DateTimePeriodExtractor = new BaseDateTimePeriodExtractor(new FrenchDateTimePeriodExtractorConfiguration(this));
+
             // DurationParser should be assigned first, as DateParser would reference the DurationParser
             DurationParser = new BaseDurationParser(new FrenchDurationParserConfiguration(this));
             DateParser = new BaseDateParser(new FrenchDateParserConfiguration(this));
@@ -47,6 +48,7 @@ namespace Microsoft.Recognizers.Text.DateTime.French
             DateTimePeriodParser = new BaseDateTimePeriodParser(new FrenchDateTimePeriodParserConfiguration(this));
             DateTimeAltParser = new BaseDateTimeAltParser(new FrenchDateTimeAltParserConfiguration(this));
         }
+
         public override IImmutableDictionary<string, int> DayOfMonth => BaseDateTime.DayOfMonthDictionary.ToImmutableDictionary().AddRange(DateTimeDefinitions.DayOfMonth);
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchDateTimeAltParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchDateTimeAltParserConfiguration.cs
@@ -2,6 +2,16 @@
 {
     public class FrenchDateTimeAltParserConfiguration : IDateTimeAltParserConfiguration
     {
+        public FrenchDateTimeAltParserConfiguration(ICommonDateTimeParserConfiguration config)
+        {
+            DateTimeParser = config.DateTimeParser;
+            DateParser = config.DateParser;
+            TimeParser = config.TimeParser;
+            DateTimePeriodParser = config.DateTimePeriodParser;
+            TimePeriodParser = config.TimePeriodParser;
+            DatePeriodParser = config.DatePeriodParser;
+        }
+
         public IDateTimeParser DateTimeParser { get; }
 
         public IDateTimeParser DateParser { get; }
@@ -13,16 +23,5 @@
         public IDateTimeParser TimePeriodParser { get; }
 
         public IDateTimeParser DatePeriodParser { get; }
-
-        public FrenchDateTimeAltParserConfiguration(ICommonDateTimeParserConfiguration config)
-        {
-            DateTimeParser = config.DateTimeParser;
-            DateParser = config.DateParser;
-            TimeParser = config.TimeParser;
-            DateTimePeriodParser = config.DateTimePeriodParser;
-            TimePeriodParser = config.TimePeriodParser;
-            DatePeriodParser = config.DatePeriodParser;
-        }
-
     }
 }


### PR DESCRIPTION
- Reordered methods and using statements.
- Fixed spacing and trailing commas when needed.
- Renamed variables.
- Removed regions.