### PR TITLE
[StyleCop] Fix warnings in DataDrivenTest/Choice

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.DataDrivenTests/Choice/TestChoiceRecognizerCache.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataDrivenTests/Choice/TestChoiceRecognizerCache.cs
@@ -1,6 +1,6 @@
-﻿using Microsoft.Recognizers.Text.DataDrivenTests;
+﻿using System.Linq;
+using Microsoft.Recognizers.Text.DataDrivenTests;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System.Linq;
 
 namespace Microsoft.Recognizers.Text.Choice.Tests
 {

--- a/.NET/Microsoft.Recognizers.Text.DataDrivenTests/Choice/TestChoiceRecognizerInitialization.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataDrivenTests/Choice/TestChoiceRecognizerInitialization.cs
@@ -10,7 +10,8 @@ namespace Microsoft.Recognizers.Text.Choice.Tests
         private const string TestInput = "true";
 
         private const string EnglishCulture = Culture.English;
-        //private const string SpanishCulture = Culture.Spanish;
+
+        // private const string SpanishCulture = Culture.Spanish;
         private const string InvalidCulture = "vo-id";
 
         private IModel controlModel;
@@ -90,7 +91,7 @@ namespace Microsoft.Recognizers.Text.Choice.Tests
         {
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => new ChoiceRecognizer(EnglishCulture, -1));
         }
-        
+
         private void TestChoice(IModel testedModel, IModel controlModel, string source)
         {
             var expectedResults = controlModel.Parse(source);

--- a/.NET/Microsoft.Recognizers.Text.DataDrivenTests/Choice/TestChoice_Chinese.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataDrivenTests/Choice/TestChoice_Chinese.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests.Choice
         [TestInitialize]
         public void TestInitialize()
         {
-            base.TestSpecInitialize(TestResources);
+            TestSpecInitialize(TestResources);
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "BooleanModel-Chinese.csv", "BooleanModel-Chinese#csv", DataAccessMethod.Sequential)]

--- a/.NET/Microsoft.Recognizers.Text.DataDrivenTests/Choice/TestChoice_Dutch.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataDrivenTests/Choice/TestChoice_Dutch.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests.Choice
         [TestInitialize]
         public void TestInitialize()
         {
-            base.TestSpecInitialize(TestResources);
+            TestSpecInitialize(TestResources);
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "BooleanModel-Dutch.cs", "BooleanModel-Dutch#csv", DataAccessMethod.Sequential)]

--- a/.NET/Microsoft.Recognizers.Text.DataDrivenTests/Choice/TestChoice_English.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataDrivenTests/Choice/TestChoice_English.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests.Choice
         [TestInitialize]
         public void TestInitialize()
         {
-            base.TestSpecInitialize(TestResources);
+            TestSpecInitialize(TestResources);
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "BooleanModel-English.csv", "BooleanModel-English#csv", DataAccessMethod.Sequential)]

--- a/.NET/Microsoft.Recognizers.Text.DataDrivenTests/Choice/TestChoice_French.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataDrivenTests/Choice/TestChoice_French.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests.Choice
         [TestInitialize]
         public void TestInitialize()
         {
-            base.TestSpecInitialize(TestResources);
+            TestSpecInitialize(TestResources);
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "BooleanModel-French.cs", "BooleanModel-French#csv", DataAccessMethod.Sequential)]

--- a/.NET/Microsoft.Recognizers.Text.DataDrivenTests/Choice/TestChoice_German.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataDrivenTests/Choice/TestChoice_German.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests.Choice
         [TestInitialize]
         public void TestInitialize()
         {
-            base.TestSpecInitialize(TestResources);
+            TestSpecInitialize(TestResources);
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "BooleanModel-German.cs", "BooleanModel-German#csv", DataAccessMethod.Sequential)]

--- a/.NET/Microsoft.Recognizers.Text.DataDrivenTests/Choice/TestChoice_Japanese.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataDrivenTests/Choice/TestChoice_Japanese.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests.Choice
         [TestInitialize]
         public void TestInitialize()
         {
-            base.TestSpecInitialize(TestResources);
+            TestSpecInitialize(TestResources);
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "BooleanModel-Japanese.csv", "BooleanModel-Japanese#csv", DataAccessMethod.Sequential)]

--- a/.NET/Microsoft.Recognizers.Text.DataDrivenTests/Choice/TestChoice_Portuguese.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataDrivenTests/Choice/TestChoice_Portuguese.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests.Choice
         [TestInitialize]
         public void TestInitialize()
         {
-            base.TestSpecInitialize(TestResources);
+            TestSpecInitialize(TestResources);
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "BooleanModel-Portuguese.csv", "BooleanModel-Portuguese#csv", DataAccessMethod.Sequential)]

--- a/.NET/Microsoft.Recognizers.Text.DataDrivenTests/Choice/TestChoice_Spanish.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataDrivenTests/Choice/TestChoice_Spanish.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests.Choice
         [TestInitialize]
         public void TestInitialize()
         {
-            base.TestSpecInitialize(TestResources);
+            TestSpecInitialize(TestResources);
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "BooleanModel-Spanish.csv", "BooleanModel-Spanish#csv", DataAccessMethod.Sequential)]


### PR DESCRIPTION
Fix
-Warning SA1100 Do not prefix calls with base unless local implementation exists
-Reorder using statements
