### PR TITLE
[StyleCop] Fix all warnings in DateTime files (spacing and commas)

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishTimeZoneExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishTimeZoneExtractorConfiguration.cs
@@ -23,17 +23,18 @@ namespace Microsoft.Recognizers.Text.DateTime.English
         {
             DirectUtcRegex,
             AbbreviationRegex,
-            StandardTimeRegex
+            StandardTimeRegex,
         };
 
-        public static readonly Regex LocationTimeSuffixRegex = 
+        public static readonly Regex LocationTimeSuffixRegex =
             new Regex(TimeZoneDefinitions.LocationTimeSuffixRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
         public static readonly StringMatcher LocationMatcher = new StringMatcher();
 
         public static readonly List<string> AmbiguousTimezoneList = TimeZoneDefinitions.AmbiguousTimezoneList.ToList();
 
-        public EnglishTimeZoneExtractorConfiguration(IOptionsConfiguration config) : base(config)
+        public EnglishTimeZoneExtractorConfiguration(IOptionsConfiguration config)
+            : base(config)
         {
             if ((Options & DateTimeOptions.EnablePreview) != 0)
             {

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanHolidayExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanHolidayExtractorConfiguration.cs
@@ -1,13 +1,13 @@
 ﻿using System.Collections.Generic;
 using System.Text.RegularExpressions;
-
 using Microsoft.Recognizers.Definitions.German;
 
 namespace Microsoft.Recognizers.Text.DateTime.German
 {
     public class GermanHolidayExtractorConfiguration : BaseOptionsConfiguration, IHolidayExtractorConfiguration
     {
-        public static readonly Regex YearRegex = new Regex(DateTimeDefinitions.YearRegex,
+        public static readonly Regex YearRegex = new Regex(
+            DateTimeDefinitions.YearRegex,
             RegexOptions.Singleline);
 
         public static readonly Regex H1 =
@@ -29,10 +29,11 @@ namespace Microsoft.Recognizers.Text.DateTime.German
         {
             H1,
             H2,
-            H3
+            H3,
         };
 
-        public GermanHolidayExtractorConfiguration(IOptionsConfiguration config) : base(config)
+        public GermanHolidayExtractorConfiguration(IOptionsConfiguration config)
+            : base(config)
         {
         }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Extractors/DateExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Extractors/DateExtractor.cs
@@ -55,17 +55,16 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
 
         public static readonly Regex[] DateRegexList =
         {
-
             // ２０１６年１２月１日
             new Regex(DateTimeDefinitions.DateRegexList1, RegexOptions.Singleline),
 
             // 2015/12/23
             new Regex(DateTimeDefinitions.DateRegexList10, RegexOptions.Singleline),
-            
-            //# ２０１６年１２月
+
+            // # ２０１６年１２月
             new Regex(DateTimeDefinitions.DateRegexList2, RegexOptions.Singleline),
 
-            //１２月１日
+            // １２月１日
             new Regex(DateTimeDefinitions.DateRegexList9, RegexOptions.Singleline),
 
             // (2015年)?(农历)?十月二十(星期三)?
@@ -79,32 +78,35 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
 
             DateTimeDefinitions.DefaultLanguageFallback == Constants.DefaultLanguageFallback_DMY
                 ?
+
                 // 23-3-2015
                 new Regex(DateTimeDefinitions.DateRegexList7, RegexOptions.Singleline)
                 :
+
                 // 3-23-2017
                 new Regex(DateTimeDefinitions.DateRegexList6, RegexOptions.Singleline),
 
             DateTimeDefinitions.DefaultLanguageFallback == Constants.DefaultLanguageFallback_DMY
                 ?
+
                 // 3-23-2017
                 new Regex(DateTimeDefinitions.DateRegexList6, RegexOptions.Singleline)
                 :
+
                 // 23-3-2015
                 new Regex(DateTimeDefinitions.DateRegexList7, RegexOptions.Singleline),
 
             // 2015-12-23
             new Regex(DateTimeDefinitions.DateRegexList8, RegexOptions.Singleline),
 
-            //2016/12
-            new Regex(DateTimeDefinitions.DateRegexList11, RegexOptions.Singleline)
+            // 2016/12
+            new Regex(DateTimeDefinitions.DateRegexList11, RegexOptions.Singleline),
         };
-
 
         public static readonly Regex[] ImplicitDateList =
         {
             LunarRegex, SpecialDayRegex, ThisRegex, LastRegex, NextRegex,
-            WeekDayRegex, WeekDayOfMonthRegex, SpecialMonthRegex, SpecialYearRegex, SpecialDate
+            WeekDayRegex, WeekDayOfMonthRegex, SpecialMonthRegex, SpecialYearRegex, SpecialDate,
         };
 
         public static readonly Regex BeforeRegex = new Regex(DateTimeDefinitions.BeforeRegex, RegexOptions.Singleline);
@@ -151,6 +153,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
                     ret.Add(new Token(match.Index, match.Index + match.Length));
                 }
             }
+
             return ret;
         }
 
@@ -166,6 +169,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
                     ret.Add(new Token(match.Index, match.Index + match.Length));
                 }
             }
+
             return ret;
         }
 
@@ -190,13 +194,14 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
                     var beforeMatch = BeforeRegex.Match(suffix);
                     var afterMatch = AfterRegex.Match(suffix);
 
-                    if ((beforeMatch.Success && suffix.StartsWith(beforeMatch.Value))|| (afterMatch.Success && suffix.StartsWith(afterMatch.Value)))
+                    if ((beforeMatch.Success && suffix.StartsWith(beforeMatch.Value)) || (afterMatch.Success && suffix.StartsWith(afterMatch.Value)))
                     {
                         var metadata = new Metadata() { IsDurationWithBeforeAndAfter = true };
                         ret.Add(new Token(er.Start ?? 0, (er.Start + er.Length ?? 0) + 1, metadata));
                     }
                 }
             }
+
             return ret;
         }
     }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Extractors/DateExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Extractors/DateExtractor.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using Microsoft.Recognizers.Definitions.Japanese;
 using DateObject = System.DateTime;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDateTimeParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDateTimeParser.cs
@@ -51,12 +51,12 @@ namespace Microsoft.Recognizers.Text.DateTime
                 {
                     innerResult.FutureResolution = new Dictionary<string, string>
                     {
-                        {TimeTypeConstants.DATETIME, DateTimeFormatUtil.FormatDateTime((DateObject) innerResult.FutureValue)}
+                        { TimeTypeConstants.DATETIME, DateTimeFormatUtil.FormatDateTime((DateObject)innerResult.FutureValue) },
                     };
 
                     innerResult.PastResolution = new Dictionary<string, string>
                     {
-                        {TimeTypeConstants.DATETIME, DateTimeFormatUtil.FormatDateTime((DateObject) innerResult.PastValue)}
+                        { TimeTypeConstants.DATETIME, DateTimeFormatUtil.FormatDateTime((DateObject)innerResult.PastValue) },
                     };
 
                     value = innerResult;
@@ -71,11 +71,16 @@ namespace Microsoft.Recognizers.Text.DateTime
                 Type = er.Type,
                 Data = er.Data,
                 Value = value,
-                TimexStr = value == null ? "" : ((DateTimeResolutionResult)value).Timex,
-                ResolutionStr = ""
+                TimexStr = value == null ? string.Empty : ((DateTimeResolutionResult)value).Timex,
+                ResolutionStr = string.Empty,
             };
 
             return ret;
+        }
+
+        public List<DateTimeParseResult> FilterResults(string query, List<DateTimeParseResult> candidateResults)
+        {
+            return candidateResults;
         }
 
         private DateTimeResolutionResult ParseBasicRegex(string text, DateObject referenceTime)
@@ -210,6 +215,7 @@ namespace Microsoft.Recognizers.Text.DateTime
             {
                 timeStr = timeStr.Substring(0, timeStr.Length - 4);
             }
+
             timeStr = "T" + hour.ToString("D2") + timeStr.Substring(3);
             ret.Timex = pr1.TimexStr + timeStr;
 
@@ -228,7 +234,7 @@ namespace Microsoft.Recognizers.Text.DateTime
             pr2.TimexStr = timeStr;
             if (!string.IsNullOrEmpty(ret.Comment))
             {
-                ((DateTimeResolutionResult)pr2.Value).Comment = ret.Comment.Equals(Constants.Comment_AmPm) ? Constants.Comment_AmPm : "";
+                ((DateTimeResolutionResult)pr2.Value).Comment = ret.Comment.Equals(Constants.Comment_AmPm) ? Constants.Comment_AmPm : string.Empty;
             }
 
             // Add the date and time object in case we want to split them
@@ -267,6 +273,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                 {
                     hour = int.Parse(hourStr);
                 }
+
                 timeStr = "T" + hour.ToString("D2");
             }
             else
@@ -318,6 +325,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                 {
                     timeStr = timeStr.Substring(0, timeStr.Length - 4);
                 }
+
                 timeStr = "T" + hour.ToString("D2") + timeStr.Substring(3);
 
                 ret.Timex = DateTimeFormatUtil.FormatDate(date) + timeStr;
@@ -338,7 +346,7 @@ namespace Microsoft.Recognizers.Text.DateTime
             {
                 return ret;
             }
-           
+
             var ers = this.config.DateExtractor.Extract(text, refDateTime);
             if (ers.Count != 1)
             {
@@ -365,7 +373,7 @@ namespace Microsoft.Recognizers.Text.DateTime
             var eod = this.config.UnspecificEndOfRegex.Match(text);
             if (eod.Success)
             {
-                ret = ResolveEndOfDay(DateTimeFormatUtil.FormatDate(refDateTime), refDateTime, refDateTime);          
+                ret = ResolveEndOfDay(DateTimeFormatUtil.FormatDate(refDateTime), refDateTime, refDateTime);
             }
 
             return ret;
@@ -390,22 +398,21 @@ namespace Microsoft.Recognizers.Text.DateTime
 
         private bool WithinMorningHoursAndNoon(int hour, int min, int sec)
         {
-            return (hour > Constants.HalfDayHourCount || (hour == Constants.HalfDayHourCount && (min > 0 || sec > 0)));
+            return hour > Constants.HalfDayHourCount || (hour == Constants.HalfDayHourCount && (min > 0 || sec > 0));
         }
 
-        // Handle cases like "two hours ago" 
+        // Handle cases like "two hours ago"
         private DateTimeResolutionResult ParserDurationWithAgoAndLater(string text, DateObject referenceTime)
         {
-
-            return AgoLaterUtil.ParseDurationWithAgoAndLater(text, referenceTime,
-                config.DurationExtractor, config.DurationParser, config.UnitMap, config.UnitRegex,
-                config.UtilityConfiguration, config.GetSwiftDay);
+            return AgoLaterUtil.ParseDurationWithAgoAndLater(
+                text,
+                referenceTime,
+                config.DurationExtractor,
+                config.DurationParser,
+                config.UnitMap,
+                config.UnitRegex,
+                config.UtilityConfiguration,
+                config.GetSwiftDay);
         }
-
-        public List<DateTimeParseResult> FilterResults(string query, List<DateTimeParseResult> candidateResults)
-        {
-            return candidateResults;
-        }
-
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseTimeZoneParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseTimeZoneParser.cs
@@ -2,15 +2,14 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
-using DateObject = System.DateTime;
-
 using Microsoft.Recognizers.Definitions.English;
+using DateObject = System.DateTime;
 
 namespace Microsoft.Recognizers.Text.DateTime
 {
     public class BaseTimeZoneParser : IDateTimeParser
     {
-        public static readonly string ParserName = Constants.SYS_DATETIME_TIMEZONE; //"TimeZone";
+        public static readonly string ParserName = Constants.SYS_DATETIME_TIMEZONE; // "TimeZone";
 
         public ParseResult Parse(ExtractResult result)
         {
@@ -64,7 +63,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                 return Constants.InvalidOffsetValue;
             }
 
-            int offsetInMinutes = hours * 60 + minutes;
+            int offsetInMinutes = (hours * 60) + minutes;
             offsetInMinutes *= sign;
 
             return offsetInMinutes;
@@ -78,9 +77,9 @@ namespace Microsoft.Recognizers.Text.DateTime
                 Start = er.Start,
                 Length = er.Length,
                 Text = er.Text,
-                Type = er.Type
+                Type = er.Type,
             };
-            
+
             string text = er.Text.ToLower();
             string matched = Regex.Match(text, TimeZoneDefinitions.DirectUtcRegex).Groups[2].Value;
             int offsetInMinutes = ComputeMinutes(matched);
@@ -114,8 +113,8 @@ namespace Microsoft.Recognizers.Text.DateTime
                     {
                         Value = "UTC+XX:XX",
                         UtcOffsetMins = Constants.InvalidOffsetValue,
-                        TimeZoneText = text
-                    }
+                        TimeZoneText = text,
+                    },
                 };
                 result.ResolutionStr = Constants.UtcOffsetMinsKey + ": XX:XX";
             }
@@ -132,8 +131,8 @@ namespace Microsoft.Recognizers.Text.DateTime
                 {
                     Value = ConvertOffsetInMinsToOffsetString(offsetMins),
                     UtcOffsetMins = offsetMins,
-                    TimeZoneText = text
-                }
+                    TimeZoneText = text,
+                },
             };
 
             return val;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseCommonDateTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseCommonDateTimeParserConfiguration.cs
@@ -9,7 +9,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
 {
     public class PortugueseCommonDateTimeParserConfiguration : BaseDateParserConfiguration
     {
-        public PortugueseCommonDateTimeParserConfiguration(IOptionsConfiguration config) : base(config)
+        public PortugueseCommonDateTimeParserConfiguration(IOptionsConfiguration config)
+            : base(config)
         {
             UtilityConfiguration = new PortugueseDatetimeUtilityConfiguration();
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Utilities/PortugueseDatetimeUtilityConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Utilities/PortugueseDatetimeUtilityConfiguration.cs
@@ -23,10 +23,12 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese.Utilities
 
         public static readonly Regex RangeUnitRegex = new Regex(DateTimeDefinitions.RangeUnitRegex, RegexOptions.Singleline);
 
-        public static readonly Regex TimeUnitRegex = new Regex(DateTimeDefinitions.TimeUnitRegex,
+        public static readonly Regex TimeUnitRegex = new Regex(
+            DateTimeDefinitions.TimeUnitRegex,
             RegexOptions.Singleline);
 
-        public static readonly Regex DateUnitRegex = new Regex(DateTimeDefinitions.DateUnitRegex,
+        public static readonly Regex DateUnitRegex = new Regex(
+            DateTimeDefinitions.DateUnitRegex,
             RegexOptions.Singleline);
 
         public static readonly Regex CommonDatePrefixRegex = new Regex(DateTimeDefinitions.CommonDatePrefixRegex, RegexOptions.Singleline);
@@ -52,6 +54,5 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese.Utilities
         Regex IDateTimeUtilityConfiguration.DateUnitRegex => DateUnitRegex;
 
         Regex IDateTimeUtilityConfiguration.CommonDatePrefixRegex => CommonDatePrefixRegex;
-
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishHolidayExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishHolidayExtractorConfiguration.cs
@@ -11,10 +11,11 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
         {
             new Regex(DateTimeDefinitions.HolidayRegex1, RegexOptions.Singleline),
             new Regex(DateTimeDefinitions.HolidayRegex2, RegexOptions.Singleline),
-            new Regex(DateTimeDefinitions.HolidayRegex3, RegexOptions.Singleline)
+            new Regex(DateTimeDefinitions.HolidayRegex3, RegexOptions.Singleline),
         };
 
-        public SpanishHolidayExtractorConfiguration(IOptionsConfiguration config) : base(config)
+        public SpanishHolidayExtractorConfiguration(IOptionsConfiguration config)
+            : base(config)
         {
         }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/RangeTimexComponents.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/RangeTimexComponents.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Globalization;
+using System.Text;
+using DateObject = System.DateTime;
+
+namespace Microsoft.Recognizers.Text.DateTime
+{
+    public class RangeTimexComponents
+    {
+        public string BeginTimex { get; set; }
+
+        public string EndTimex { get; set; }
+
+        public string DurationTimex { get; set; }
+
+        public bool IsValid { get; set; } = false;
+    }
+}

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/TimeZoneUtility.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/TimeZoneUtility.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                             er.Length = newLength;
                             er.Data = new Dictionary<string, object>()
                             {
-                                { Constants.SYS_DATETIME_TIMEZONE, timeZoneEr }
+                                { Constants.SYS_DATETIME_TIMEZONE, timeZoneEr },
                             };
                         }
                     }
@@ -44,9 +44,9 @@ namespace Microsoft.Recognizers.Text.DateTime
 
             if (er.Data is Dictionary<string, object>)
             {
-                var metadata = er.Data as Dictionary<string, object>;
+                var metaData = er.Data as Dictionary<string, object>;
 
-                if (metadata != null && metadata.ContainsKey(Constants.SYS_DATETIME_TIMEZONE))
+                if (metaData != null && metaData.ContainsKey(Constants.SYS_DATETIME_TIMEZONE))
                 {
                     hasTimeZoneData = true;
                 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/TimexUtility.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/TimexUtility.cs
@@ -13,15 +13,15 @@ namespace Microsoft.Recognizers.Text.DateTime
 
         private static readonly HashSet<char> NumberComponents = new HashSet<char>()
         {
-            '0','1','2','3','4','5','6','7','8','9','.'
+            '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '.',
         };
 
         private static readonly Dictionary<DatePeriodTimexType, string> DatePeriodTimexTypeToTimexSuffix = new Dictionary<DatePeriodTimexType, string>()
         {
-            {DatePeriodTimexType.ByDay, Constants.TimexDay },
-            {DatePeriodTimexType.ByWeek, Constants.TimexWeek },
-            {DatePeriodTimexType.ByMonth, Constants.TimexMonth },
-            {DatePeriodTimexType.ByYear, Constants.TimexYear }
+            { DatePeriodTimexType.ByDay, Constants.TimexDay },
+            { DatePeriodTimexType.ByWeek, Constants.TimexWeek },
+            { DatePeriodTimexType.ByMonth, Constants.TimexMonth },
+            { DatePeriodTimexType.ByYear, Constants.TimexYear },
         };
 
         public static string GenerateCompoundDurationTimex(Dictionary<string, string> unitToTimexComponents, IImmutableDictionary<string, long> unitValueMap)
@@ -35,7 +35,7 @@ namespace Microsoft.Recognizers.Text.DateTime
             {
                 var timexComponent = unitToTimexComponents[unitList[i]];
 
-                // The Time Duration component occurs first time, 
+                // The Time Duration component occurs first time,
                 if (!isTimeDurationAlreadyExist && IsTimeDurationTimex(timexComponent))
                 {
                     timexBuilder.Append($"{Constants.TimeTimexPrefix}{GetDurationTimexWithoutPrefix(timexComponent)}");
@@ -50,20 +50,9 @@ namespace Microsoft.Recognizers.Text.DateTime
             return timexBuilder.ToString();
         }
 
-        private static bool IsTimeDurationTimex(string timex)
-        {
-            return timex.StartsWith($"{Constants.GeneralPeriodPrefix}{Constants.TimeTimexPrefix}");
-        }
-
-        private static string GetDurationTimexWithoutPrefix(string timex)
-        {
-            // Remove "PT" prefix for TimeDuration, Remove "P" prefix for DateDuration
-            return timex.Substring(IsTimeDurationTimex(timex) ? 2 : 1);
-        }
-
         public static string GenerateDatePeriodTimex(DateObject begin, DateObject end, DatePeriodTimexType timexType, DateObject alternativeBegin = default(DateObject), DateObject alternativeEnd = default(DateObject))
         {
-            var equalDurationLength = ((end - begin) == (alternativeEnd - alternativeBegin));
+            var equalDurationLength = (end - begin) == (alternativeEnd - alternativeBegin);
 
             if (alternativeBegin.IsDefaultValue() || alternativeEnd.IsDefaultValue())
             {
@@ -86,7 +75,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                         unitCount = (((end.Year - begin.Year) * 12) + (end.Month - begin.Month)).ToString();
                         break;
                     default:
-                        unitCount = ((end.Year - begin.Year) + (end.Month - begin.Month) / 12.0).ToString(CultureInfo.InvariantCulture);
+                        unitCount = ((end.Year - begin.Year) + ((end.Month - begin.Month) / 12.0)).ToString(CultureInfo.InvariantCulture);
                         break;
                 }
             }
@@ -152,8 +141,8 @@ namespace Microsoft.Recognizers.Text.DateTime
                 }
             }
 
-            return Constants.GeneralPeriodPrefix + 
-                   (isLessThanDay ? Constants.TimeTimexPrefix : string.Empty) + 
+            return Constants.GeneralPeriodPrefix +
+                   (isLessThanDay ? Constants.TimeTimexPrefix : string.Empty) +
                    number.ToString(CultureInfo.InvariantCulture) + unitStr;
         }
 
@@ -249,10 +238,10 @@ namespace Microsoft.Recognizers.Text.DateTime
                     result.EndHour = 23;
                     result.EndMin = 59;
                     break;
-               default:
+                default:
                     break;
             }
-         
+
             return result;
         }
 
@@ -289,10 +278,10 @@ namespace Microsoft.Recognizers.Text.DateTime
 
         public static RangeTimexComponents GetRangeTimexComponents(string rangeTimex)
         {
-            rangeTimex = rangeTimex.Replace("(", "").Replace(")", "");
+            rangeTimex = rangeTimex.Replace("(", string.Empty).Replace(")", string.Empty);
             var components = rangeTimex.Split(new string[] { "," }, StringSplitOptions.RemoveEmptyEntries);
             var result = new RangeTimexComponents();
-            
+
             if (components.Length == 3)
             {
                 result.BeginTimex = components[0];
@@ -313,16 +302,16 @@ namespace Microsoft.Recognizers.Text.DateTime
         {
             return timex.Replace(Constants.TimexFuzzyYear, context.Year.ToString("D4"));
         }
-    }
 
-    public class RangeTimexComponents
-    {
-        public string BeginTimex;
+        private static bool IsTimeDurationTimex(string timex)
+        {
+            return timex.StartsWith($"{Constants.GeneralPeriodPrefix}{Constants.TimeTimexPrefix}");
+        }
 
-        public string EndTimex;
-
-        public string DurationTimex;
-
-        public bool IsValid = false;
+        private static string GetDurationTimexWithoutPrefix(string timex)
+        {
+            // Remove "PT" prefix for TimeDuration, Remove "P" prefix for DateDuration
+            return timex.Substring(IsTimeDurationTimex(timex) ? 2 : 1);
+        }
     }
 }


### PR DESCRIPTION
- Added trailing commas and parenthesis when needed.
- Fixed spacing.
- Reordered methods and using properties.
