### PR TITLE
[StyleCop] Fix all warnings in TimexProperty

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/Resolution.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/Resolution.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using DateObject = System.DateTime;
+
+namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
+{
+    public class Resolution
+    {
+        public Resolution()
+        {
+            Values = new List<Entry>();
+        }
+
+        public List<Entry> Values { get; private set; }
+
+        public class Entry
+        {
+            public string Timex { get; set; }
+
+            public string Type { get; set; }
+
+            public string Value { get; set; }
+
+            public string Start { get; set; }
+
+            public string End { get; set; }
+        }
+    }
+}

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexProperty.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexProperty.cs
@@ -19,75 +19,9 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
             TimexParsing.ParseString(timex, this);
         }
 
-        public static TimexProperty FromDate(DateObject date)
-        {
-            return new TimexProperty
-            {
-                Year = date.Year,
-                Month = date.Month,
-                DayOfMonth = date.Day
-            };
-        }
-		
-        public static TimexProperty FromDateTime(DateObject datetime)
-        {
-            var timex = FromDate(datetime);
-            timex.Hour = datetime.Hour;
-            timex.Minute = datetime.Minute;
-            timex.Second = datetime.Second;
-            return timex;
-        }
-		
-        public static TimexProperty FromTime(Time time)
-        {
-            return new TimexProperty
-            {
-                Hour = time.Hour,
-                Minute = time.Minute,
-                Second = time.Second
-            };
-        }
-
         public string TimexValue => TimexFormat.Format(this);
 
         public HashSet<string> Types => TimexInference.Infer(this);
-
-        public override string ToString()
-        {
-            return TimexConvert.ConvertTimexToString(this);
-        }
-
-        public string ToNaturalLanguage(DateObject referenceDate)
-        {
-            return TimexRelativeConvert.ConvertTimexToStringRelative(this, referenceDate);
-        }
-
-        public TimexProperty Clone()
-        {
-            return new TimexProperty
-            {
-                Now = Now,
-                Years = Years,
-                Months = Months,
-                Weeks = Weeks,
-                Days = Days,
-                Hours = Hours,
-                Minutes = Minutes,
-                Seconds = Seconds,
-                Year = Year,
-                Month = Month,
-                DayOfMonth = DayOfMonth,
-                DayOfWeek = DayOfWeek,
-                Season = Season,
-                WeekOfYear = WeekOfYear,
-                Weekend = Weekend,
-                WeekOfMonth = WeekOfMonth,
-                Hour = Hour,
-                Minute = Minute,
-                Second = Second,
-                PartOfDay = PartOfDay
-            };
-        }
 
         public bool? Now { get; set; }
 
@@ -123,7 +57,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
 
         public int? Hour
         {
-            get { return time?.Hour; }
+            get => time?.Hour;
 
             set
             {
@@ -147,7 +81,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
 
         public int? Minute
         {
-            get { return time?.Minute; }
+            get => time?.Minute;
 
             set
             {
@@ -171,7 +105,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
 
         public int? Second
         {
-            get { return time?.Second; }
+            get => time?.Second;
 
             set
             {
@@ -194,6 +128,72 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
         }
 
         public string PartOfDay { get; set; }
+
+        public static TimexProperty FromDate(DateObject date)
+        {
+            return new TimexProperty
+            {
+                Year = date.Year,
+                Month = date.Month,
+                DayOfMonth = date.Day,
+            };
+        }
+
+        public static TimexProperty FromDateTime(DateObject datetime)
+        {
+            var timex = FromDate(datetime);
+            timex.Hour = datetime.Hour;
+            timex.Minute = datetime.Minute;
+            timex.Second = datetime.Second;
+            return timex;
+        }
+
+        public static TimexProperty FromTime(Time time)
+        {
+            return new TimexProperty
+            {
+                Hour = time.Hour,
+                Minute = time.Minute,
+                Second = time.Second,
+            };
+        }
+
+        public override string ToString()
+        {
+            return TimexConvert.ConvertTimexToString(this);
+        }
+
+        public string ToNaturalLanguage(DateObject referenceDate)
+        {
+            return TimexRelativeConvert.ConvertTimexToStringRelative(this, referenceDate);
+        }
+
+        public TimexProperty Clone()
+        {
+            return new TimexProperty
+            {
+                Now = Now,
+                Years = Years,
+                Months = Months,
+                Weeks = Weeks,
+                Days = Days,
+                Hours = Hours,
+                Minutes = Minutes,
+                Seconds = Seconds,
+                Year = Year,
+                Month = Month,
+                DayOfMonth = DayOfMonth,
+                DayOfWeek = DayOfWeek,
+                Season = Season,
+                WeekOfYear = WeekOfYear,
+                Weekend = Weekend,
+                WeekOfMonth = WeekOfMonth,
+                Hour = Hour,
+                Minute = Minute,
+                Second = Second,
+                PartOfDay = PartOfDay,
+            };
+        }
 
         public void AssignProperties(IDictionary<string, string> source)
         {

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexRangeResolver.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexRangeResolver.cs
@@ -23,6 +23,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
 
             return timexResults;
         }
+
         private static List<string> ResolveDurations(IEnumerable<string> candidates, IEnumerable<TimexProperty> constraints)
         {
             var results = new List<string>();
@@ -67,10 +68,12 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
         private static IEnumerable<string> ResolveByDateRangeConstraints(IEnumerable<string> candidates, IEnumerable<TimexProperty> timexConstraints)
         {
             var dateRangeconstraints = timexConstraints
-                .Where((timex) => {
+                .Where((timex) =>
+                {
                     return timex.Types.Contains(Constants.TimexTypes.DateRange);
                 })
-                .Select((timex) => {
+                .Select((timex) =>
+                {
                     return TimexHelpers.DateRangeFromTimex(timex);
                 });
 
@@ -85,7 +88,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
             foreach (var timex in candidates)
             {
                 var r = ResolveDate(new TimexProperty(timex), collapsedDateRanges);
-                resolution.AddRange(r);        
+                resolution.AddRange(r);
             }
 
             return RemoveDuplicates(resolution);
@@ -104,12 +107,13 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
 
         private static IEnumerable<string> ResolveByTimeRangeConstraints(IEnumerable<string> candidates, IEnumerable<TimexProperty> timexConstraints)
         {
-
             var timeRangeConstraints = timexConstraints
-                .Where((timex) => {
+                .Where((timex) =>
+                {
                     return timex.Types.Contains(Constants.TimexTypes.TimeRange);
                 })
-                .Select((timex) => {
+                .Select((timex) =>
+                {
                     return TimexHelpers.TimeRangeFromTimex(timex);
                 });
 
@@ -138,7 +142,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
 
             return RemoveDuplicates(resolution);
         }
-        
+
         private static IEnumerable<string> ResolveTimeRange(TimexProperty timex, IEnumerable<TimeRange> constraints)
         {
             var candidate = TimexHelpers.TimeRangeFromTimex(timex);
@@ -184,7 +188,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
             var t = new Time(timex.Hour.Value, timex.Minute.Value, timex.Second.Value);
             if (t.GetTime() >= constraint.Start.GetTime() && t.GetTime() < constraint.End.GetTime())
             {
-                return new [] { timex.TimexValue };
+                return new[] { timex.TimexValue };
             }
 
             return Enumerable.Empty<string>();
@@ -247,19 +251,22 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
         private static IEnumerable<string> ResolveByTimeConstraints(IEnumerable<string> candidates, IEnumerable<TimexProperty> timexConstraints)
         {
             var times = timexConstraints
-                .Where((timex) => {
+                .Where((timex) =>
+                {
                     return timex.Types.Contains(Constants.TimexTypes.Time);
                 })
-                .Select((timex) => {
+                .Select((timex) =>
+                {
                     return TimexHelpers.TimeFromTimex(timex);
                 });
 
-            if (!times.Any()) {
+            if (!times.Any())
+            {
                 return candidates;
             }
 
             var resolution = new List<string>();
-            foreach (var timex in candidates.Select(t => new TimexProperty(t))) 
+            foreach (var timex in candidates.Select(t => new TimexProperty(t)))
             {
                 if (timex.Types.Contains(Constants.TimexTypes.Date) && !timex.Types.Contains(Constants.TimexTypes.Time))
                 {

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexRegex.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexRegex.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
                     new Regex(@"^(?<year>\d\d\d\d)-W(?<weekOfYear>\d\d)-(?<weekend>WE)$"),
                     new Regex(@"^XXXX-(?<month>\d\d)$"),
                     new Regex(@"^XXXX-(?<month>\d\d)-W(?<weekOfMonth>\d\d)$"),
-                    new Regex(@"^XXXX-(?<month>\d\d)-WXX-(?<weekOfMonth>\d)-(?<dayOfWeek>\d)$")
+                    new Regex(@"^XXXX-(?<month>\d\d)-WXX-(?<weekOfMonth>\d)-(?<dayOfWeek>\d)$"),
                 }
             },
             {
@@ -39,17 +39,30 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
                     new Regex(@"^T(?<hour>\d\d):(?<minute>\d\d):(?<second>\d\d)$"),
 
                     // timerange
-                    new Regex(@"^T(?<partOfDay>DT|NI|MO|AF|EV)$")
+                    new Regex(@"^T(?<partOfDay>DT|NI|MO|AF|EV)$"),
                 }
             },
             {
                 "period", new Regex[]
                 {
                     new Regex(@"^P(?<amount>\d*\.?\d+)(?<dateUnit>Y|M|W|D)$"),
-                    new Regex(@"^PT(?<amount>\d*\.?\d+)(?<timeUnit>H|M|S)$")
+                    new Regex(@"^PT(?<amount>\d*\.?\d+)(?<timeUnit>H|M|S)$"),
+                }
+            },
+        };
+
+        public static bool Extract(string name, string timex, IDictionary<string, string> result)
+        {
+            foreach (var entry in timexRegex[name])
+            {
+                if (TryExtract(entry, timex, result))
+                {
+                    return true;
                 }
             }
-        };
+
+            return false;
+        }
 
         private static bool TryExtract(Regex regex, string timex, IDictionary<string, string> result)
         {
@@ -65,19 +78,6 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
             }
 
             return true;
-        }
-
-        public static bool Extract(string name, string timex, IDictionary<string, string> result)
-        {
-            foreach (var entry in timexRegex[name])
-            {
-                if (TryExtract(entry, timex, result))
-                {
-                    return true;
-                }
-            }
-
-            return false;
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexResolver.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexResolver.cs
@@ -9,31 +9,8 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
 {
     public static class TimexResolver
     {
-        public class Resolution
+        public static Resolution Resolve(string[] timexArray, DateObject date = default(DateObject))
         {
-            public class Entry
-            {
-                public string Timex { get; set; }
-
-                public string Type { get; set; }
-
-                public string Value { get; set; }
-
-                public string Start { get; set; }
-
-                public string End { get; set; }
-            }
-
-            public List<Entry> Values { get; private set; }
-
-            public Resolution()
-            {
-                Values = new List<Entry>();
-            }
-        }
-
-        public static Resolution Resolve(string[] timexArray, DateObject date = default(DateObject)) {
-
             var resolution = new Resolution();
             foreach (var timex in timexArray)
             {
@@ -105,8 +82,8 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
                 {
                     Timex = timex.TimexValue,
                     Type = "datetime",
-                    Value = $"{TimexValue.DateValue(timex)} {TimexValue.TimeValue(timex)}"
-                }
+                    Value = $"{TimexValue.DateValue(timex)} {TimexValue.TimeValue(timex)}",
+                },
             };
         }
 
@@ -118,10 +95,11 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
                 {
                     Timex = timex.TimexValue,
                     Type = "date",
-                    Value = TimexValue.DateValue(timex)
-                }
+                    Value = TimexValue.DateValue(timex),
+                },
             };
         }
+
         private static List<Resolution.Entry> ResolveDate(TimexProperty timex, DateObject date)
         {
             return new List<Resolution.Entry>
@@ -130,14 +108,14 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
                 {
                     Timex = timex.TimexValue,
                     Type = "date",
-                    Value = LastDateValue(timex, date)
+                    Value = LastDateValue(timex, date),
                 },
                 new Resolution.Entry
                 {
                     Timex = timex.TimexValue,
                     Type = "date",
-                    Value = NextDateValue(timex, date)
-                }
+                    Value = NextDateValue(timex, date),
+                },
             };
         }
 
@@ -149,7 +127,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
                 {
                     Year = date.Year - 1,
                     Month = timex.Month,
-                    DayOfMonth = timex.DayOfMonth
+                    DayOfMonth = timex.DayOfMonth,
                 });
             }
 
@@ -161,7 +139,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
                 {
                     Year = result.Year,
                     Month = result.Month,
-                    DayOfMonth = result.Day
+                    DayOfMonth = result.Day,
                 });
             }
 
@@ -176,7 +154,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
                 {
                     Year = date.Year,
                     Month = timex.Month,
-                    DayOfMonth = timex.DayOfMonth
+                    DayOfMonth = timex.DayOfMonth,
                 });
             }
 
@@ -188,7 +166,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
                 {
                     Year = result.Year,
                     Month = result.Month,
-                    DayOfMonth = result.Day
+                    DayOfMonth = result.Day,
                 });
             }
 
@@ -203,8 +181,8 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
                 {
                     Timex = timex.TimexValue,
                     Type = "time",
-                    Value = TimexValue.TimeValue(timex)
-                }
+                    Value = TimexValue.TimeValue(timex),
+                },
             };
         }
 
@@ -216,16 +194,16 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
                 {
                     Timex = timex.TimexValue,
                     Type = "duration",
-                    Value = TimexValue.DurationValue(timex)
-                }
+                    Value = TimexValue.DurationValue(timex),
+                },
             };
         }
 
-        private static Tuple<string, string> MonthDateRange(int year, int month) {
+        private static Tuple<string, string> MonthDateRange(int year, int month)
+        {
             return new Tuple<string, string>(
                 TimexValue.DateValue(new TimexProperty { Year = year, Month = month, DayOfMonth = 1 }),
-                TimexValue.DateValue(new TimexProperty { Year = year, Month = month + 1, DayOfMonth = 1 })
-            );
+                TimexValue.DateValue(new TimexProperty { Year = year, Month = month + 1, DayOfMonth = 1 }));
         }
 
         private static List<Resolution.Entry> ResolveDateRange(TimexProperty timex, DateObject date)
@@ -238,8 +216,8 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
                     {
                         Timex = timex.TimexValue,
                         Type = "daterange",
-                        Value = "not resolved"
-                    }
+                        Value = "not resolved",
+                    },
                 };
             }
             else
@@ -254,8 +232,8 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
                             Timex = timex.TimexValue,
                             Type = "daterange",
                             Start = dateRange.Item1,
-                            End = dateRange.Item2
-                        }
+                            End = dateRange.Item2,
+                        },
                     };
                 }
 
@@ -264,7 +242,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
                     var y = date.Year;
                     var lastYearDateRange = MonthDateRange(y - 1, timex.Month.Value);
                     var thisYearDateRange = MonthDateRange(y, timex.Month.Value);
-            
+
                     return new List<Resolution.Entry>
                     {
                         new Resolution.Entry
@@ -272,15 +250,15 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
                             Timex = timex.TimexValue,
                             Type = "daterange",
                             Start = lastYearDateRange.Item1,
-                            End = lastYearDateRange.Item2
+                            End = lastYearDateRange.Item2,
                         },
                         new Resolution.Entry
                         {
                             Timex = timex.TimexValue,
                             Type = "daterange",
                             Start = thisYearDateRange.Item1,
-                            End = thisYearDateRange.Item2
-                        }
+                            End = thisYearDateRange.Item2,
+                        },
                     };
                 }
 
@@ -313,8 +291,8 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
                         Timex = timex.TimexValue,
                         Type = "timerange",
                         Start = range.Item1,
-                        End = range.Item2
-                    }
+                        End = range.Item2,
+                    },
                 };
             }
             else
@@ -327,8 +305,8 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
                         Timex = timex.TimexValue,
                         Type = "timerange",
                         Start = TimexValue.TimeValue(range.Start),
-                        End = TimexValue.TimeValue(range.End)
-                    }
+                        End = TimexValue.TimeValue(range.End),
+                    },
                 };
             }
         }
@@ -358,8 +336,8 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
                         Timex = timex.TimexValue,
                         Type = "datetimerange",
                         Start = $"{date} {timeRange.Item1}",
-                        End = $"{date} {timeRange.Item2}"
-                    }
+                        End = $"{date} {timeRange.Item2}",
+                    },
                 };
             }
             else
@@ -372,8 +350,8 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
                         Timex = timex.TimexValue,
                         Type = "datetimerange",
                         Start = $"{TimexValue.DateValue(range.Start)} {TimexValue.TimeValue(range.Start)}",
-                        End = $"{TimexValue.DateValue(range.End)} {TimexValue.TimeValue(range.End)}"
-                    }
+                        End = $"{TimexValue.DateValue(range.End)} {TimexValue.TimeValue(range.End)}",
+                    },
                 };
             }
         }


### PR DESCRIPTION
- Remove trailing whitespace
- Reorder methods and parameters
- Add trailing comma
- Create the file for the class Resolution