### PR TITLE
[StyleCop] Fix warnings in DataDrivenTest\TestHelpers, Models, Base and StringMatcher files

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.DataDrivenTests/Matcher/StringMatcherTest.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataDrivenTests/Matcher/StringMatcherTest.cs
@@ -26,16 +26,16 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests.Matcher
         public void SimpleTestWithIdsStringMatcher()
         {
             var values = new List<string>() { "China", "Beijing", "City" };
-            var Ids = new List<string>() { "1", "2", "3" };
+            var ids = new List<string>() { "1", "2", "3" };
             var stringMatcher = new StringMatcher();
-            stringMatcher.Init(values, Ids.ToArray());
+            stringMatcher.Init(values, ids.ToArray());
 
             for (var i = 0; i < values.Count; i++)
             {
                 var value = values[i];
                 var match = stringMatcher.Find(value).Single();
                 Assert.AreEqual(value, match.Text);
-                Assert.AreEqual(Ids[i], match.CanonicalValues.First());
+                Assert.AreEqual(ids[i], match.CanonicalValues.First());
             }
         }
 
@@ -45,13 +45,13 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests.Matcher
             var utc8Value = "UTC+08:00";
             var utc8Words = new List<string>()
             {
-                "beijing time", "chongqing time", "hong kong time", "urumqi time"
+                "beijing time", "chongqing time", "hong kong time", "urumqi time",
             };
 
             var utc2Value = "UTC+02:00";
             var utc2Words = new List<string>()
             {
-                  "cairo time", "beirut time", "gaza time", "amman time"
+                  "cairo time", "beirut time", "gaza time", "amman time",
             };
 
             var valueDictionary = new Dictionary<string, List<string>>()

--- a/.NET/Microsoft.Recognizers.Text.DataDrivenTests/TestBase.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataDrivenTests/TestBase.cs
@@ -22,7 +22,9 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
         }
 
         public IDateTimeExtractor Extractor { get; set; }
+
         public IDateTimeParser DateTimeParser { get; set; }
+
         public TestModel TestSpec { get; set; }
 
         public void TestSpecInitialize(TestResources resources)
@@ -92,7 +94,7 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
                 Assert.AreEqual(expected.End, actual.End, GetMessage(TestSpec));
 
                 var values = actual.Resolution as IDictionary<string, object>;
-                
+
                 // Actual ValueSet types should not be modified as that's considered a breaking API change
                 var actualValues = ((List<Dictionary<string, string>>)values[ResolutionKey.ValueSet]).ToList();
                 var expectedValues =
@@ -130,8 +132,7 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
 
                 if (expected.ParentText != null)
                 {
-                    Assert.AreEqual(expected.ParentText, ((ExtendedModelResult)actual).ParentText,
-                        GetMessage(TestSpec));
+                    Assert.AreEqual(expected.ParentText, ((ExtendedModelResult)actual).ParentText, GetMessage(TestSpec));
                 }
 
                 // Actual ValueSet types should not be modified as that's considered a breaking API change
@@ -175,7 +176,6 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
                 Assert.AreEqual(expected.Start, actual.Start, GetMessage(TestSpec));
                 Assert.AreEqual(expected.Length, actual.Length, GetMessage(TestSpec));
             }
-
         }
 
         public void TestDateTimeParser()
@@ -224,7 +224,6 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
                     Assert.AreEqual(expectedValue.TimeZoneResolution.Value, actualValue.TimeZoneResolution.Value, GetMessage(TestSpec));
                     Assert.AreEqual(expectedValue.TimeZoneResolution.UtcOffsetMins, actualValue.TimeZoneResolution.UtcOffsetMins, GetMessage(TestSpec));
                 }
-
             }
         }
 
@@ -320,6 +319,11 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
             ValidateResults(new string[] { ResolutionKey.Value, ResolutionKey.Score });
         }
 
+        private static string GetMessage(TestModel spec)
+        {
+            return $"Input: \"{spec.Input}\"";
+        }
+
         private void TestPreValidation()
         {
             if (TestUtils.EvaluateSpec(TestSpec, out string message))
@@ -335,7 +339,6 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
 
         private void ValidateResults(IEnumerable<string> testResolutionKeys = null)
         {
-
             var actualResults = TestContext.GetModelParseResults(TestSpec);
             var expectedResults = TestSpec.CastResults<ModelResult>();
 
@@ -361,8 +364,7 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
                     Assert.AreEqual(expected.End, actual.End, GetMessage(TestSpec));
                 }
 
-                Assert.AreEqual(expected.Resolution[ResolutionKey.Value], actual.Resolution[ResolutionKey.Value],
-                                GetMessage(TestSpec));
+                Assert.AreEqual(expected.Resolution[ResolutionKey.Value], actual.Resolution[ResolutionKey.Value], GetMessage(TestSpec));
 
                 foreach (var key in testResolutionKeys ?? Enumerable.Empty<string>())
                 {
@@ -373,15 +375,7 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
 
                     Assert.AreEqual(expected.Resolution[key], actual.Resolution[key], GetMessage(TestSpec));
                 }
-
             }
-            
         }
-
-        private static string GetMessage(TestModel spec)
-        {
-            return $"Input: \"{spec.Input}\"";
-        }
-
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DataDrivenTests/TestHelpers.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataDrivenTests/TestHelpers.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
@@ -787,12 +787,12 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
     {
         public static bool IsNotSupported(this TestModel testSpec)
         {
-            return testSpec.NotSupported.HasFlag(Platform.dotNet);
+            return testSpec.NotSupported.HasFlag(Platform.DotNet);
         }
 
         public static bool IsNotSupportedByDesign(this TestModel testSpec)
         {
-            return testSpec.NotSupportedByDesign.HasFlag(Platform.dotNet);
+            return testSpec.NotSupportedByDesign.HasFlag(Platform.DotNet);
         }
 
         public static DateObject GetReferenceDateTime(this TestModel testSpec)

--- a/.NET/Microsoft.Recognizers.Text.DataDrivenTests/TestModel.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataDrivenTests/TestModel.cs
@@ -1,18 +1,55 @@
-﻿using Newtonsoft.Json;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Newtonsoft.Json;
 
 namespace Microsoft.Recognizers.Text.DataDrivenTests
 {
+    [Flags]
+    public enum Platform
+    {
+        /// <summary>
+        /// dotNet flag
+        /// </summary>
+        DotNet = 1,
+
+        /// <summary>
+        /// JavaScript flag
+        /// </summary>
+        Javascript = 2,
+
+        /// <summary>
+        /// Python flag
+        /// </summary>
+        Python = 4,
+
+        /// <summary>
+        /// Java flag
+        /// </summary>
+        Java = 8,
+    }
+
     public class TestModel
     {
+        public TestModel()
+        {
+            Context = new Dictionary<string, object>();
+            Results = Enumerable.Empty<object>();
+            Debug = false;
+        }
+
         public string TestType { get; set; }
+
         public string Input { get; set; }
+
         public IDictionary<string, object> Context { get; set; }
+
         public bool Debug { get; set; }
+
         public Platform NotSupported { get; set; }
+
         public Platform NotSupportedByDesign { get; set; }
+
         public IEnumerable<object> Results { get; set; }
 
         public IEnumerable<T> CastResults<T>()
@@ -21,25 +58,9 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
             return JsonConvert.DeserializeObject<IEnumerable<T>>(results);
         }
 
-        public TestModel()
-        {
-            Context = new Dictionary<string, object>();
-            Results = Enumerable.Empty<object>();
-            Debug = false;
-        }
-
         public bool IsSupportedDotNet()
         {
-            return (NotSupported & Platform.dotNet) == 0 && (NotSupportedByDesign & Platform.dotNet) == 0;
+            return (NotSupported & Platform.DotNet) == 0 && (NotSupportedByDesign & Platform.DotNet) == 0;
         }
-    }
-
-    [Flags]
-    public enum Platform
-    {
-        dotNet = 1,
-        javascript = 2,
-        python = 4,
-        java = 8
     }
 }


### PR DESCRIPTION
- Remove trailing whitespace
- Reorder static methods
- Add trailing comma
- Add space between properties
- Update variables to properly user upper and lower case. 