### PR TITLE
 [StyleCop] Fix all the warnings in DataType.Tests

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.DataDrivenTests/Microsoft.Recognizers.Text.DataDrivenTests.csproj
+++ b/.NET/Microsoft.Recognizers.Text.DataDrivenTests/Microsoft.Recognizers.Text.DataDrivenTests.csproj
@@ -30,6 +30,7 @@
     <DefineConstants>TRACE;DEBUG;NET462</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <CodeAnalysisRuleSet>../Recognizers-Text.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests.csproj
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests.csproj
@@ -24,6 +24,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <CodeAnalysisRuleSet>../Recognizers-Text.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests.csproj
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests.csproj
@@ -16,6 +16,17 @@
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
   </PropertyGroup>
+  <PropertyGroup>
+	  <!--
+		Make sure any documentation comments which are included in code get checked for syntax during the build, but do
+		not report warnings for missing comments.
+
+		CS1573: Parameter 'parameter' has no matching param tag in the XML comment for 'parameter' (but other parameters do)
+		CS1591: Missing XML comment for publicly visible type or member 'Type_or_Member'
+	  -->
+	  <DocumentationFile>$(OutputPath)$(AssemblyName).xml</DocumentationFile>
+	  <NoWarn>$(NoWarn),1573,1591,1712</NoWarn>
+	</PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests.xml
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<doc>
+    <assembly>
+        <name>Microsoft.Recognizers.Text.DataTypes.DataDrivenTests</name>
+    </assembly>
+    <members>
+    </members>
+</doc>

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests/TestTimex.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests/TestTimex.cs
@@ -21,17 +21,6 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         }
 
         [TestMethod]
-        public void DataTypes_Timex_FromTime()
-        {
-            Assert.AreEqual("T23:59:30", TimexProperty.FromTime(new Time(23, 59, 30)).TimexValue);
-        }
-
-        private static void Roundtrip(string timex)
-        {
-            Assert.AreEqual(timex, (new TimexProperty(timex)).TimexValue);
-        }
-
-        [TestMethod]
         public void DataTypes_Timex_Roundtrip_Date()
         {
             Roundtrip("2017-09-27");
@@ -122,14 +111,25 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         [TestMethod]
         public void DataTypes_Timex_ToString()
         {
-            Assert.AreEqual("5th May", (new TimexProperty("XXXX-05-05")).ToString());
+            Assert.AreEqual("5th May", new TimexProperty("XXXX-05-05").ToString());
         }
 
         [TestMethod]
         public void DataTypes_Timex_ToNaturalLanguage()
         {
             var today = new System.DateTime(2017, 10, 16);
-            Assert.AreEqual("tomorrow", (new TimexProperty("2017-10-17")).ToNaturalLanguage(today));
+            Assert.AreEqual("tomorrow", new TimexProperty("2017-10-17").ToNaturalLanguage(today));
+        }
+
+        [TestMethod]
+        public void DataTypes_Timex_FromTime()
+        {
+            Assert.AreEqual("T23:59:30", TimexProperty.FromTime(new Time(23, 59, 30)).TimexValue);
+        }
+
+        private static void Roundtrip(string timex)
+        {
+            Assert.AreEqual(timex, new TimexProperty(timex).TimexValue);
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests/TestTimexConvert.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests/TestTimexConvert.cs
@@ -116,6 +116,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         {
             Assert.AreEqual("summer 1999", TimexConvert.ConvertTimexToString(new TimexProperty("1999-SU")));
         }
+
         public void DataTypes_Convert_Season()
         {
             Assert.AreEqual("summer", TimexConvert.ConvertTimexToString(new TimexProperty("SU")));
@@ -170,7 +171,8 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         {
             // date + time + duration
             var timex = new TimexProperty("(2017-09-08T21:19:29,2017-09-08T21:24:29,PT5M)");
-            // TODO 
+
+            // TODO
         }
 
         [TestMethod]
@@ -178,6 +180,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         {
             // date + duration
             var timex = new TimexProperty("(XXXX-WXX-3,XXXX-WXX-6,P3D)");
+
             // TODO
         }
 

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests/TestTimexCreator.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests/TestTimexCreator.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
             {
                 Year = d.Year,
                 Month = d.Month,
-                DayOfMonth = d.Day
+                DayOfMonth = d.Day,
             });
             Assert.AreEqual(expected, TimexCreator.Today());
         }
@@ -37,7 +37,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
             {
                 Year = d.Year,
                 Month = d.Month,
-                DayOfMonth = d.Day
+                DayOfMonth = d.Day,
             });
             Assert.AreEqual(expected, TimexCreator.Tomorrow());
         }
@@ -57,7 +57,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
             {
                 Year = d.Year,
                 Month = d.Month,
-                DayOfMonth = d.Day
+                DayOfMonth = d.Day,
             });
             Assert.AreEqual(expected, TimexCreator.Yesterday());
         }
@@ -77,7 +77,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
                 Year = d.Year,
                 Month = d.Month,
                 DayOfMonth = d.Day,
-                Days = 7
+                Days = 7,
             });
             Assert.AreEqual(expected, TimexCreator.WeekFromToday());
         }
@@ -98,7 +98,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
                 Year = d.Year,
                 Month = d.Month,
                 DayOfMonth = d.Day,
-                Days = 7
+                Days = 7,
             });
             Assert.AreEqual(expected, TimexCreator.WeekBackFromToday());
         }
@@ -124,7 +124,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         {
             Assert.AreEqual("(2017-10-09,2017-10-16,P7D)", TimexCreator.NextWeek(new System.DateTime(2017, 10, 5)));
         }
-        
+
         [TestMethod]
         public void DataTypes_Creator_lastWeek()
         {
@@ -151,7 +151,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
                 Year = d.Year,
                 Month = d.Month,
                 DayOfMonth = d.Day,
-                Days = 14
+                Days = 14,
             });
             Assert.AreEqual(expected, TimexCreator.NextWeeksFromToday(2));
         }

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests/TestTimexFormat.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests/TestTimexFormat.cs
@@ -11,67 +11,67 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         [TestMethod]
         public void DataTypes_Format_Date()
         {
-            Assert.AreEqual("2017-09-27", (new TimexProperty { Year = 2017, Month = 9, DayOfMonth = 27 }).TimexValue);
-            Assert.AreEqual("XXXX-WXX-3", (new TimexProperty { DayOfWeek = 3 }).TimexValue);
-            Assert.AreEqual("XXXX-12-05", (new TimexProperty { Month = 12, DayOfMonth = 5 }).TimexValue);
+            Assert.AreEqual("2017-09-27", new TimexProperty { Year = 2017, Month = 9, DayOfMonth = 27 }.TimexValue);
+            Assert.AreEqual("XXXX-WXX-3", new TimexProperty { DayOfWeek = 3 }.TimexValue);
+            Assert.AreEqual("XXXX-12-05", new TimexProperty { Month = 12, DayOfMonth = 5 }.TimexValue);
         }
 
         [TestMethod]
         public void DataTypes_Format_Time()
         {
-            Assert.AreEqual("T17:30:45", (new TimexProperty { Hour = 17, Minute = 30, Second = 45 }).TimexValue);
-            Assert.AreEqual("T05:06:07", (new TimexProperty { Hour = 5, Minute = 6, Second = 7 }).TimexValue);
-            Assert.AreEqual("T17:30", (new TimexProperty { Hour = 17, Minute = 30, Second = 0 }).TimexValue);
-            Assert.AreEqual("T23", (new TimexProperty { Hour = 23, Minute = 0, Second = 0 }).TimexValue);
+            Assert.AreEqual("T17:30:45", new TimexProperty { Hour = 17, Minute = 30, Second = 45 }.TimexValue);
+            Assert.AreEqual("T05:06:07", new TimexProperty { Hour = 5, Minute = 6, Second = 7 }.TimexValue);
+            Assert.AreEqual("T17:30", new TimexProperty { Hour = 17, Minute = 30, Second = 0 }.TimexValue);
+            Assert.AreEqual("T23", new TimexProperty { Hour = 23, Minute = 0, Second = 0 }.TimexValue);
         }
 
         [TestMethod]
         public void DataTypes_Format_Duration()
         {
-            Assert.AreEqual("P50Y", (new TimexProperty { Years = 50 }).TimexValue);
-            Assert.AreEqual("P6M", (new TimexProperty { Months = 6 }).TimexValue);
-            Assert.AreEqual("P3W", (new TimexProperty { Weeks = 3 }).TimexValue);
-            Assert.AreEqual("P5D", (new TimexProperty { Days = 5 }).TimexValue);
-            Assert.AreEqual("PT16H", (new TimexProperty { Hours = 16 }).TimexValue);
-            Assert.AreEqual("PT32M", (new TimexProperty { Minutes = 32 }).TimexValue);
-            Assert.AreEqual("PT20S", (new TimexProperty { Seconds = 20 }).TimexValue);
+            Assert.AreEqual("P50Y", new TimexProperty { Years = 50 }.TimexValue);
+            Assert.AreEqual("P6M", new TimexProperty { Months = 6 }.TimexValue);
+            Assert.AreEqual("P3W", new TimexProperty { Weeks = 3 }.TimexValue);
+            Assert.AreEqual("P5D", new TimexProperty { Days = 5 }.TimexValue);
+            Assert.AreEqual("PT16H", new TimexProperty { Hours = 16 }.TimexValue);
+            Assert.AreEqual("PT32M", new TimexProperty { Minutes = 32 }.TimexValue);
+            Assert.AreEqual("PT20S", new TimexProperty { Seconds = 20 }.TimexValue);
         }
 
         [TestMethod]
         public void DataTypes_Format_Present()
         {
-            Assert.AreEqual("PRESENT_REF", (new TimexProperty { Now = true }).TimexValue);
+            Assert.AreEqual("PRESENT_REF", new TimexProperty { Now = true }.TimexValue);
         }
 
         [TestMethod]
         public void DataTypes_Format_DateTime()
         {
-            Assert.AreEqual("XXXX-WXX-3T04", (new TimexProperty { DayOfWeek = 3, Hour = 4, Minute = 0, Second = 0 }).TimexValue);
-            Assert.AreEqual("2017-09-27T11:41:30", (new TimexProperty { Year = 2017, Month = 9, DayOfMonth = 27, Hour = 11, Minute = 41, Second = 30 }).TimexValue);
+            Assert.AreEqual("XXXX-WXX-3T04", new TimexProperty { DayOfWeek = 3, Hour = 4, Minute = 0, Second = 0 }.TimexValue);
+            Assert.AreEqual("2017-09-27T11:41:30", new TimexProperty { Year = 2017, Month = 9, DayOfMonth = 27, Hour = 11, Minute = 41, Second = 30 }.TimexValue);
         }
 
         [TestMethod]
         public void DataTypes_Format_DateRange()
         {
-            Assert.AreEqual("2017", (new TimexProperty { Year = 2017 }).TimexValue);
-            Assert.AreEqual("SU", (new TimexProperty { Season = "SU" }).TimexValue);
-            Assert.AreEqual("2017-WI", (new TimexProperty { Year = 2017, Season = "WI" }).TimexValue);
-            Assert.AreEqual("2017-09", (new TimexProperty { Year = 2017, Month = 9 }).TimexValue);
-            Assert.AreEqual("2017-W37", (new TimexProperty { Year = 2017, WeekOfYear = 37 }).TimexValue);
-            Assert.AreEqual("2017-W37-WE", (new TimexProperty { Year = 2017, WeekOfYear = 37, Weekend = true }).TimexValue);
-            Assert.AreEqual("XXXX-05", (new TimexProperty { Month = 5 }).TimexValue);
+            Assert.AreEqual("2017", new TimexProperty { Year = 2017 }.TimexValue);
+            Assert.AreEqual("SU", new TimexProperty { Season = "SU" }.TimexValue);
+            Assert.AreEqual("2017-WI", new TimexProperty { Year = 2017, Season = "WI" }.TimexValue);
+            Assert.AreEqual("2017-09", new TimexProperty { Year = 2017, Month = 9 }.TimexValue);
+            Assert.AreEqual("2017-W37", new TimexProperty { Year = 2017, WeekOfYear = 37 }.TimexValue);
+            Assert.AreEqual("2017-W37-WE", new TimexProperty { Year = 2017, WeekOfYear = 37, Weekend = true }.TimexValue);
+            Assert.AreEqual("XXXX-05", new TimexProperty { Month = 5 }.TimexValue);
         }
 
         [TestMethod]
         public void DataTypes_Format_TimeRange()
         {
-            Assert.AreEqual("TEV", (new TimexProperty { PartOfDay = "EV" }).TimexValue);
+            Assert.AreEqual("TEV", new TimexProperty { PartOfDay = "EV" }.TimexValue);
         }
 
         [TestMethod]
         public void DataTypes_Format_DateTimeRange()
         {
-            Assert.AreEqual("2017-09-27TEV", (new TimexProperty { Year = 2017, Month = 9, DayOfMonth = 27, PartOfDay = "EV" }).TimexValue);
+            Assert.AreEqual("2017-09-27TEV", new TimexProperty { Year = 2017, Month = 9, DayOfMonth = 27, PartOfDay = "EV" }.TimexValue);
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests/TestTimexHelpers.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests/TestTimexHelpers.cs
@@ -93,7 +93,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         {
             var timex = new TimexProperty("T00:05:00");
             var time = TimexHelpers.TimeFromTimex(timex);
-            Assert.AreEqual((new Time(0, 5, 0)).GetTime(), time.GetTime());
+            Assert.AreEqual(new Time(0, 5, 0).GetTime(), time.GetTime());
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests/TestTimexParsing.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests/TestTimexParsing.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System.Linq;
@@ -36,7 +36,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
             Assert.IsNull(timex.Seconds);
             Assert.IsNull(timex.Now);
         }
-		
+
         [TestMethod]
         public void DataTypes_Parsing_MonthAndDayOfMonth()
         {
@@ -64,7 +64,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
             Assert.IsNull(timex.Seconds);
             Assert.IsNull(timex.Now);
         }
-		
+
         [TestMethod]
         public void DataTypes_Parsing_DayOfWeek()
         {
@@ -92,7 +92,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
             Assert.IsNull(timex.Seconds);
             Assert.IsNull(timex.Now);
         }
-		
+
         [TestMethod]
         public void DataTypes_Parsing_HoursMinutesAndSeconds()
         {
@@ -120,7 +120,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
             Assert.IsNull(timex.Seconds);
             Assert.IsNull(timex.Now);
         }
-		
+
         [TestMethod]
         public void DataTypes_Parsing_HoursAndMinutes()
         {
@@ -148,7 +148,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
             Assert.IsNull(timex.Seconds);
             Assert.IsNull(timex.Now);
         }
-		
+
         [TestMethod]
         public void DataTypes_Parsing_Hours()
         {
@@ -176,16 +176,19 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
             Assert.IsNull(timex.Seconds);
             Assert.IsNull(timex.Now);
         }
-		
+
         [TestMethod]
         public void DataTypes_Parsing_Now()
         {
             var timex = new TimexProperty("PRESENT_REF");
-            CollectionAssert.AreEquivalent(new[] {
+            CollectionAssert.AreEquivalent(
+                new[]
+                {
                 Constants.TimexTypes.Present,
                 Constants.TimexTypes.Date,
                 Constants.TimexTypes.Time,
-                Constants.TimexTypes.DateTime }, timex.Types.ToList());
+                Constants.TimexTypes.DateTime,
+                }, timex.Types.ToList());
 
             Assert.IsNull(timex.Year);
             Assert.IsNull(timex.Month);
@@ -208,16 +211,19 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
             Assert.IsNull(timex.Seconds);
             Assert.AreEqual(true, timex.Now);
         }
-		
+
         [TestMethod]
         public void DataTypes_Parsing_FullDatetime()
         {
             var timex = new TimexProperty("1984-01-03T18:30:45");
-            CollectionAssert.AreEquivalent(new[] {
+            CollectionAssert.AreEquivalent(
+                new[]
+                {
                 Constants.TimexTypes.Definite,
                 Constants.TimexTypes.Date,
                 Constants.TimexTypes.Time,
-                Constants.TimexTypes.DateTime }, timex.Types.ToList());
+                Constants.TimexTypes.DateTime,
+                }, timex.Types.ToList());
 
             Assert.AreEqual(1984, timex.Year);
             Assert.AreEqual(1, timex.Month);
@@ -240,13 +246,13 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
             Assert.IsNull(timex.Seconds);
             Assert.IsNull(timex.Now);
         }
-		
+
         [TestMethod]
         public void DataTypes_Parsing_ParicularTimeOnParticularDayOfWeek()
         {
             var timex = new TimexProperty("XXXX-WXX-3T16");
-            CollectionAssert.AreEquivalent(new[] { Constants.TimexTypes.Time, Constants.TimexTypes.Date, Constants.TimexTypes.DateTime }, 
-                                           timex.Types.ToList());
+            CollectionAssert.AreEquivalent(
+                new[] { Constants.TimexTypes.Time, Constants.TimexTypes.Date, Constants.TimexTypes.DateTime }, timex.Types.ToList());
 
             Assert.IsNull(timex.Year);
             Assert.IsNull(timex.Month);
@@ -269,7 +275,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
             Assert.IsNull(timex.Seconds);
             Assert.IsNull(timex.Now);
         }
-		
+
         [TestMethod]
         public void DataTypes_Parsing_Year()
         {
@@ -297,7 +303,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
             Assert.IsNull(timex.Seconds);
             Assert.IsNull(timex.Now);
         }
-		
+
         [TestMethod]
         public void DataTypes_Parsing_SummerOf1999()
         {
@@ -325,7 +331,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
             Assert.IsNull(timex.Seconds);
             Assert.IsNull(timex.Now);
         }
-		
+
         [TestMethod]
         public void DataTypes_Parsing_YearAndWeek()
         {
@@ -353,7 +359,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
             Assert.IsNull(timex.Seconds);
             Assert.IsNull(timex.Now);
         }
-		
+
         [TestMethod]
         public void DataTypes_Parsing_SeasonSummer()
         {
@@ -381,7 +387,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
             Assert.IsNull(timex.Seconds);
             Assert.IsNull(timex.Now);
         }
-		
+
         [TestMethod]
         public void DataTypes_Parsing_SeasonWinter()
         {
@@ -409,7 +415,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
             Assert.IsNull(timex.Seconds);
             Assert.IsNull(timex.Now);
         }
-		
+
         [TestMethod]
         public void DataTypes_Parsing_YearAndWeekend()
         {
@@ -437,7 +443,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
             Assert.IsNull(timex.Seconds);
             Assert.IsNull(timex.Now);
         }
-		
+
         [TestMethod]
         public void DataTypes_Parsing_May()
         {
@@ -465,7 +471,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
             Assert.IsNull(timex.Seconds);
             Assert.IsNull(timex.Now);
         }
-		
+
         [TestMethod]
         public void DataTypes_Parsing_July2020()
         {
@@ -493,7 +499,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
             Assert.IsNull(timex.Seconds);
             Assert.IsNull(timex.Now);
         }
-		
+
         [TestMethod]
         public void DataTypes_Parsing_WeekOfMonth()
         {
@@ -521,15 +527,18 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
             Assert.IsNull(timex.Seconds);
             Assert.IsNull(timex.Now);
         }
-		
+
         [TestMethod]
         public void DataTypes_Parsing_WednesdayToSaturday()
         {
             var timex = new TimexProperty("(XXXX-WXX-3,XXXX-WXX-6,P3D)");
-            CollectionAssert.AreEquivalent(new[] {
+            CollectionAssert.AreEquivalent(
+                new[]
+                {
                 Constants.TimexTypes.Date,
                 Constants.TimexTypes.Duration,
-                Constants.TimexTypes.DateRange }, timex.Types.ToList());
+                Constants.TimexTypes.DateRange,
+                }, timex.Types.ToList());
 
             Assert.IsNull(timex.Year);
             Assert.IsNull(timex.Month);
@@ -552,15 +561,18 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
             Assert.IsNull(timex.Seconds);
             Assert.IsNull(timex.Now);
         }
-		
+
         [TestMethod]
         public void DataTypes_Parsing_Jan1ToAug5()
         {
             var timex = new TimexProperty("(XXXX-01-01,XXXX-08-05,P216D)");
-            CollectionAssert.AreEquivalent(new[] {
+            CollectionAssert.AreEquivalent(
+                new[]
+                {
                 Constants.TimexTypes.Date,
                 Constants.TimexTypes.Duration,
-                Constants.TimexTypes.DateRange }, timex.Types.ToList());
+                Constants.TimexTypes.DateRange,
+                }, timex.Types.ToList());
 
             Assert.IsNull(timex.Year);
             Assert.AreEqual(1, timex.Month);
@@ -583,16 +595,19 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
             Assert.IsNull(timex.Seconds);
             Assert.IsNull(timex.Now);
         }
-		
+
         [TestMethod]
         public void DataTypes_Parsing_Jan1ToAug5Year2015()
         {
             var timex = new TimexProperty("(2015-01-01,2015-08-05,P216D)");
-            CollectionAssert.AreEquivalent(new[] {
+            CollectionAssert.AreEquivalent(
+                new[]
+                {
                 Constants.TimexTypes.Definite,
                 Constants.TimexTypes.Date,
                 Constants.TimexTypes.Duration,
-                Constants.TimexTypes.DateRange }, timex.Types.ToList());
+                Constants.TimexTypes.DateRange,
+                }, timex.Types.ToList());
 
             Assert.AreEqual(2015, timex.Year);
             Assert.AreEqual(1, timex.Month);
@@ -615,7 +630,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
             Assert.IsNull(timex.Seconds);
             Assert.IsNull(timex.Now);
         }
-		
+
         [TestMethod]
         public void DataTypes_Parsing_DayTime()
         {
@@ -643,7 +658,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
             Assert.IsNull(timex.Seconds);
             Assert.IsNull(timex.Now);
         }
-		
+
         [TestMethod]
         public void DataTypes_Parsing_NightTime()
         {
@@ -671,7 +686,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
             Assert.IsNull(timex.Seconds);
             Assert.IsNull(timex.Now);
         }
-		
+
         [TestMethod]
         public void DataTypes_Parsing_Morning()
         {
@@ -699,7 +714,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
             Assert.IsNull(timex.Seconds);
             Assert.IsNull(timex.Now);
         }
-		
+
         [TestMethod]
         public void DataTypes_Parsing_Afternoon()
         {
@@ -727,7 +742,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
             Assert.IsNull(timex.Seconds);
             Assert.IsNull(timex.Now);
         }
-		
+
         [TestMethod]
         public void DataTypes_Parsing_Evening()
         {
@@ -755,15 +770,18 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
             Assert.IsNull(timex.Seconds);
             Assert.IsNull(timex.Now);
         }
-		
+
         [TestMethod]
         public void DataTypes_Parsing_Timerange430pmTo445pm()
         {
             var timex = new TimexProperty("(T16:30,T16:45,PT15M)");
-            CollectionAssert.AreEquivalent(new[] {
+            CollectionAssert.AreEquivalent(
+                new[]
+                {
                 Constants.TimexTypes.Time,
                 Constants.TimexTypes.Duration,
-                Constants.TimexTypes.TimeRange }, timex.Types.ToList());
+                Constants.TimexTypes.TimeRange,
+                }, timex.Types.ToList());
 
             Assert.IsNull(timex.Year);
             Assert.IsNull(timex.Month);
@@ -786,15 +804,18 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
             Assert.IsNull(timex.Seconds);
             Assert.IsNull(timex.Now);
         }
-		
+
         [TestMethod]
         public void DataTypes_Parsing_DateTimeRange()
         {
             var timex = new TimexProperty("XXXX-WXX-5TEV");
-            CollectionAssert.AreEquivalent(new[] {
+            CollectionAssert.AreEquivalent(
+                new[]
+                {
                 Constants.TimexTypes.Date,
                 Constants.TimexTypes.TimeRange,
-                Constants.TimexTypes.DateTimeRange }, timex.Types.ToList());
+                Constants.TimexTypes.DateTimeRange,
+                }, timex.Types.ToList());
 
             Assert.IsNull(timex.Year);
             Assert.IsNull(timex.Month);
@@ -817,16 +838,19 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
             Assert.IsNull(timex.Seconds);
             Assert.IsNull(timex.Now);
         }
-		
+
         [TestMethod]
         public void DataTypes_Parsing_LastNight()
         {
             var timex = new TimexProperty("2017-09-07TNI");
-            CollectionAssert.AreEquivalent(new[] {
+            CollectionAssert.AreEquivalent(
+                new[]
+                {
                 Constants.TimexTypes.Definite,
                 Constants.TimexTypes.Date,
                 Constants.TimexTypes.TimeRange,
-                Constants.TimexTypes.DateTimeRange }, timex.Types.ToList());
+                Constants.TimexTypes.DateTimeRange,
+                }, timex.Types.ToList());
 
             Assert.AreEqual(2017, timex.Year);
             Assert.AreEqual(9, timex.Month);
@@ -849,12 +873,14 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
             Assert.IsNull(timex.Seconds);
             Assert.IsNull(timex.Now);
         }
-		
+
         [TestMethod]
         public void DataTypes_Parsing_Last5Minutes()
         {
             var timex = new TimexProperty("(2017-09-08T21:19:29,2017-09-08T21:24:29,PT5M)");
-            CollectionAssert.AreEquivalent(new[] {
+            CollectionAssert.AreEquivalent(
+                new[]
+                {
                 Constants.TimexTypes.Date,
                 Constants.TimexTypes.TimeRange,
                 Constants.TimexTypes.DateTimeRange,
@@ -862,7 +888,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
                 Constants.TimexTypes.DateTime,
                 Constants.TimexTypes.Duration,
                 Constants.TimexTypes.DateRange,
-                Constants.TimexTypes.Definite
+                Constants.TimexTypes.Definite,
             }, timex.Types.ToList());
 
             Assert.AreEqual(2017, timex.Year);
@@ -886,12 +912,14 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
             Assert.IsNull(timex.Seconds);
             Assert.IsNull(timex.Now);
         }
-		
+
         [TestMethod]
         public void DataTypes_Parsing_Wed4PMToSat3PM()
         {
             var timex = new TimexProperty("(XXXX-WXX-3T16,XXXX-WXX-6T15,PT71H)");
-            CollectionAssert.AreEquivalent(new[] {
+            CollectionAssert.AreEquivalent(
+                new[]
+                {
                 Constants.TimexTypes.Date,
                 Constants.TimexTypes.TimeRange,
                 Constants.TimexTypes.DateTimeRange,
@@ -922,7 +950,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
             Assert.IsNull(timex.Seconds);
             Assert.IsNull(timex.Now);
         }
-		
+
         [TestMethod]
         public void DataTypes_Parsing_DurationYears()
         {
@@ -950,7 +978,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
             Assert.IsNull(timex.Seconds);
             Assert.IsNull(timex.Now);
         }
-		
+
         [TestMethod]
         public void DataTypes_Parsing_DurationMonths()
         {
@@ -978,7 +1006,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
             Assert.IsNull(timex.Seconds);
             Assert.IsNull(timex.Now);
         }
-		
+
         [TestMethod]
         public void DataTypes_Parsing_DurationWeeks()
         {
@@ -1006,7 +1034,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
             Assert.IsNull(timex.Seconds);
             Assert.IsNull(timex.Now);
         }
-		
+
         [TestMethod]
         public void DataTypes_Parsing_DurationWeeksFloatingPoint()
         {
@@ -1034,7 +1062,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
             Assert.IsNull(timex.Seconds);
             Assert.IsNull(timex.Now);
         }
-		
+
         [TestMethod]
         public void DataTypes_Parsing_DurationDays()
         {
@@ -1062,7 +1090,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
             Assert.IsNull(timex.Seconds);
             Assert.IsNull(timex.Now);
         }
-		
+
         [TestMethod]
         public void DataTypes_Parsing_DurationHours()
         {
@@ -1090,7 +1118,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
             Assert.IsNull(timex.Seconds);
             Assert.IsNull(timex.Now);
         }
-		
+
         [TestMethod]
         public void DataTypes_Parsing_DurationMinutes()
         {
@@ -1118,7 +1146,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
             Assert.IsNull(timex.Seconds);
             Assert.IsNull(timex.Now);
         }
-		
+
         [TestMethod]
         public void DataTypes_Parsing_DurationSeconds()
         {

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests/TestTimexRangeResolve.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests/TestTimexRangeResolve.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         public void DataTypes_RangeResolve_daterange_definite()
         {
             var candidates = new[] { "2017-09-28" };
-            var constraints = new[] { (new TimexProperty { Year = 2017, Month = 9, DayOfMonth = 27, Days = 2 }).TimexValue };
+            var constraints = new[] { new TimexProperty { Year = 2017, Month = 9, DayOfMonth = 27, Days = 2 }.TimexValue };
 
             var result = TimexRangeResolver.Evaluate(candidates, constraints);
 
@@ -40,7 +40,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         public void DataTypes_RangeResolve_daterange_month_and_date()
         {
             var candidates = new[] { "XXXX-05-29" };
-            var constraints = new[] { (new TimexProperty { Year = 2006, Month = 1, DayOfMonth = 1, Years = 2 }).TimexValue };
+            var constraints = new[] { new TimexProperty { Year = 2006, Month = 1, DayOfMonth = 1, Years = 2 }.TimexValue };
 
             var result = TimexRangeResolver.Evaluate(candidates, constraints);
 
@@ -145,12 +145,12 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
             var candidates = new[]
             {
                 "XXXX-WXX-2",
-                "XXXX-WXX-4"
+                "XXXX-WXX-4",
             };
             var constraints = new[]
             {
                 "(2017-09-01,2017-09-08,P7D)",
-                "(2017-10-01,2017-10-08,P7D)"
+                "(2017-10-01,2017-10-08,P7D)",
             };
 
             var result = TimexRangeResolver.Evaluate(candidates, constraints);
@@ -180,7 +180,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         public void DataTypes_RangeResolve_timerange_time_within_range()
         {
             var candidates = new[] { "T16" };
-            var constraints = new[] { (new TimexProperty { Hour = 14, Hours = 4 }).TimexValue };
+            var constraints = new[] { new TimexProperty { Hour = 14, Hours = 4 }.TimexValue };
 
             var result = TimexRangeResolver.Evaluate(candidates, constraints);
 
@@ -193,7 +193,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         public void DataTypes_RangeResolve_timerange_multiple_times_within_range()
         {
             var candidates = new[] { "T12", "T16", "T16:30", "T17", "T18" };
-            var constraints = new[] { (new TimexProperty { Hour = 14, Hours = 4 }).TimexValue };
+            var constraints = new[] { new TimexProperty { Hour = 14, Hours = 4 }.TimexValue };
 
             var result = TimexRangeResolver.Evaluate(candidates, constraints);
 
@@ -207,7 +207,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         [TestMethod]
         public void DataTypes_RangeResolve_timerange_time_with_overlapping_ranges()
         {
-            var constraints = new List<string> { (new TimexProperty { Hour = 16, Hours = 4 }).TimexValue };
+            var constraints = new List<string> { new TimexProperty { Hour = 16, Hours = 4 }.TimexValue };
 
             var result1 = TimexRangeResolver.Evaluate(new[] { "T19" }, constraints);
 
@@ -215,7 +215,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
             Assert.IsTrue(r1.Contains("T19"));
             Assert.AreEqual(1, r1.Count);
 
-            constraints.Add((new TimexProperty { Hour = 14, Hours = 4 }).TimexValue);
+            constraints.Add(new TimexProperty { Hour = 14, Hours = 4 }.TimexValue);
 
             var result2 = TimexRangeResolver.Evaluate(new[] { "T19" }, constraints);
 
@@ -232,7 +232,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         [TestMethod]
         public void DataTypes_RangeResolve_multiple_times_with_overlapping_ranges()
         {
-            var constraints = new List<string> { (new TimexProperty { Hour = 16, Hours = 4 }).TimexValue };
+            var constraints = new List<string> { new TimexProperty { Hour = 16, Hours = 4 }.TimexValue };
 
             var result1 = TimexRangeResolver.Evaluate(new[] { "T19", "T19:30" }, constraints);
 
@@ -241,7 +241,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
             Assert.IsTrue(r1.Contains("T19:30"));
             Assert.AreEqual(2, r1.Count);
 
-            constraints.Add((new TimexProperty { Hour = 14, Hours = 4 }).TimexValue);
+            constraints.Add(new TimexProperty { Hour = 14, Hours = 4 }.TimexValue);
 
             var result2 = TimexRangeResolver.Evaluate(new[] { "T19", "T19:30" }, constraints);
 
@@ -259,7 +259,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         [TestMethod]
         public void DataTypes_RangeResolve_filter_duplicate()
         {
-            var constraints = new List<string> { (new TimexProperty { Hour = 16, Hours = 4 }).TimexValue };
+            var constraints = new List<string> { new TimexProperty { Hour = 16, Hours = 4 }.TimexValue };
 
             var result = TimexRangeResolver.Evaluate(new[] { "T16", "T16", "T16" }, constraints);
 
@@ -273,7 +273,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         {
             var constraints = new List<string>
             {
-                (new TimexProperty { Year = 2017, Month = 9, DayOfMonth = 27, Days = 2 }).TimexValue
+                new TimexProperty { Year = 2017, Month = 9, DayOfMonth = 27, Days = 2 }.TimexValue,
             };
 
             var result = TimexRangeResolver.Evaluate(new[] { "2017-09-28T18:30:01" }, constraints);
@@ -300,7 +300,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         {
             var constraints = new List<string>
             {
-                (new TimexProperty { Year = 2006, Month = 1, DayOfMonth = 1, Years = 2 }).TimexValue
+                new TimexProperty { Year = 2006, Month = 1, DayOfMonth = 1, Years = 2 }.TimexValue,
             };
 
             var result = TimexRangeResolver.Evaluate(new[] { "XXXX-05-29T19:30" }, constraints);
@@ -347,7 +347,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
             var constraints = new List<string>
             {
                 "(2017-09-01,2017-09-08,P7D)",
-                "(2017-10-01,2017-10-08,P7D)"
+                "(2017-10-01,2017-10-08,P7D)",
             };
 
             var result = TimexRangeResolver.Evaluate(new[] { "XXXX-WXX-3T01:02" }, constraints);
@@ -363,8 +363,8 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         {
             var constraints = new List<string>
             {
-                (new TimexProperty { Year = 2017, Month = 10, DayOfMonth = 5, Days = 7 }).TimexValue,
-                (new TimexProperty { Hour = 0, Minute = 0, Second = 0, Hours = 24 }).TimexValue
+                new TimexProperty { Year = 2017, Month = 10, DayOfMonth = 5, Days = 7 }.TimexValue,
+                new TimexProperty { Hour = 0, Minute = 0, Second = 0, Hours = 24 }.TimexValue,
             };
 
             var result = TimexRangeResolver.Evaluate(new[] { "XXXX-WXX-3T04", "XXXX-WXX-3T16" }, constraints);
@@ -380,8 +380,8 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         {
             var constraints = new List<string>
             {
-                (new TimexProperty { Year = 2017, Month = 10, DayOfMonth = 5, Days = 7 }).TimexValue,
-                (new TimexProperty { Hour = 12, Minute = 0, Second = 0, Hours = 8 }).TimexValue
+                new TimexProperty { Year = 2017, Month = 10, DayOfMonth = 5, Days = 7 }.TimexValue,
+                new TimexProperty { Hour = 12, Minute = 0, Second = 0, Hours = 8 }.TimexValue,
             };
 
             var result = TimexRangeResolver.Evaluate(new[] { "XXXX-WXX-3T04", "XXXX-WXX-3T16" }, constraints);
@@ -414,7 +414,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
             {
                 "2017",
                 "T19:30:00",
-                "T20:01:01"
+                "T20:01:01",
             };
 
             var result = TimexRangeResolver.Evaluate(new[] { "XXXX-05-29" }, constraints);
@@ -430,7 +430,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         {
             var constraints = new List<string>
             {
-                "2017-12-05T19:30:00"
+                "2017-12-05T19:30:00",
             };
 
             var result = TimexRangeResolver.Evaluate(new[] { "PT5M" }, constraints);
@@ -445,7 +445,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         {
             var constraints = new List<string>
             {
-                "T19:30:00"
+                "T19:30:00",
             };
 
             var result = TimexRangeResolver.Evaluate(new[] { "PT5M" }, constraints);
@@ -474,7 +474,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         {
             var constraints = new List<string>
             {
-                (new TimexProperty { Year = 2017, Month = 10, DayOfMonth = 5, Days = 7 }).TimexValue
+                new TimexProperty { Year = 2017, Month = 10, DayOfMonth = 5, Days = 7 }.TimexValue,
             };
 
             var result = TimexRangeResolver.Evaluate(new[] { "PT5M" }, constraints);
@@ -491,7 +491,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
             {
                 "(2018-06-04,2018-06-11,P7D)",  // e.g. this week
                 "(2018-06-11,2018-06-18,P7D)",  // e.g. next week
-                TimexCreator.Evening
+                TimexCreator.Evening,
             };
 
             var result = TimexRangeResolver.Evaluate(candidates, constraints);
@@ -509,7 +509,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
             var constraints = new[]
             {
                 "(2018-06-04,2018-06-11,P7D)",  // e.g. this week
-                "(2018-06-11,2018-06-18,P7D)"   // e.g. next week
+                "(2018-06-11,2018-06-18,P7D)",   // e.g. next week
             };
 
             var result = TimexRangeResolver.Evaluate(candidates, constraints);
@@ -528,7 +528,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
             {
                 "(2018-06-04,2018-06-11,P7D)",  // e.g. this week
                 "(2018-06-11,2018-06-18,P7D)",  // e.g. next week
-                "(T18,T22,PT4H)"
+                "(T18,T22,PT4H)",
             };
 
             var result = TimexRangeResolver.Evaluate(candidates, constraints);
@@ -547,7 +547,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
             {
                 "(2018-06-04,2018-06-11,P7D)",  // e.g. this week
                 "(2018-06-11,2018-06-18,P7D)",  // e.g. next week
-                "(T15,T19,PT4H)"
+                "(T15,T19,PT4H)",
             };
 
             var result = TimexRangeResolver.Evaluate(candidates, constraints);
@@ -566,7 +566,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
             {
                 "(2018-06-04,2018-06-11,P7D)",  // e.g. this week
                 "(2018-06-11,2018-06-18,P7D)",  // e.g. next week
-                TimexCreator.Morning
+                TimexCreator.Morning,
             };
 
             var result = TimexRangeResolver.Evaluate(candidates, constraints);
@@ -582,7 +582,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
             {
                 "(2018-06-04,2018-06-11,P7D)",  // e.g. this week
                 "(2018-06-11,2018-06-18,P7D)",  // e.g. next week
-                TimexCreator.Evening
+                TimexCreator.Evening,
             };
 
             var result = TimexRangeResolver.Evaluate(candidates, constraints);

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests/TestTimexRelativeConvert.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests/TestTimexRelativeConvert.cs
@@ -145,14 +145,16 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         }
 
         [TestMethod]
-        public void DataTypes_RelativeConvert_DateRange_this_week(){
+        public void DataTypes_RelativeConvert_DateRange_this_week()
+        {
             var timex = new TimexProperty("2017-W40");
             var today = new System.DateTime(2017, 9, 25);
             Assert.AreEqual("this week", TimexRelativeConvert.ConvertTimexToStringRelative(timex, today));
         }
 
         [TestMethod]
-        public void DataTypes_RelativeConvert_DateRange_next_week(){
+        public void DataTypes_RelativeConvert_DateRange_next_week()
+        {
             var timex = new TimexProperty("2017-W41");
             var today = new System.DateTime(2017, 9, 25);
             Assert.AreEqual("next week", TimexRelativeConvert.ConvertTimexToStringRelative(timex, today));
@@ -205,6 +207,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
             var today = new System.DateTime(2017, 9, 25);
             Assert.AreEqual("next weekend", TimexRelativeConvert.ConvertTimexToStringRelative(timex, today));
         }
+
         [TestMethod]
         public void DataTypes_RelativeConvert_Weekend_last_weekend()
         {
@@ -236,6 +239,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
             var today = new System.DateTime(2017, 9, 25);
             Assert.AreEqual("last month", TimexRelativeConvert.ConvertTimexToStringRelative(timex, today));
         }
+
         [TestMethod]
         public void DataTypes_RelativeConvert_Year_this_year()
         {

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests/TestTimexResolver.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests/TestTimexResolver.cs
@@ -98,7 +98,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         public void DataTypes_Resolver_DateTime_Next_Wednesday_4_am()
         {
             var today = new System.DateTime(2017, 9, 7);
-            var resolution = TimexResolver.Resolve(new [] { "2017-10-11T04" }, today);
+            var resolution = TimexResolver.Resolve(new[] { "2017-10-11T04" }, today);
             Assert.AreEqual(1, resolution.Values.Count);
 
             Assert.AreEqual("2017-10-11T04", resolution.Values[0].Timex);
@@ -111,7 +111,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         [TestMethod]
         public void DataTypes_Resolver_Duration_2years()
         {
-            var resolution = TimexResolver.Resolve(new [] { "P2Y" });
+            var resolution = TimexResolver.Resolve(new[] { "P2Y" });
             Assert.AreEqual(1, resolution.Values.Count);
 
             Assert.AreEqual("P2Y", resolution.Values[0].Timex);
@@ -124,7 +124,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         [TestMethod]
         public void DataTypes_Resolver_Duration_6months()
         {
-            var resolution = TimexResolver.Resolve(new [] { "P6M" });
+            var resolution = TimexResolver.Resolve(new[] { "P6M" });
             Assert.AreEqual(1, resolution.Values.Count);
 
             Assert.AreEqual("P6M", resolution.Values[0].Timex);
@@ -137,7 +137,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         [TestMethod]
         public void DataTypes_Resolver_Duration_3weeks()
         {
-            var resolution = TimexResolver.Resolve(new [] { "P3W" });
+            var resolution = TimexResolver.Resolve(new[] { "P3W" });
             Assert.AreEqual(1, resolution.Values.Count);
 
             Assert.AreEqual("P3W", resolution.Values[0].Timex);
@@ -150,7 +150,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         [TestMethod]
         public void DataTypes_Resolver_Duration_5days()
         {
-            var resolution = TimexResolver.Resolve(new [] { "P5D" });
+            var resolution = TimexResolver.Resolve(new[] { "P5D" });
             Assert.AreEqual(1, resolution.Values.Count);
 
             Assert.AreEqual("P5D", resolution.Values[0].Timex);
@@ -163,7 +163,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         [TestMethod]
         public void DataTypes_Resolver_Duration_8hours()
         {
-            var resolution = TimexResolver.Resolve(new [] { "PT8H" });
+            var resolution = TimexResolver.Resolve(new[] { "PT8H" });
             Assert.AreEqual(1, resolution.Values.Count);
 
             Assert.AreEqual("PT8H", resolution.Values[0].Timex);
@@ -176,7 +176,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         [TestMethod]
         public void DataTypes_Resolver_Duration_15minutes()
         {
-            var resolution = TimexResolver.Resolve(new [] { "PT15M" });
+            var resolution = TimexResolver.Resolve(new[] { "PT15M" });
             Assert.AreEqual(1, resolution.Values.Count);
 
             Assert.AreEqual("PT15M", resolution.Values[0].Timex);
@@ -189,7 +189,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         [TestMethod]
         public void DataTypes_Resolver_Duration_10seconds()
         {
-            var resolution = TimexResolver.Resolve(new [] { "PT10S" });
+            var resolution = TimexResolver.Resolve(new[] { "PT10S" });
             Assert.AreEqual(1, resolution.Values.Count);
 
             Assert.AreEqual("PT10S", resolution.Values[0].Timex);
@@ -203,7 +203,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         public void DataTypes_Resolver_DateRange_September()
         {
             var today = new System.DateTime(2017, 9, 28);
-            var resolution = TimexResolver.Resolve(new [] { "XXXX-09" }, today);
+            var resolution = TimexResolver.Resolve(new[] { "XXXX-09" }, today);
             Assert.AreEqual(2, resolution.Values.Count);
 
             Assert.AreEqual("XXXX-09", resolution.Values[0].Timex);
@@ -222,7 +222,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         [TestMethod]
         public void DataTypes_Resolver_DateRange_Winter()
         {
-            var resolution = TimexResolver.Resolve(new [] { "WI" });
+            var resolution = TimexResolver.Resolve(new[] { "WI" });
             Assert.AreEqual(1, resolution.Values.Count);
 
             Assert.AreEqual("WI", resolution.Values[0].Timex);
@@ -236,7 +236,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         public void DataTypes_Resolver_TimeRange_4am_to_8pm()
         {
             var today = System.DateTime.Now;
-            var resolution = TimexResolver.Resolve(new [] { "(T04,T20,PT16H)" }, today);
+            var resolution = TimexResolver.Resolve(new[] { "(T04,T20,PT16H)" }, today);
             Assert.AreEqual(1, resolution.Values.Count);
 
             Assert.AreEqual("(T04,T20,PT16H)", resolution.Values[0].Timex);
@@ -250,7 +250,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         public void DataTypes_Resolver_TimeRange_Morning()
         {
             var today = System.DateTime.Now;
-            var resolution = TimexResolver.Resolve(new [] { "TMO" }, today);
+            var resolution = TimexResolver.Resolve(new[] { "TMO" }, today);
             Assert.AreEqual(1, resolution.Values.Count);
 
             Assert.AreEqual("TMO", resolution.Values[0].Timex);
@@ -264,7 +264,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         public void DataTypes_Resolver_TimeRange_Afternoon()
         {
             var today = System.DateTime.Now;
-            var resolution = TimexResolver.Resolve(new [] { "TAF" }, today);
+            var resolution = TimexResolver.Resolve(new[] { "TAF" }, today);
             Assert.AreEqual(1, resolution.Values.Count);
 
             Assert.AreEqual("TAF", resolution.Values[0].Timex);
@@ -278,7 +278,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         public void DataTypes_Resolver_TimeRange_Evening()
         {
             var today = System.DateTime.Now;
-            var resolution = TimexResolver.Resolve(new [] { "TEV" }, today);
+            var resolution = TimexResolver.Resolve(new[] { "TEV" }, today);
             Assert.AreEqual(1, resolution.Values.Count);
 
             Assert.AreEqual("TEV", resolution.Values[0].Timex);
@@ -291,7 +291,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         [TestMethod]
         public void DataTypes_Resolver_DateTimeRange_This_Morning()
         {
-            var resolution = TimexResolver.Resolve(new [] { "2017-10-07TMO" });
+            var resolution = TimexResolver.Resolve(new[] { "2017-10-07TMO" });
             Assert.AreEqual(1, resolution.Values.Count);
 
             Assert.AreEqual("2017-10-07TMO", resolution.Values[0].Timex);
@@ -318,7 +318,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         public void DataTypes_Resolver_DateTimeRange_next_monday_4am_to_next_thursday_3pm()
         {
             var today = System.DateTime.Now;
-            var resolution = TimexResolver.Resolve(new [] { "(2017-10-09T04,2017-10-12T15,PT83H)" }, today);
+            var resolution = TimexResolver.Resolve(new[] { "(2017-10-09T04,2017-10-12T15,PT83H)" }, today);
             Assert.AreEqual(1, resolution.Values.Count);
 
             Assert.AreEqual("(2017-10-09T04,2017-10-12T15,PT83H)", resolution.Values[0].Timex);
@@ -331,7 +331,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         [TestMethod]
         public void DataTypes_Resolver_Time_4am()
         {
-            var resolution = TimexResolver.Resolve(new [] { "T04" });
+            var resolution = TimexResolver.Resolve(new[] { "T04" });
             Assert.AreEqual(1, resolution.Values.Count);
 
             Assert.AreEqual("T04", resolution.Values[0].Timex);
@@ -344,7 +344,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         [TestMethod]
         public void DataTypes_Resolver_Time_4_oclock()
         {
-            var resolution = TimexResolver.Resolve(new [] { "T04", "T16" });
+            var resolution = TimexResolver.Resolve(new[] { "T04", "T16" });
             Assert.AreEqual(2, resolution.Values.Count);
 
             Assert.AreEqual("T04", resolution.Values[0].Timex);


### PR DESCRIPTION
- Add code analysis rule set for tests
- Add settings file
- Remove parenthesis
- Add spacing
- Add trailing comma