### PR TITLE
[StyleCop] Fix all warnings in BaseDateTimeExtractor

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/BaseDateTimeExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/BaseDateTimeExtractor.cs
@@ -2,9 +2,8 @@
 using System.Collections.Immutable;
 using System.Linq;
 using System.Text.RegularExpressions;
-using DateObject = System.DateTime;
-
 using Microsoft.Recognizers.Text.Number;
+using DateObject = System.DateTime;
 
 namespace Microsoft.Recognizers.Text.DateTime.Chinese
 {
@@ -12,7 +11,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
     {
         internal abstract ImmutableDictionary<Regex, T> Regexes { get; }
 
-        protected virtual string ExtractType { get; } = "";
+        protected virtual string ExtractType { get; } = string.Empty;
 
         public List<ExtractResult> Extract(string text)
         {
@@ -43,7 +42,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                         matched[m.Index + j] = true;
                     }
 
-                    //Keep Source Data for extra information
+                    // Keep Source Data for extra information
                     matchSource.Add(m, collection.Value);
                 }
             }
@@ -72,9 +71,9 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                                     new DateTimeExtra<T>
                                     {
                                         NamedEntity = srcMatch.Groups,
-                                        Type = matchSource[srcMatch]
+                                        Type = matchSource[srcMatch],
                                     }
-                                    : null
+                                    : null,
                             };
                             result.Add(er);
                         }
@@ -85,14 +84,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                     last = i;
                 }
             }
+
             return result;
         }
-    }
-
-    public class DateTimeExtra<T>
-    {
-        public GroupCollection NamedEntity { get; set; }
-
-        public T Type { get; set; }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/DateTimeExtra.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/DateTimeExtra.cs
@@ -1,0 +1,11 @@
+﻿using System.Text.RegularExpressions;
+
+namespace Microsoft.Recognizers.Text.DateTime.Chinese
+{
+    public class DateTimeExtra<T>
+    {
+        public GroupCollection NamedEntity { get; set; }
+
+        public T Type { get; set; }
+    }
+}


### PR DESCRIPTION
- Classes were separated into different files.
- Reordered using statements.
- Added spaces and trailing commas where needed.