### PR TITLE
[StyleCop] Fix all the warnings in choiceconfig

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.Choice/ChoiceOptions.cs
+++ b/.NET/Microsoft.Recognizers.Text.Choice/ChoiceOptions.cs
@@ -5,6 +5,9 @@ namespace Microsoft.Recognizers.Text.Choice
     [Flags]
     public enum ChoiceOptions
     {
+        /// <summary>
+        /// None
+        /// </summary>
         None = 0,
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.Choice/ChoiceRecognizer.cs
+++ b/.NET/Microsoft.Recognizers.Text.Choice/ChoiceRecognizer.cs
@@ -33,16 +33,16 @@ namespace Microsoft.Recognizers.Text.Choice
         {
         }
 
-        public IModel GetBooleanModel(string culture = null, bool fallbackToDefaultCulture = true)
-        {
-            return GetModel<BooleanModel>(culture, fallbackToDefaultCulture);
-        }
-
         public static List<ModelResult> RecognizeBoolean(string query, string culture, ChoiceOptions options = ChoiceOptions.None, bool fallbackToDefaultCulture = true)
         {
             var recognizer = new ChoiceRecognizer(options);
             var model = recognizer.GetBooleanModel(culture, fallbackToDefaultCulture);
             return model.Parse(query);
+        }
+
+        public IModel GetBooleanModel(string culture = null, bool fallbackToDefaultCulture = true)
+        {
+            return GetModel<BooleanModel>(culture, fallbackToDefaultCulture);
         }
 
         protected override void InitializeConfiguration()

--- a/.NET/Microsoft.Recognizers.Text.Choice/Config/BooleanParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Choice/Config/BooleanParserConfiguration.cs
@@ -4,10 +4,10 @@ namespace Microsoft.Recognizers.Text.Choice
 {
     public class BooleanParserConfiguration : IChoiceParserConfiguration<bool>
     {
-        public static IDictionary<string, bool> Resolutions = new Dictionary<string, bool>
+        public static IDictionary<string, bool> Resolutions { get; set; } = new Dictionary<string, bool>
         {
             { Constants.SYS_BOOLEAN_TRUE, true },
-            { Constants.SYS_BOOLEAN_FALSE, false }
+            { Constants.SYS_BOOLEAN_FALSE, false },
         };
 
         IDictionary<string, bool> IChoiceParserConfiguration<bool>.Resolutions => Resolutions;

--- a/.NET/Microsoft.Recognizers.Text.Choice/Constants.cs
+++ b/.NET/Microsoft.Recognizers.Text.Choice/Constants.cs
@@ -1,5 +1,8 @@
-﻿namespace Microsoft.Recognizers.Text.Choice
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.Recognizers.Text.Choice
 {
+    [SuppressMessage("StyleCop.CSharp.NamingRules", "SA1310: CSharp.Naming : Field names must not contain underscores.", Justification = "Constant names are written in upper case so they can be readily distinguished from camel case variable names.")]
     public class Constants
     {
         public const string SYS_BOOLEAN_TRUE = "boolean_true";

--- a/.NET/Microsoft.Recognizers.Text.Choice/Microsoft.Recognizers.Text.Choice.csproj
+++ b/.NET/Microsoft.Recognizers.Text.Choice/Microsoft.Recognizers.Text.Choice.csproj
@@ -6,6 +6,8 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <CodeAnalysisRuleSet>../Recognizers-Text.ruleset</CodeAnalysisRuleSet>
+    <DocumentationFile>$(OutputPath)$(AssemblyName).xml</DocumentationFile>
+    <NoWarn>$(NoWarn),1573,1591,1712</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/.NET/Microsoft.Recognizers.Text.Choice/Microsoft.Recognizers.Text.Choice.xml
+++ b/.NET/Microsoft.Recognizers.Text.Choice/Microsoft.Recognizers.Text.Choice.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<doc>
+    <assembly>
+        <name>Microsoft.Recognizers.Text.Choice</name>
+    </assembly>
+    <members>
+    </members>
+</doc>


### PR DESCRIPTION
- Add enum comments.
- FixeS0001 warning including .xml comment file.
- Add trailing comma
- Supress warning for constants with underscore