### PR TITLE
[StyleCop] Fix warnings TextNumberChinese Extractors and Parsers

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.Number/Chinese/Extractors/CardinalExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Chinese/Extractors/CardinalExtractor.cs
@@ -5,10 +5,6 @@ namespace Microsoft.Recognizers.Text.Number.Chinese
 {
     public class CardinalExtractor : BaseNumberExtractor
     {
-        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
-
-        protected sealed override string ExtractType { get; } = Constants.SYS_NUM_CARDINAL;
-
         // CardinalExtractor = Int + Double
         public CardinalExtractor(ChineseNumberExtractorMode mode = ChineseNumberExtractorMode.Default)
         {
@@ -22,5 +18,9 @@ namespace Microsoft.Recognizers.Text.Number.Chinese
 
             Regexes = builder.ToImmutable();
         }
+
+        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
+
+        protected sealed override string ExtractType { get; } = Constants.SYS_NUM_CARDINAL;
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.Number/Chinese/Extractors/DoubleExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Chinese/Extractors/DoubleExtractor.cs
@@ -8,10 +8,6 @@ namespace Microsoft.Recognizers.Text.Number.Chinese
 {
     public class DoubleExtractor : BaseNumberExtractor
     {
-        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
-
-        protected sealed override string ExtractType { get; } = Constants.SYS_NUM_DOUBLE;
-
         public DoubleExtractor()
         {
             var regexes = new Dictionary<Regex, TypeTag>
@@ -26,7 +22,7 @@ namespace Microsoft.Recognizers.Text.Number.Chinese
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    //(-).2 
+                    // (-).2
                     new Regex(NumbersDefinitions.SimpleDoubleSpecialsChars, RegexOptions.Singleline),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.NUMBER_SUFFIX)
                 },
@@ -36,12 +32,12 @@ namespace Microsoft.Recognizers.Text.Number.Chinese
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    //１５.２万
+                    // １５.２万
                     new Regex(NumbersDefinitions.DoubleWithThousandsRegex, RegexOptions.Singleline),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.CHINESE)
                 },
                 {
-                    //四十五点三三
+                    // 四十五点三三
                     new Regex(NumbersDefinitions.DoubleAllFloatRegex, RegexOptions.Singleline),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.CHINESE)
                 },
@@ -51,13 +47,16 @@ namespace Microsoft.Recognizers.Text.Number.Chinese
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.POWER_SUFFIX)
                 },
                 {
-                    //2^5
+                    // 2^5
                     new Regex(NumbersDefinitions.DoubleScientificNotationRegex, RegexOptions.Singleline),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.POWER_SUFFIX)
-                }
+                },
             };
-
             Regexes = regexes.ToImmutableDictionary();
         }
+
+        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
+
+        protected sealed override string ExtractType { get; } = Constants.SYS_NUM_DOUBLE;
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.Number/Chinese/Extractors/FractionExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Chinese/Extractors/FractionExtractor.cs
@@ -8,10 +8,6 @@ namespace Microsoft.Recognizers.Text.Number.Chinese
 {
     public class FractionExtractor : BaseNumberExtractor
     {
-        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
-
-        protected sealed override string ExtractType { get; } = Constants.SYS_NUM_FRACTION;
-        
         public FractionExtractor()
         {
             var regexes = new Dictionary<Regex, TypeTag>
@@ -21,16 +17,20 @@ namespace Microsoft.Recognizers.Text.Number.Chinese
                     new Regex(NumbersDefinitions.FractionNotationSpecialsCharsRegex, RegexOptions.Singleline), RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    // 8/3 
+                    // 8/3
                     new Regex(NumbersDefinitions.FractionNotationRegex, RegexOptions.Singleline), RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    //四分之六十五
+                    // 四分之六十五
                     new Regex(NumbersDefinitions.AllFractionNumber, RegexOptions.Singleline), RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.CHINESE)
-                }
+                },
             };
 
             Regexes = regexes.ToImmutableDictionary();
         }
+
+        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
+
+        protected sealed override string ExtractType { get; } = Constants.SYS_NUM_FRACTION;
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.Number/Chinese/Extractors/IntegerExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Chinese/Extractors/IntegerExtractor.cs
@@ -8,10 +8,6 @@ namespace Microsoft.Recognizers.Text.Number.Chinese
 {
     public class IntegerExtractor : BaseNumberExtractor
     {
-        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
-
-        protected sealed override string ExtractType { get; } = Constants.SYS_NUM_INTEGER;
-        
         public IntegerExtractor(ChineseNumberExtractorMode mode = ChineseNumberExtractorMode.Default)
         {
             var regexes = new Dictionary<Regex, TypeTag>()
@@ -21,37 +17,37 @@ namespace Microsoft.Recognizers.Text.Number.Chinese
                     new Regex(NumbersDefinitions.NumbersSpecialsChars, RegexOptions.Singleline), RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    //15k,  16 G
+                    // 15k,  16 G
                     new Regex(NumbersDefinitions.NumbersSpecialsCharsWithSuffix, RegexOptions.Singleline), RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    //1,234,  ２，３３２，１１１
+                    // 1,234,  ２，３３２，１１１
                     new Regex(NumbersDefinitions.DottedNumbersSpecialsChar, RegexOptions.Singleline), RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    //半百  半打
+                    // 半百  半打
                     new Regex(NumbersDefinitions.NumbersWithHalfDozen, RegexOptions.Singleline), RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.CHINESE)
                 },
                 {
-                    //半
+                    // 半
                     new Regex(NumbersDefinitions.HalfUnitRegex, RegexOptions.Singleline), RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.CHINESE)
                 },
                 {
-                    //一打  五十打
+                    // 一打  五十打
                     new Regex(NumbersDefinitions.NumbersWithDozen, RegexOptions.Singleline), RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.CHINESE)
-                }
+                },
             };
 
             switch (mode)
             {
                 case ChineseNumberExtractorMode.Default:
-                    // 一百五十五, 负一亿三百二十二. 
+                    // 一百五十五, 负一亿三百二十二.
                     // Uses an allow list to avoid extracting "四" from "四川"
                     regexes.Add(new Regex(NumbersDefinitions.NumbersWithAllowListRegex, RegexOptions.Singleline), RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.CHINESE));
                     break;
 
                 case ChineseNumberExtractorMode.ExtractAll:
-                    // 一百五十五, 负一亿三百二十二, "四" from "四川". 
+                    // 一百五十五, 负一亿三百二十二, "四" from "四川".
                     // Uses no allow lists and extracts all potential integers (useful in Units, for example).
                     regexes.Add(new Regex(NumbersDefinitions.NumbersAggressiveRegex, RegexOptions.Singleline), RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.CHINESE));
                     break;
@@ -59,5 +55,9 @@ namespace Microsoft.Recognizers.Text.Number.Chinese
 
             Regexes = regexes.ToImmutableDictionary();
         }
+
+        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
+
+        protected sealed override string ExtractType { get; } = Constants.SYS_NUM_INTEGER;
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.Number/Chinese/Extractors/NumberExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Chinese/Extractors/NumberExtractor.cs
@@ -3,12 +3,26 @@ using System.Text.RegularExpressions;
 
 namespace Microsoft.Recognizers.Text.Number.Chinese
 {
+    /// <summary>
+    /// These modes only apply to ChineseNumberExtractor.
+    /// The default more urilizes an allow list to avoid extracting numbers in ambiguous/undesired combinations of Chinese ideograms.
+    /// ExtractAll mode is to be used in cases where extraction should be more aggressive (e.g. in Units extraction).
+    /// </summary>
+    public enum ChineseNumberExtractorMode
+    {
+        /// <summary>
+        /// Number extraction with an allow list that filters what numbers to extract.
+        /// </summary>
+        Default,
+
+        /// <summary>
+        /// Extract all number-related terms aggressively.
+        /// </summary>
+        ExtractAll,
+    }
+
     public class NumberExtractor : BaseNumberExtractor
     {
-        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
-
-        protected sealed override string ExtractType { get; } = Constants.SYS_NUM;
-
         public NumberExtractor(ChineseNumberExtractorMode mode = ChineseNumberExtractorMode.Default)
         {
             var builder = ImmutableDictionary.CreateBuilder<Regex, TypeTag>();
@@ -16,21 +30,16 @@ namespace Microsoft.Recognizers.Text.Number.Chinese
             // Add Cardinal
             var cardExtractChs = new CardinalExtractor(mode);
             builder.AddRange(cardExtractChs.Regexes);
-            
+
             // Add Fraction
             var fracExtractChs = new FractionExtractor();
             builder.AddRange(fracExtractChs.Regexes);
 
             Regexes = builder.ToImmutable();
         }
-    }
 
-    // These modes only apply to ChineseNumberExtractor.
-    // The default more urilizes an allow list to avoid extracting numbers in ambiguous/undesired combinations of Chinese ideograms.
-    // ExtractAll mode is to be used in cases where extraction should be more aggressive (e.g. in Units extraction).
-    public enum ChineseNumberExtractorMode
-    {
-        Default, // Number extraction with an allow list that filters what numbers to extract.
-        ExtractAll, // Extract all number-related terms aggressively.
+        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
+
+        protected sealed override string ExtractType { get; } = Constants.SYS_NUM;
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.Number/Chinese/Extractors/NumberRangeExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Chinese/Extractors/NumberRangeExtractor.cs
@@ -1,19 +1,14 @@
-﻿using Microsoft.Recognizers.Definitions.Chinese;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Text.RegularExpressions;
+using Microsoft.Recognizers.Definitions.Chinese;
 
 namespace Microsoft.Recognizers.Text.Number.Chinese
 {
     public class NumberRangeExtractor : BaseNumberRangeExtractor
     {
-        internal sealed override ImmutableDictionary<Regex, string> Regexes { get; }
-
-        internal sealed override Regex AmbiguousFractionConnectorsRegex { get; }
-
-        protected sealed override string ExtractType { get; } = Constants.SYS_NUMRANGE;
-
-        public NumberRangeExtractor(NumberOptions options = NumberOptions.None) : base(new NumberExtractor(), new OrdinalExtractor(), new BaseCJKNumberParser(new ChineseNumberParserConfiguration()), options: options)
+        public NumberRangeExtractor(NumberOptions options = NumberOptions.None)
+            : base(new NumberExtractor(), new OrdinalExtractor(), new BaseCJKNumberParser(new ChineseNumberParserConfiguration()), options: options)
         {
             var regexes = new Dictionary<Regex, string>()
             {
@@ -71,13 +66,19 @@ namespace Microsoft.Recognizers.Text.Number.Chinese
                     // 等于...
                     new Regex(NumbersDefinitions.OneNumberRangeEqualRegex, RegexOptions.Singleline),
                     NumberRangeConstants.EQUAL
-                }
+                },
             };
 
             Regexes = regexes.ToImmutableDictionary();
 
-            AmbiguousFractionConnectorsRegex = 
+            AmbiguousFractionConnectorsRegex =
                 new Regex(NumbersDefinitions.AmbiguousFractionConnectorsRegex, RegexOptions.Singleline);
         }
+
+        internal sealed override ImmutableDictionary<Regex, string> Regexes { get; }
+
+        internal sealed override Regex AmbiguousFractionConnectorsRegex { get; }
+
+        protected sealed override string ExtractType { get; } = Constants.SYS_NUMRANGE;
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.Number/Chinese/Extractors/OrdinalExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Chinese/Extractors/OrdinalExtractor.cs
@@ -9,26 +9,25 @@ namespace Microsoft.Recognizers.Text.Number.Chinese
 {
     public class OrdinalExtractor : BaseNumberExtractor
     {
-        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
-
-        protected sealed override string ExtractType { get; } = Constants.SYS_NUM_ORDINAL;
-
         public OrdinalExtractor()
         {
             var regexes = new Dictionary<Regex, TypeTag>
             {
                 {
-                    //第一百五十四
+                    // 第一百五十四
                     new Regex(NumbersDefinitions.OrdinalRegex, RegexOptions.Singleline), RegexTagGenerator.GenerateRegexTag(Constants.ORDINAL_PREFIX, Constants.CHINESE)
                 },
                 {
-                    //第２５６５,  第1234
-                    new Regex(NumbersDefinitions.OrdinalNumbersRegex, RegexOptions.Singleline)
-                    , RegexTagGenerator.GenerateRegexTag(Constants.ORDINAL_PREFIX, Constants.CHINESE)
-                }
+                    // 第２５６５,  第1234
+                    new Regex(NumbersDefinitions.OrdinalNumbersRegex, RegexOptions.Singleline), RegexTagGenerator.GenerateRegexTag(Constants.ORDINAL_PREFIX, Constants.CHINESE)
+                },
             };
 
             Regexes = regexes.ToImmutableDictionary();
         }
+
+        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
+
+        protected sealed override string ExtractType { get; } = Constants.SYS_NUM_ORDINAL;
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.Number/Chinese/Extractors/PercentageExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Chinese/Extractors/PercentageExtractor.cs
@@ -8,10 +8,6 @@ namespace Microsoft.Recognizers.Text.Number.Chinese
 {
     public class PercentageExtractor : BaseNumberExtractor
     {
-        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
-
-        protected sealed override string ExtractType { get; } = Constants.SYS_NUM_PERCENTAGE;
-
         public PercentageExtractor()
         {
             var regexes = new Dictionary<Regex, TypeTag>
@@ -33,7 +29,7 @@ namespace Microsoft.Recognizers.Text.Number.Chinese
                     new Regex(NumbersDefinitions.NumbersPercentageWithSeparatorRegex, RegexOptions.Singleline), RegexTagGenerator.GenerateRegexTag(Constants.PERCENT_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    // 百分之3.2 k 
+                    // 百分之3.2 k
                     new Regex(NumbersDefinitions.NumbersPercentageWithMultiplierRegex, RegexOptions.Singleline), RegexTagGenerator.GenerateRegexTag(Constants.PERCENT_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
@@ -53,7 +49,7 @@ namespace Microsoft.Recognizers.Text.Number.Chinese
                     new Regex(NumbersDefinitions.SimpleNumbersPercentageRegex, RegexOptions.Singleline), RegexTagGenerator.GenerateRegexTag(Constants.PERCENT_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    // 百分之15k 
+                    // 百分之15k
                     new Regex(NumbersDefinitions.SimpleNumbersPercentageWithMultiplierRegex, RegexOptions.Singleline), RegexTagGenerator.GenerateRegexTag(Constants.PERCENT_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
@@ -103,10 +99,14 @@ namespace Microsoft.Recognizers.Text.Number.Chinese
                 {
                     // 打对折 半成
                     new Regex(NumbersDefinitions.SpecialsFoldsPercentageRegex, RegexOptions.Singleline), RegexTagGenerator.GenerateRegexTag(Constants.PERCENT_PREFIX, Constants.SPECIAL_SUFFIX)
-                }
+                },
             };
 
             Regexes = regexes.ToImmutableDictionary();
         }
+
+        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
+
+        protected sealed override string ExtractType { get; } = Constants.SYS_NUM_PERCENTAGE;
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.Number/Chinese/Parsers/ChineseNumberParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Chinese/Parsers/ChineseNumberParserConfiguration.cs
@@ -10,7 +10,8 @@ namespace Microsoft.Recognizers.Text.Number.Chinese
 {
     public class ChineseNumberParserConfiguration : ICJKNumberParserConfiguration
     {
-        public ChineseNumberParserConfiguration() : this(new CultureInfo(Culture.Chinese))
+        public ChineseNumberParserConfiguration()
+               : this(new CultureInfo(Culture.Chinese))
         {
         }
 

--- a/.NET/Microsoft.Recognizers.Text.Number/Chinese/Parsers/ChineseNumberRangeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Chinese/Parsers/ChineseNumberRangeParserConfiguration.cs
@@ -1,11 +1,31 @@
-﻿using Microsoft.Recognizers.Definitions.Chinese;
-using System.Globalization;
+﻿using System.Globalization;
 using System.Text.RegularExpressions;
+using Microsoft.Recognizers.Definitions.Chinese;
 
 namespace Microsoft.Recognizers.Text.Number.Chinese
 {
-    public class ChineseNumberRangeParserConfiguration :INumberRangeParserConfiguration
+    public class ChineseNumberRangeParserConfiguration : INumberRangeParserConfiguration
     {
+        public ChineseNumberRangeParserConfiguration()
+           : this(new CultureInfo(Culture.Chinese))
+        {
+        }
+
+        public ChineseNumberRangeParserConfiguration(CultureInfo ci)
+        {
+            CultureInfo = ci;
+
+            NumberExtractor = new NumberExtractor();
+            OrdinalExtractor = new OrdinalExtractor();
+            NumberParser = new BaseCJKNumberParser(new ChineseNumberParserConfiguration());
+            MoreOrEqual = new Regex(NumbersDefinitions.MoreOrEqual, RegexOptions.Singleline);
+            LessOrEqual = new Regex(NumbersDefinitions.LessOrEqual, RegexOptions.Singleline);
+            MoreOrEqualSuffix = new Regex(NumbersDefinitions.MoreOrEqualSuffix, RegexOptions.Singleline);
+            LessOrEqualSuffix = new Regex(NumbersDefinitions.LessOrEqualSuffix, RegexOptions.Singleline);
+            MoreOrEqualSeparate = new Regex(NumbersDefinitions.OneNumberRangeMoreSeparateRegex, RegexOptions.Singleline);
+            LessOrEqualSeparate = new Regex(NumbersDefinitions.OneNumberRangeLessSeparateRegex, RegexOptions.Singleline);
+        }
+
         public CultureInfo CultureInfo { get; private set; }
 
         public IExtractor NumberExtractor { get; private set; }
@@ -25,24 +45,5 @@ namespace Microsoft.Recognizers.Text.Number.Chinese
         public Regex MoreOrEqualSeparate { get; private set; }
 
         public Regex LessOrEqualSeparate { get; private set; }
-
-        public ChineseNumberRangeParserConfiguration() : this(new CultureInfo(Culture.Chinese))
-        {
-        }
-
-        public ChineseNumberRangeParserConfiguration(CultureInfo ci)
-        {
-            CultureInfo = ci;
-
-            NumberExtractor = new NumberExtractor();
-            OrdinalExtractor = new OrdinalExtractor();
-            NumberParser =  new BaseCJKNumberParser(new ChineseNumberParserConfiguration());
-            MoreOrEqual = new Regex(NumbersDefinitions.MoreOrEqual, RegexOptions.Singleline);
-            LessOrEqual = new Regex(NumbersDefinitions.LessOrEqual, RegexOptions.Singleline);
-            MoreOrEqualSuffix = new Regex(NumbersDefinitions.MoreOrEqualSuffix, RegexOptions.Singleline);
-            LessOrEqualSuffix = new Regex(NumbersDefinitions.LessOrEqualSuffix, RegexOptions.Singleline);
-            MoreOrEqualSeparate = new Regex(NumbersDefinitions.OneNumberRangeMoreSeparateRegex, RegexOptions.Singleline);
-            LessOrEqualSeparate = new Regex(NumbersDefinitions.OneNumberRangeLessSeparateRegex, RegexOptions.Singleline);
-        }
     }
 }


### PR DESCRIPTION
- Remove trailing whitespace
- Reorder fields and properties
- Add trailing comma
- Reorder using statements
- Reorder using statements