### PR TITLE
[StyleCop] Fix all the warnings in NumberWithUnitExtractor

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Extractors/DinoComparer.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Extractors/DinoComparer.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Microsoft.Recognizers.Text.Matcher;
+
+namespace Microsoft.Recognizers.Text.NumberWithUnit
+{
+    public class DinoComparer : IComparer<string>
+    {
+        public int Compare(string x, string y)
+        {
+            if (x == null)
+            {
+                if (y == null)
+                {
+                    // If x is null and y is null, they're equal.
+                    return 0;
+                }
+                else
+                {
+                    // If x is null and y is not null, y is greater.
+                    return 1;
+                }
+            }
+            else
+            {
+                // If x is not null and y is null, x is greater.
+                if (y == null)
+                {
+                    return -1;
+                }
+                else
+                {
+                    // ...and y is not null, compare the lengths of the two strings.
+                    int result = y.Length.CompareTo(x.Length);
+
+                    if (result != 0)
+                    {
+                        // If the strings are not of equal length, the longer string is greater.
+                        return result;
+                    }
+                    else
+                    {
+                        // If the strings are of equal length, sort them with ordinary string comparison.
+                        return string.Compare(x, y, StringComparison.Ordinal);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Extractors/NumberWithUnitExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Extractors/NumberWithUnitExtractor.cs
@@ -46,6 +46,266 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit
             separateRegex = BuildSeparateRegexFromSet();
         }
 
+        public bool ValidateUnit(string source)
+        {
+            return !source.StartsWith("-");
+        }
+
+        public List<ExtractResult> Extract(string source)
+        {
+            var result = new List<ExtractResult>();
+
+            if (!PreCheckStr(source))
+            {
+                return result;
+            }
+
+            var mappingPrefix = new Dictionary<int, PrefixUnitResult>();
+            var sourceLen = source.Length;
+            var prefixMatched = false;
+
+            MatchCollection nonUnitMatches = null;
+            var prefixMatch = prefixMatcher.Find(source).OrderBy(o => o.Start).ToList();
+            var suffixMatch = suffixMatcher.Find(source).OrderBy(o => o.Start).ToList();
+
+            if (prefixMatch.Count > 0 || suffixMatch.Count > 0)
+            {
+                var numbers = this.config.UnitNumExtractor.Extract(source).OrderBy(o => o.Start);
+
+                // Special case for cases where number multipliers clash with unit
+                var ambiguousMultiplierRegex = this.config.AmbiguousUnitNumberMultiplierRegex;
+                if (ambiguousMultiplierRegex != null)
+                {
+                    foreach (var number in numbers)
+                    {
+                        var match = ambiguousMultiplierRegex.Matches(number.Text);
+                        if (match.Count == 1)
+                        {
+                            var newLength = number.Text.Length - match[0].Length;
+                            number.Text = number.Text.Substring(0, newLength);
+                            number.Length = newLength;
+                        }
+                    }
+                }
+
+                foreach (var number in numbers)
+                {
+                    if (number.Start == null || number.Length == null)
+                    {
+                        continue;
+                    }
+
+                    int start = (int)number.Start, length = (int)number.Length;
+                    var maxFindPref = Math.Min(maxPrefixMatchLen, number.Start.Value);
+                    var maxFindSuff = sourceLen - start - length;
+
+                    if (maxFindPref != 0)
+                    {
+                        // Scan from left to right, find the longest match
+                        var lastIndex = start;
+                        MatchResult<string> bestMatch = null;
+
+                        foreach (var m in prefixMatch)
+                        {
+                            if (m.Length > 0 && m.End > start)
+                            {
+                                break;
+                            }
+
+                            if (m.Length > 0 && source.Substring(m.Start, lastIndex - m.Start).ToLower().Trim() == m.Text)
+                            {
+                                bestMatch = m;
+                                break;
+                            }
+                        }
+
+                        if (bestMatch != null)
+                        {
+                            var offSet = lastIndex - bestMatch.Start;
+                            var unitStr = source.Substring(bestMatch.Start, offSet);
+                            mappingPrefix.Add(number.Start.Value, new PrefixUnitResult { Offset = offSet, UnitStr = unitStr });
+                        }
+                    }
+
+                    mappingPrefix.TryGetValue(start, out PrefixUnitResult prefixUnit);
+                    if (maxFindSuff > 0)
+                    {
+                        // find the best suffix unit
+                        var maxlen = 0;
+                        var firstIndex = start + length;
+
+                        foreach (var m in suffixMatch)
+                        {
+                            if (m.Length > 0 && m.Start >= firstIndex)
+                            {
+                                var endpos = m.Start + m.Length - firstIndex;
+                                if (maxlen < endpos)
+                                {
+                                    var midStr = source.Substring(firstIndex, m.Start - firstIndex);
+                                    if (string.IsNullOrWhiteSpace(midStr) || midStr.Trim().Equals(this.config.ConnectorToken))
+                                    {
+                                        maxlen = endpos;
+                                    }
+                                }
+                            }
+                        }
+
+                        if (maxlen != 0)
+                        {
+                            var substr = source.Substring(start, length + maxlen);
+                            var er = new ExtractResult
+                            {
+                                Start = start,
+                                Length = length + maxlen,
+                                Text = substr,
+                                Type = this.config.ExtractType,
+                            };
+
+                            if (prefixUnit != null)
+                            {
+                                prefixMatched = true;
+                                er.Start -= prefixUnit.Offset;
+                                er.Length += prefixUnit.Offset;
+                                er.Text = prefixUnit.UnitStr + er.Text;
+                            }
+
+                            // Relative position will be used in Parser
+                            number.Start = start - er.Start;
+                            er.Data = number;
+
+                            // Special treatment, handle cases like '2:00 pm', '00 pm' is not dimension
+                            var isNotUnit = false;
+                            if (er.Type.Equals(Constants.SYS_UNIT_DIMENSION))
+                            {
+                                if (nonUnitMatches == null)
+                                {
+                                    nonUnitMatches = this.config.NonUnitRegex.Matches(source);
+                                }
+
+                                foreach (Match time in nonUnitMatches)
+                                {
+                                    if (er.Start >= time.Index && er.Start + er.Length <= time.Index + time.Length)
+                                    {
+                                        isNotUnit = true;
+                                        break;
+                                    }
+                                }
+                            }
+
+                            if (isNotUnit)
+                            {
+                                continue;
+                            }
+
+                            result.Add(er);
+                        }
+                    }
+
+                    if (prefixUnit != null && !prefixMatched)
+                    {
+                        var er = new ExtractResult
+                        {
+                            Start = number.Start - prefixUnit.Offset,
+                            Length = number.Length + prefixUnit.Offset,
+                            Text = prefixUnit.UnitStr + number.Text,
+                            Type = this.config.ExtractType,
+                        };
+
+                        // Relative position will be used in Parser
+                        number.Start = start - er.Start;
+                        er.Data = number;
+                        result.Add(er);
+                    }
+                }
+            }
+
+            // Extract Separate unit
+            if (separateRegex != null)
+            {
+                if (nonUnitMatches == null)
+                {
+                    nonUnitMatches = this.config.NonUnitRegex.Matches(source);
+                }
+
+                ExtractSeparateUnits(source, result, nonUnitMatches);
+
+                // Remove common ambiguous cases
+                result = FilterAmbiguity(result, source);
+            }
+
+            return result;
+        }
+
+        public void ExtractSeparateUnits(string source, List<ExtractResult> numDependResults, MatchCollection nonUnitMatches)
+        {
+            // Default is false
+            bool[] matchResult = new bool[source.Length];
+            foreach (var numDependResult in numDependResults)
+            {
+                int start = numDependResult.Start.Value;
+                int i = 0;
+                do
+                {
+                    matchResult[start + i++] = true;
+                }
+                while (i < numDependResult.Length.Value);
+            }
+
+            // Extract all SeparateUnits, then merge it with numDependResults
+            var matchCollection = separateRegex.Matches(source);
+            if (matchCollection.Count != 0)
+            {
+                foreach (Match match in matchCollection)
+                {
+                    if (match.Success)
+                    {
+                        int i = 0;
+                        while (i < match.Length && !matchResult[match.Index + i])
+                        {
+                            i++;
+                        }
+
+                        if (i == match.Length)
+                        {
+                            // Mark as extracted
+                            for (int j = 0; j < i; j++)
+                            {
+                                matchResult[j] = true;
+                            }
+
+                            // Special treatment, handle cases like '2:00 pm', both '00 pm' and 'pm' are not dimension
+                            var isNotUnit = false;
+                            if (match.Value.Equals(Constants.AMBIGUOUS_TIME_TERM))
+                            {
+                                foreach (Match nonUnitMatch in nonUnitMatches)
+                                {
+                                    if (IsMatchOverlap(match, nonUnitMatch))
+                                    {
+                                        isNotUnit = true;
+                                        break;
+                                    }
+                                }
+                            }
+
+                            if (isNotUnit)
+                            {
+                                continue;
+                            }
+
+                            numDependResults.Add(new ExtractResult
+                            {
+                                Start = match.Index,
+                                Length = match.Length,
+                                Text = match.Value,
+                                Type = this.config.ExtractType,
+                                Data = null,
+                            });
+                        }
+                    }
+                }
+            }
+        }
+
         protected StringMatcher BuildMatcherFromSet(IEnumerable<string> collection, bool ignoreCase = true)
         {
             StringMatcher matcher = new StringMatcher(MatchStrategy.TrieTree, new NumberWithUnitTokenizer());
@@ -138,267 +398,6 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit
             return regex;
         }
 
-        public bool ValidateUnit(string source)
-        {
-            return !source.StartsWith("-");
-        }
-
-        public List<ExtractResult> Extract(string source)
-        {
-            var result = new List<ExtractResult>();
-
-            if (!PreCheckStr(source))
-            {
-                return result;
-            }
-
-            var mappingPrefix = new Dictionary<int, PrefixUnitResult>();
-            var sourceLen = source.Length;
-            var prefixMatched = false;
-
-            MatchCollection nonUnitMatches = null;
-            var prefixMatch = prefixMatcher.Find(source).OrderBy(o => o.Start).ToList();
-            var suffixMatch = suffixMatcher.Find(source).OrderBy(o => o.Start).ToList();
-
-            if (prefixMatch.Count > 0 || suffixMatch.Count > 0)
-            {
-                var numbers = this.config.UnitNumExtractor.Extract(source).OrderBy(o => o.Start);
-                
-                // Special case for cases where number multipliers clash with unit
-                var ambiguousMultiplierRegex = this.config.AmbiguousUnitNumberMultiplierRegex;
-                if (ambiguousMultiplierRegex != null)
-                {
-                    foreach (var number in numbers)
-                    {
-                        var match = ambiguousMultiplierRegex.Matches(number.Text);
-                        if (match.Count == 1)
-                        {
-                            var newLength = number.Text.Length - match[0].Length;
-                            number.Text = number.Text.Substring(0, newLength);
-                            number.Length = newLength;
-                        }
-                    }
-                }
-
-                foreach (var number in numbers)
-                {
-                    if (number.Start == null || number.Length == null)
-                    {
-                        continue;
-                    }
-
-                    int start = (int)number.Start, length = (int)number.Length;
-                    var maxFindPref = Math.Min(maxPrefixMatchLen, number.Start.Value);
-                    var maxFindSuff = sourceLen - start - length;
-
-                    if (maxFindPref != 0)
-                    {
-                        // Scan from left to right, find the longest match              
-                        var lastIndex = start;
-                        MatchResult<String> bestMatch = null;
-
-                        foreach (var m in prefixMatch)
-                        {
-                            if (m.Length > 0 && m.End > start)
-                            {
-                                break;
-                            }
-
-                            if (m.Length > 0 && source.Substring(m.Start, lastIndex - m.Start).ToLower().Trim() == 
-                                m.Text)
-                            {
-                                bestMatch = m;
-                                break;
-                            }
-                        }
-
-                        if (bestMatch != null)
-                        {
-                            var offSet = lastIndex - bestMatch.Start;
-                            var unitStr = source.Substring(bestMatch.Start, offSet);
-                            mappingPrefix.Add(number.Start.Value, new PrefixUnitResult { Offset = offSet, UnitStr = unitStr });
-                        }
-                    }
-
-                    mappingPrefix.TryGetValue(start, out PrefixUnitResult prefixUnit);
-                    if (maxFindSuff > 0)
-                    {
-                        // find the best suffix unit
-                        var maxlen = 0;
-                        var firstIndex = start + length;
-
-                        foreach (var m in suffixMatch)
-                        {
-                            if (m.Length > 0 && m.Start >= firstIndex)
-                            {
-                                var endpos = m.Start + m.Length - firstIndex;
-                                if (maxlen < endpos)
-                                {
-                                    var midStr = source.Substring(firstIndex, m.Start - firstIndex);
-                                    if (string.IsNullOrWhiteSpace(midStr) || midStr.Trim().Equals(this.config.ConnectorToken))
-                                    {
-                                        maxlen = endpos;
-                                    }
-                                }
-                            }
-                        }
-
-                        if (maxlen != 0)
-                        {
-                            var substr = source.Substring(start, length + maxlen);
-                            var er = new ExtractResult
-                            {
-                                Start = start,
-                                Length = length + maxlen,
-                                Text = substr,
-                                Type = this.config.ExtractType
-                            };
-
-                            if (prefixUnit != null)
-                            {
-                                prefixMatched = true;
-                                er.Start -= prefixUnit.Offset;
-                                er.Length += prefixUnit.Offset;
-                                er.Text = prefixUnit.UnitStr + er.Text;
-                            }
-
-                            // Relative position will be used in Parser
-                            number.Start = start - er.Start;
-                            er.Data = number;
-
-                            // Special treatment, handle cases like '2:00 pm', '00 pm' is not dimension
-                            var isNotUnit = false;
-                            if (er.Type.Equals(Constants.SYS_UNIT_DIMENSION))
-                            {
-                                if (nonUnitMatches == null)
-                                {
-                                    nonUnitMatches = this.config.NonUnitRegex.Matches(source);
-                                }
-
-                                foreach (Match time in nonUnitMatches)
-                                {
-                                    if (er.Start >= time.Index && er.Start + er.Length <= time.Index + time.Length)
-                                    {
-                                        isNotUnit = true;
-                                        break;
-                                    }
-                                }
-                            }
-
-                            if (isNotUnit)
-                            {
-                                continue;
-                            }
-
-                            result.Add(er);
-                        }
-                    }
-
-                    if (prefixUnit != null && !prefixMatched)
-                    {
-                        var er = new ExtractResult
-                        {
-                            Start = number.Start - prefixUnit.Offset,
-                            Length = number.Length + prefixUnit.Offset,
-                            Text = prefixUnit.UnitStr + number.Text,
-                            Type = this.config.ExtractType
-
-                        };
-                        
-                        // Relative position will be used in Parser
-                        number.Start = start - er.Start;
-                        er.Data = number;
-                        result.Add(er);
-                    }
-                }
-            }
-
-            // Extract Separate unit
-            if (separateRegex != null)
-            {
-                if (nonUnitMatches == null)
-                {
-                    nonUnitMatches = this.config.NonUnitRegex.Matches(source);
-                }
-
-                ExtractSeparateUnits(source, result, nonUnitMatches);
-
-                // Remove common ambiguous cases
-                result = FilterAmbiguity(result, source);
-            }
-
-            return result;
-        }
-
-        public void ExtractSeparateUnits(string source, List<ExtractResult> numDependResults, MatchCollection nonUnitMatches)
-        {
-            // Default is false
-            bool[] matchResult = new bool[source.Length];
-            foreach (var numDependResult in numDependResults)
-            {
-                int start = numDependResult.Start.Value;
-                int i = 0;
-                do
-                {
-                    matchResult[start + i++] = true;
-                } while (i < numDependResult.Length.Value);
-            }
-
-            // Extract all SeparateUnits, then merge it with numDependResults
-            var matchCollection = separateRegex.Matches(source);
-            if (matchCollection.Count != 0)
-            {
-                foreach (Match match in matchCollection)
-                {
-                    if (match.Success)
-                    {
-                        int i = 0;
-                        while (i < match.Length && !matchResult[match.Index + i])
-                        {
-                            i++;
-                        }
-
-                        if (i == match.Length)
-                        {
-                            // Mark as extracted
-                            for (int j = 0; j < i; j++)
-                            {
-                                matchResult[j] = true;
-                            }
-
-                            // Special treatment, handle cases like '2:00 pm', both '00 pm' and 'pm' are not dimension
-                            var isNotUnit = false;
-                            if (match.Value.Equals(Constants.AMBIGUOUS_TIME_TERM))
-                            {
-                                foreach (Match nonUnitMatch in nonUnitMatches)
-                                {
-                                    if (IsMatchOverlap(match, nonUnitMatch))
-                                    {
-                                        isNotUnit = true;
-                                        break;
-                                    }
-                                }
-                            }
-
-                            if (isNotUnit)
-                            {
-                                continue;
-                            }
-
-                            numDependResults.Add(new ExtractResult
-                            {
-                                Start = match.Index,
-                                Length = match.Length,
-                                Text = match.Value,
-                                Type = this.config.ExtractType,
-                                Data = null
-                            });
-                        }
-                    }
-                }
-            }
-        }
-
         protected virtual bool PreCheckStr(string str)
         {
             return !string.IsNullOrEmpty(str);
@@ -407,7 +406,7 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit
         private static bool IsMatchOverlap(Match match, Match nonUnitMatch)
         {
             bool isSubMatch = match.Index >= nonUnitMatch.Index && match.Index + match.Length <= nonUnitMatch.Index + nonUnitMatch.Length;
-            return isSubMatch;        
+            return isSubMatch;
         }
 
         private List<ExtractResult> FilterAmbiguity(List<ExtractResult> ers, string text)
@@ -427,57 +426,5 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit
 
             return ers;
         }
-
     }
-
-    public class DinoComparer : IComparer<string>
-    {
-        public int Compare(string x, string y)
-        {
-            if (x == null)
-            {
-                if (y == null)
-                {
-                    // If x is null and y is null, they're equal. 
-                    return 0;
-                }
-                else
-                {
-                    // If x is null and y is not null, y is greater. 
-                    return 1;
-                }
-            }
-            else
-            {
-                // If x is not null...
-                if (y == null) // ...and y is null, x is greater.
-                {
-                    return -1;
-                }
-                else
-                {
-                    // ...and y is not null, compare the lengths of the two strings.
-                    int result = y.Length.CompareTo(x.Length);
-
-                    if (result != 0)
-                    {
-                        // If the strings are not of equal length, the longer string is greater.
-                        return result;
-                    }
-                    else
-                    {
-                        // If the strings are of equal length, sort them with ordinary string comparison.
-                        return string.Compare(x, y, StringComparison.Ordinal);
-                    }
-                }
-            }
-        }
-    }
-
-    public class PrefixUnitResult
-    {
-        public int Offset;
-        public string UnitStr;
-    }
-
 }

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Extractors/PrefixUnitResult.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Extractors/PrefixUnitResult.cs
@@ -1,0 +1,9 @@
+﻿namespace Microsoft.Recognizers.Text.NumberWithUnit
+{
+    public class PrefixUnitResult
+    {
+        public int Offset { get; set; }
+
+        public string UnitStr { get; set; }
+    }
+}


### PR DESCRIPTION
- Add trailing coma in multi-line initializers
- Remove trailing whitespace
- Remove extra blank line
- Extract DinoComparer class
- Extract PrefixUnitResult class