### PR TITLE
[StyleCop] Fix all the warnings in Choise\Parsers

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.Choice/Parsers/BooleanParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.Choice/Parsers/BooleanParser.cs
@@ -2,9 +2,9 @@
 {
     public class BooleanParser : OptionsParser<bool>
     {
-        public BooleanParser(): base(new BooleanParserConfiguration())
+        public BooleanParser()
+               : base(new BooleanParserConfiguration())
         {
-
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.Choice/Parsers/OptionsOtherMatchParseResult.cs
+++ b/.NET/Microsoft.Recognizers.Text.Choice/Parsers/OptionsOtherMatchParseResult.cs
@@ -1,0 +1,14 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.Recognizers.Text.Choice
+{
+    public class OptionsOtherMatchParseResult
+    {
+        public double Score { get; set; }
+
+        public string Text { get; set; }
+
+        public object Value { get; set; }
+    }
+}

--- a/.NET/Microsoft.Recognizers.Text.Choice/Parsers/OptionsParseDataResult.cs
+++ b/.NET/Microsoft.Recognizers.Text.Choice/Parsers/OptionsParseDataResult.cs
@@ -1,0 +1,12 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.Recognizers.Text.Choice
+{
+    public class OptionsParseDataResult
+    {
+        public double Score { get; set; }
+
+        public IEnumerable<OptionsOtherMatchParseResult> OtherMatches { get; set; }
+    }
+}

--- a/.NET/Microsoft.Recognizers.Text.Choice/Parsers/OptionsParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.Choice/Parsers/OptionsParser.cs
@@ -3,22 +3,6 @@ using System.Linq;
 
 namespace Microsoft.Recognizers.Text.Choice
 {
-    public class OptionsOtherMatchParseResult
-    {
-        public double Score { get; set; }
-
-        public string Text { get; set; }
-
-        public object Value { get; set; }
-    }
-
-    public class OptionsParseDataResult
-    {
-        public double Score { get; set; }
-
-        public IEnumerable<OptionsOtherMatchParseResult> OtherMatches { get; set; }
-    }
-
     public class OptionsParser<T> : IParser
     {
         private readonly IChoiceParserConfiguration<T> config;
@@ -36,7 +20,7 @@ namespace Microsoft.Recognizers.Text.Choice
             result.Data = new OptionsParseDataResult()
             {
                 Score = data.Score,
-                OtherMatches = data.OtherMatches.Select(er => TOptionsOtherMatchReuslt(er))
+                OtherMatches = data.OtherMatches.Select(er => TOptionsOtherMatchReuslt(er)),
             };
 
             return result;
@@ -51,7 +35,7 @@ namespace Microsoft.Recognizers.Text.Choice
             {
                 Text = rp.Text,
                 Value = config.Resolutions[rp.Type],
-                Score = data.Score
+                Score = data.Score,
             };
 
             return result;


### PR DESCRIPTION
- Remove extra black space
- Add trailing coma in multi-line initializers
- Separate the file ChoiseParser on to
-- OptionsOtherMatchParseResult
-- OptionsParser
-- OptionsParseDataResult