### PR TITLE
[StyleCop] Fix warnings in DataDrivenTest\Number

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.DataDrivenTests/Microsoft.Recognizers.Text.DataDrivenTests.csproj
+++ b/.NET/Microsoft.Recognizers.Text.DataDrivenTests/Microsoft.Recognizers.Text.DataDrivenTests.csproj
@@ -92,6 +92,7 @@
     <Compile Include="NumberWithUnit\TestNumberWithUnit_Chinese.cs" />
     <Compile Include="NumberWithUnit\TestNumberWithUnit_English.cs" />
     <Compile Include="NumberWithUnit\TestNumberWithUnitRecognizerInitialization.cs" />
+    <Compile Include="Number\LongFormTestConfiguration.cs" />
     <Compile Include="Number\TestDecimalAndThousandsSeparators.cs" />
     <Compile Include="Number\TestNumber_Italian.cs" />
     <Compile Include="Number\TestNumberRecognizerCache.cs" />

--- a/.NET/Microsoft.Recognizers.Text.DataDrivenTests/Number/LongFormTestConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataDrivenTests/Number/LongFormTestConfiguration.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Globalization;
+using System.Text.RegularExpressions;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.Recognizers.Text.Number.Tests
+{
+    public class LongFormTestConfiguration : INumberParserConfiguration
+    {
+        public LongFormTestConfiguration(char decimalSep, char nonDecimalSep)
+        {
+            this.DecimalSeparatorChar = decimalSep;
+            this.NonDecimalSeparatorChar = nonDecimalSep;
+            this.CultureInfo = new CultureInfo(Culture.English);
+            this.CardinalNumberMap = ImmutableDictionary<string, long>.Empty;
+            this.OrdinalNumberMap = ImmutableDictionary<string, long>.Empty;
+            this.RoundNumberMap = ImmutableDictionary<string, long>.Empty;
+            this.DigitalNumberRegex = new Regex(
+                @"((?<=\b)(hundred|thousand|million|billion|trillion|dozen(s)?)(?=\b))|((?<=(\d|\b))(k|t|m|g|b)(?=\b))", RegexOptions.Singleline);
+        }
+
+        public ImmutableDictionary<string, long> CardinalNumberMap { get; }
+
+        public ImmutableDictionary<string, long> OrdinalNumberMap { get; }
+
+        public ImmutableDictionary<string, long> RoundNumberMap { get; }
+
+        public NumberOptions Options { get; }
+
+        public CultureInfo CultureInfo { get; }
+
+        public Regex DigitalNumberRegex { get; }
+
+        public Regex FractionPrepositionRegex { get; }
+
+        public string FractionMarkerToken { get; }
+
+        public Regex HalfADozenRegex { get; }
+
+        public string HalfADozenText { get; }
+
+        public string LangMarker { get; } = "SelfDefined";
+
+        public char NonDecimalSeparatorChar { get; }
+
+        public char DecimalSeparatorChar { get; }
+
+        public string WordSeparatorToken { get; }
+
+        public IEnumerable<string> WrittenDecimalSeparatorTexts { get; }
+
+        public IEnumerable<string> WrittenGroupSeparatorTexts { get; }
+
+        public IEnumerable<string> WrittenIntegerSeparatorTexts { get; }
+
+        public IEnumerable<string> WrittenFractionSeparatorTexts { get; }
+
+        // Test-specific initialization: the Regex matches nothing.
+        public Regex NegativeNumberSignRegex { get; } = new Regex(@"[^\s\S]");
+
+        public IEnumerable<string> NormalizeTokenSet(IEnumerable<string> tokens, ParseResult context)
+        {
+            throw new NotImplementedException();
+        }
+
+        public long ResolveCompositeNumber(string numberStr)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/.NET/Microsoft.Recognizers.Text.DataDrivenTests/Number/TestDecimalAndThousandsSeparators.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataDrivenTests/Number/TestDecimalAndThousandsSeparators.cs
@@ -8,70 +8,6 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.Recognizers.Text.Number.Tests
 {
-    public class LongFormTestConfiguration : INumberParserConfiguration
-    {
-        public ImmutableDictionary<string, long> CardinalNumberMap { get; }
-
-        public ImmutableDictionary<string, long> OrdinalNumberMap { get; }
-
-        public ImmutableDictionary<string, long> RoundNumberMap { get; }
-
-        public NumberOptions Options { get; }
-
-        public CultureInfo CultureInfo { get; }
-
-        public Regex DigitalNumberRegex { get; }
-
-        public Regex FractionPrepositionRegex { get; }
-
-        public string FractionMarkerToken { get; }
-
-        public Regex HalfADozenRegex { get; }
-
-        public string HalfADozenText { get; }
-
-        public string LangMarker { get; } = "SelfDefined";
-
-        public char NonDecimalSeparatorChar { get; }
-
-        public char DecimalSeparatorChar { get; }
-
-        public string WordSeparatorToken { get; }
-
-        public IEnumerable<string> WrittenDecimalSeparatorTexts { get; }
-
-        public IEnumerable<string> WrittenGroupSeparatorTexts { get; }
-
-        public IEnumerable<string> WrittenIntegerSeparatorTexts { get; }
-
-        public IEnumerable<string> WrittenFractionSeparatorTexts { get; }
-
-        // Test-specific initialization: the Regex matches nothing.
-        public Regex NegativeNumberSignRegex { get; } = new Regex(@"[^\s\S]"); 
-
-        public LongFormTestConfiguration(char decimalSep, char nonDecimalSep)
-        {
-            this.DecimalSeparatorChar = decimalSep;
-            this.NonDecimalSeparatorChar = nonDecimalSep;
-            this.CultureInfo = new CultureInfo(Culture.English);
-            this.CardinalNumberMap = ImmutableDictionary<string, long>.Empty;
-            this.OrdinalNumberMap = ImmutableDictionary<string, long>.Empty;
-            this.RoundNumberMap = ImmutableDictionary<string, long>.Empty;
-            this.DigitalNumberRegex = new Regex(@"((?<=\b)(hundred|thousand|million|billion|trillion|dozen(s)?)(?=\b))|((?<=(\d|\b))(k|t|m|g|b)(?=\b))",
-                                                RegexOptions.Singleline);
-        }
-
-        public IEnumerable<string> NormalizeTokenSet(IEnumerable<string> tokens, ParseResult context)
-        {
-            throw new NotImplementedException();
-        }
-
-        public long ResolveCompositeNumber(string numberStr)
-        {
-            throw new NotImplementedException();
-        }
-    }
-
     [TestClass]
     public class TestDecimalAndThousandsSeparators
     {
@@ -79,11 +15,12 @@ namespace Microsoft.Recognizers.Text.Number.Tests
         {
             char decimalSep = type.DecimalsMark, nonDecimalSep = type.ThousandsMark;
 
-            var parser = AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Double,
-                                                               new LongFormTestConfiguration(decimalSep, nonDecimalSep));
+            var parser = AgnosticNumberParserFactory.GetParser(
+                AgnosticNumberParserType.Double, new LongFormTestConfiguration(decimalSep, nonDecimalSep));
 
-            var resultJson = parser.Parse(new ExtractResult() {
-                Text = query, Start = 0, Length = query.Length, Type = "builtin.num.double", Data = "Num"
+            var resultJson = parser.Parse(new ExtractResult()
+            {
+                Text = query, Start = 0, Length = query.Length, Type = "builtin.num.double", Data = "Num",
             });
 
             Assert.AreEqual(value, resultJson.ResolutionStr);

--- a/.NET/Microsoft.Recognizers.Text.DataDrivenTests/Number/TestNumberRecognizerCache.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataDrivenTests/Number/TestNumberRecognizerCache.cs
@@ -1,6 +1,6 @@
-﻿using Microsoft.Recognizers.Text.DataDrivenTests;
+﻿using System.Linq;
+using Microsoft.Recognizers.Text.DataDrivenTests;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System.Linq;
 
 namespace Microsoft.Recognizers.Text.Number.Tests
 {

--- a/.NET/Microsoft.Recognizers.Text.DataDrivenTests/Number/TestNumberRecognizerInitialization.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataDrivenTests/Number/TestNumberRecognizerInitialization.cs
@@ -1,7 +1,7 @@
-﻿using Microsoft.Recognizers.Text.Number.English;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
+﻿using System;
 using System.Linq;
+using Microsoft.Recognizers.Text.Number.English;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.Recognizers.Text.Number.Tests
 {
@@ -22,7 +22,7 @@ namespace Microsoft.Recognizers.Text.Number.Tests
                     AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Number, new EnglishNumberParserConfiguration()),
                     NumberExtractor.GetInstance(NumberMode.PureNumber));
         }
-        
+
         [TestMethod]
         public void WithoutCulture_UseTargetCulture()
         {
@@ -81,7 +81,7 @@ namespace Microsoft.Recognizers.Text.Number.Tests
             var recognizer = new NumberRecognizer(InvalidCulture);
             Assert.ThrowsException<ArgumentException>(() => recognizer.GetNumberModel(fallbackToDefaultCulture: false));
         }
-        
+
         [TestMethod]
         public void InitializationWithIntOption_ResolveOptionsEnum()
         {

--- a/.NET/Microsoft.Recognizers.Text.DataDrivenTests/Number/TestNumber_Chinese.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataDrivenTests/Number/TestNumber_Chinese.cs
@@ -18,42 +18,42 @@ namespace Microsoft.Recognizers.Text.Number.Tests
         [TestInitialize]
         public void TestInitialize()
         {
-            base.TestSpecInitialize(TestResources);
+            TestSpecInitialize(TestResources);
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "NumberModel-Chinese.csv", "NumberModel-Chinese#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void NumberModel()
         {
-            base.TestNumber();
+            TestNumber();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "OrdinalModel-Chinese.csv", "OrdinalModel-Chinese#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void OrdinalModel()
         {
-            base.TestNumber();
+            TestNumber();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "PercentModel-Chinese.csv", "PercentModel-Chinese#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void PercentModel()
         {
-            base.TestNumber();
+            TestNumber();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "NumberRangeModel-Chinese.csv", "NumberRangeModel-Chinese#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void NumberRangeModel()
         {
-            base.TestNumber();
+            TestNumber();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "NumberRangeModelExperimentalMode-Chinese.csv", "NumberRangeModelExperimentalMode-Chinese#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void NumberRangeModelExperimentalMode()
         {
-            base.TestNumber();
+            TestNumber();
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DataDrivenTests/Number/TestNumber_Dutch.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataDrivenTests/Number/TestNumber_Dutch.cs
@@ -1,4 +1,4 @@
-using Microsoft.Recognizers.Text.DataDrivenTests;
+﻿using Microsoft.Recognizers.Text.DataDrivenTests;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.Recognizers.Text.Number.Tests
@@ -18,29 +18,29 @@ namespace Microsoft.Recognizers.Text.Number.Tests
         [TestInitialize]
         public void TestInitialize()
         {
-            base.TestSpecInitialize(TestResources);
+            TestSpecInitialize(TestResources);
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "NumberModel-Dutch.csv", "NumberModel-Dutch#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void NumberModel()
         {
-            base.TestNumber();
+            TestNumber();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "NumberModelPercentMode-Dutch.csv", "NumberModelPercentMode-Dutch#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void NumberModelPercentMode()
         {
-            base.TestNumber();
+            TestNumber();
         }
-       
+
         /*
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "NumberModelExperimentalMode-Dutch.csv", "NumberModelExperimentalMode-Dutch#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void NumberModelExperimentalMode()
         {
-            base.TestNumber();
+            TestNumber();
         }
         */
 
@@ -48,7 +48,7 @@ namespace Microsoft.Recognizers.Text.Number.Tests
         [TestMethod]
         public void OrdinalModel()
         {
-            base.TestNumber();
+            TestNumber();
         }
 
         /*
@@ -56,14 +56,14 @@ namespace Microsoft.Recognizers.Text.Number.Tests
         [TestMethod]
         public void PercentModel()
         {
-            base.TestNumber();
+            TestNumber();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "PercentModelPercentMode-Dutch.csv", "PercentModelPercentMode-Dutch#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void PercentModelPercentMode()
         {
-            base.TestNumber();
+            TestNumber();
         }
 
         /*
@@ -71,7 +71,7 @@ namespace Microsoft.Recognizers.Text.Number.Tests
         [TestMethod]
         public void NumberRangeModel()
         {
-            base.TestNumber();
+            TestNumber();
         }
         */
 
@@ -80,9 +80,8 @@ namespace Microsoft.Recognizers.Text.Number.Tests
         [TestMethod]
         public void NumberRangeModelExperimentalMode()
         {
-            base.TestNumber();
+            TestNumber();
         }
         */
-
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DataDrivenTests/Number/TestNumber_English.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataDrivenTests/Number/TestNumber_English.cs
@@ -19,63 +19,63 @@ namespace Microsoft.Recognizers.Text.Number.Tests
         [TestInitialize]
         public void TestInitialize()
         {
-            base.TestSpecInitialize(TestResources);
+            TestSpecInitialize(TestResources);
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "NumberModel-English.csv", "NumberModel-English#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void NumberModel()
         {
-            base.TestNumber();
+            TestNumber();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "NumberModelPercentMode-English.csv", "NumberModelPercentMode-English#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void NumberModelPercentMode()
         {
-            base.TestNumber();
+            TestNumber();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "NumberModelExperimentalMode-English.csv", "NumberModelExperimentalMode-English#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void NumberModelExperimentalMode()
         {
-            base.TestNumber();
+            TestNumber();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "OrdinalModel-English.csv", "OrdinalModel-English#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void OrdinalModel()
         {
-            base.TestNumber();
+            TestNumber();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "PercentModel-English.csv", "PercentModel-English#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void PercentModel()
         {
-            base.TestNumber();
+            TestNumber();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "PercentModelPercentMode-English.csv", "PercentModelPercentMode-English#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void PercentModelPercentMode()
         {
-            base.TestNumber();
+            TestNumber();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "NumberRangeModel-English.csv", "NumberRangeModel-English#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void NumberRangeModel()
         {
-            base.TestNumber();
+            TestNumber();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "NumberRangeModelExperimentalMode-English.csv", "NumberRangeModelExperimentalMode-English#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void NumberRangeModelExperimentalMode()
         {
-            base.TestNumber();
+            TestNumber();
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DataDrivenTests/Number/TestNumber_French.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataDrivenTests/Number/TestNumber_French.cs
@@ -18,28 +18,28 @@ namespace Microsoft.Recognizers.Text.Number.Tests
         [TestInitialize]
         public void TestInitialize()
         {
-            base.TestSpecInitialize(TestResources);
+            TestSpecInitialize(TestResources);
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "NumberModel-French.csv", "NumberModel-French#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void NumberModel()
         {
-            base.TestNumber();
+            TestNumber();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "OrdinalModel-French.csv", "OrdinalModel-French#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void OrdinalModel()
         {
-            base.TestNumber();
+            TestNumber();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "PercentModel-French.csv", "PercentModel-French#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void PercentModel()
         {
-            base.TestNumber();
+            TestNumber();
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DataDrivenTests/Number/TestNumber_German.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataDrivenTests/Number/TestNumber_German.cs
@@ -19,28 +19,28 @@ namespace Microsoft.Recognizers.Text.Number.Tests
         [TestInitialize]
         public void TestInitialize()
         {
-            base.TestSpecInitialize(TestResources);
+            TestSpecInitialize(TestResources);
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "NumberModel-German.csv", "NumberModel-German#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void NumberModel()
         {
-            base.TestNumber();
+            TestNumber();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "OrdinalModel-German.csv", "OrdinalModel-German#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void OrdinalModel()
         {
-            base.TestNumber();
+            TestNumber();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "PercentModel-German.csv", "PercentModel-German#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void PercentModel()
         {
-            base.TestNumber();
+            TestNumber();
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DataDrivenTests/Number/TestNumber_Italian.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataDrivenTests/Number/TestNumber_Italian.cs
@@ -18,28 +18,28 @@ namespace Microsoft.Recognizers.Text.Number.Tests
         [TestInitialize]
         public void TestInitialize()
         {
-            base.TestSpecInitialize(TestResources);
+            TestSpecInitialize(TestResources);
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "NumberModel-Italian.csv", "NumberModel-Italian#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void NumberModel()
         {
-            base.TestNumber();
+            TestNumber();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "OrdinalModel-Italian.csv", "OrdinalModel-Italian#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void OrdinalModel()
         {
-            base.TestNumber();
+            TestNumber();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "PercentModel-Italian.csv", "PercentModel-Italian#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void PercentModel()
         {
-            base.TestNumber();
+            TestNumber();
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DataDrivenTests/Number/TestNumber_Japanese.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataDrivenTests/Number/TestNumber_Japanese.cs
@@ -18,28 +18,28 @@ namespace Microsoft.Recognizers.Text.Number.Tests
         [TestInitialize]
         public void TestInitialize()
         {
-            base.TestSpecInitialize(TestResources);
+            TestSpecInitialize(TestResources);
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "NumberModel-Japanese.csv", "NumberModel-Japanese#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void NumberModel()
         {
-            base.TestNumber();
+            TestNumber();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "OrdinalModel-Japanese.csv", "OrdinalModel-Japanese#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void OrdinalModel()
         {
-            base.TestNumber();
+            TestNumber();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "PercentModel-Japanese.csv", "PercentModel-Japanese#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void PercentModel()
         {
-            base.TestNumber();
+            TestNumber();
         }
 
         /*
@@ -47,14 +47,14 @@ namespace Microsoft.Recognizers.Text.Number.Tests
         [TestMethod]
         public void NumberRangeModel()
         {
-            base.TestNumber();
+            TestNumber();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "NumberRangeModelExperimentalMode-Japanese.csv", "NumberRangeModelExperimentalMode-Japanese#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void NumberRangeModelExperimentalMode()
         {
-            base.TestNumber();
+            TestNumber();
         }
         */
     }

--- a/.NET/Microsoft.Recognizers.Text.DataDrivenTests/Number/TestNumber_Korean.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataDrivenTests/Number/TestNumber_Korean.cs
@@ -18,14 +18,14 @@ namespace Microsoft.Recognizers.Text.Number.Tests
         [TestInitialize]
         public void TestInitialize()
         {
-            base.TestSpecInitialize(TestResources);
+            TestSpecInitialize(TestResources);
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "NumberModel-Korean.csv", "NumberModel-Korean#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void NumberModel()
         {
-            base.TestNumber();
+            TestNumber();
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DataDrivenTests/Number/TestNumber_Portuguese.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataDrivenTests/Number/TestNumber_Portuguese.cs
@@ -19,28 +19,28 @@ namespace Microsoft.Recognizers.Text.Number.Tests
         [TestInitialize]
         public void TestInitialize()
         {
-            base.TestSpecInitialize(TestResources);
+            TestSpecInitialize(TestResources);
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "NumberModel-Portuguese.csv", "NumberModel-Portuguese#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void NumberModel()
         {
-            base.TestNumber();
+            TestNumber();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "OrdinalModel-Portuguese.csv", "OrdinalModel-Portuguese#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void OrdinalModel()
         {
-            base.TestNumber();
+            TestNumber();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "PercentModel-Portuguese.csv", "PercentModel-Portuguese#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void PercentModel()
         {
-            base.TestNumber();
+            TestNumber();
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DataDrivenTests/Number/TestNumber_Spanish.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataDrivenTests/Number/TestNumber_Spanish.cs
@@ -20,35 +20,35 @@ namespace Microsoft.Recognizers.Text.Number.Tests
         [TestInitialize]
         public void TestInitialize()
         {
-            base.TestSpecInitialize(TestResources);
+            TestSpecInitialize(TestResources);
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "NumberModel-Spanish.csv", "NumberModel-Spanish#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void NumberModel()
         {
-            base.TestNumber();
+            TestNumber();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "OrdinalModel-Spanish.csv", "OrdinalModel-Spanish#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void OrdinalModel()
         {
-            base.TestNumber();
+            TestNumber();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "PercentModel-Spanish.csv", "PercentModel-Spanish#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void PercentModel()
         {
-            base.TestNumber();
+            TestNumber();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "NumberRangeModel-Spanish.csv", "NumberRangeModel-Spanish#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void NumberRangeModel()
         {
-            base.TestNumber();
+            TestNumber();
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DataDrivenTests/Number/TestParserFactory.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataDrivenTests/Number/TestParserFactory.cs
@@ -4,8 +4,8 @@ using Microsoft.Recognizers.Text.Number.French;
 using Microsoft.Recognizers.Text.Number.German;
 using Microsoft.Recognizers.Text.Number.Italian;
 using Microsoft.Recognizers.Text.Number.Japanese;
-using Microsoft.Recognizers.Text.Number.Spanish;
 using Microsoft.Recognizers.Text.Number.Korean;
+using Microsoft.Recognizers.Text.Number.Spanish;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.Recognizers.Text.Number.Tests
@@ -13,16 +13,6 @@ namespace Microsoft.Recognizers.Text.Number.Tests
     [TestClass]
     public class TestParserFactory
     {
-        private ExtractResult getNumberToParse(string number, string data)
-        {
-            return new ExtractResult
-            {
-                Type = Constants.SYS_NUM,
-                Data = data,
-                Text = number
-            };
-        }
-
         [TestMethod]
         public void TestEnglishParser()
         {
@@ -97,7 +87,7 @@ namespace Microsoft.Recognizers.Text.Number.Tests
             IParser parseNumber = AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Number, new GermanNumberParserConfiguration());
             IParser parseCardinal = AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Cardinal, new GermanNumberParserConfiguration());
             IParser parsePercentage = AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Percentage, new GermanNumberParserConfiguration());
- 
+
             Assert.IsTrue(parseNumber is BaseNumberParser);
             Assert.IsTrue(parseCardinal is BaseNumberParser);
             Assert.IsTrue(parsePercentage is BasePercentageParser);
@@ -113,6 +103,16 @@ namespace Microsoft.Recognizers.Text.Number.Tests
             Assert.IsTrue(parseNumber is BaseNumberParser);
             Assert.IsTrue(parseCardinal is BaseNumberParser);
             Assert.IsTrue(parsePercentage is BasePercentageParser);
+        }
+
+        private ExtractResult GetNumberToParse(string number, string data)
+        {
+            return new ExtractResult
+            {
+                Type = Constants.SYS_NUM,
+                Data = data,
+                Text = number,
+            };
         }
     }
 }


### PR DESCRIPTION
- Warning SA1100 Do not prefix calls with base unless local implementation exists
- Extract LongFormTestConfiguration