### PR TITLE
[StyleCop] Fix all the warnings in German Extractors

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/German/Extractors/AgeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/German/Extractors/AgeExtractorConfiguration.cs
@@ -7,9 +7,17 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.German
 {
     public class AgeExtractorConfiguration : GermanNumberWithUnitExtractorConfiguration
     {
-        public AgeExtractorConfiguration() : this(new CultureInfo(Culture.German)) { }
+        public static readonly ImmutableDictionary<string, string> AgeSuffixList = NumbersWithUnitDefinitions.AgeSuffixList.ToImmutableDictionary();
 
-        public AgeExtractorConfiguration(CultureInfo ci) : base(ci) { }
+        public AgeExtractorConfiguration()
+            : this(new CultureInfo(Culture.German))
+        {
+        }
+
+        public AgeExtractorConfiguration(CultureInfo ci)
+            : base(ci)
+        {
+        }
 
         public override ImmutableDictionary<string, string> SuffixList => AgeSuffixList;
 
@@ -18,7 +26,5 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.German
         public override ImmutableList<string> AmbiguousUnitList => null;
 
         public override string ExtractType => Constants.SYS_UNIT_AGE;
-
-        public static readonly ImmutableDictionary<string, string> AgeSuffixList = NumbersWithUnitDefinitions.AgeSuffixList.ToImmutableDictionary();
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/German/Extractors/AreaExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/German/Extractors/AreaExtractorConfiguration.cs
@@ -7,9 +7,17 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.German
 {
     public class AreaExtractorConfiguration : GermanNumberWithUnitExtractorConfiguration
     {
-        public AreaExtractorConfiguration() : this(new CultureInfo(Culture.German)) { }
+        public static readonly ImmutableDictionary<string, string> AreaSuffixList = NumbersWithUnitDefinitions.AreaSuffixList.ToImmutableDictionary();
 
-        public AreaExtractorConfiguration(CultureInfo ci) : base(ci) { }
+        public AreaExtractorConfiguration()
+            : this(new CultureInfo(Culture.German))
+        {
+        }
+
+        public AreaExtractorConfiguration(CultureInfo ci)
+            : base(ci)
+        {
+        }
 
         public override ImmutableDictionary<string, string> SuffixList => AreaSuffixList;
 
@@ -18,7 +26,5 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.German
         public override ImmutableList<string> AmbiguousUnitList => null;
 
         public override string ExtractType => Constants.SYS_UNIT_AREA;
-
-        public static readonly ImmutableDictionary<string, string> AreaSuffixList = NumbersWithUnitDefinitions.AreaSuffixList.ToImmutableDictionary();
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/German/Extractors/CurrencyExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/German/Extractors/CurrencyExtractorConfiguration.cs
@@ -7,9 +7,21 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.German
 {
     public class CurrencyExtractorConfiguration : GermanNumberWithUnitExtractorConfiguration
     {
-        public CurrencyExtractorConfiguration() : this(new CultureInfo(Culture.German)) { }
+        public static readonly ImmutableDictionary<string, string> CurrencyPrefixList = NumbersWithUnitDefinitions.CurrencyPrefixList.ToImmutableDictionary();
 
-        public CurrencyExtractorConfiguration(CultureInfo ci) : base(ci) { }
+        public static readonly ImmutableDictionary<string, string> CurrencySuffixList = NumbersWithUnitDefinitions.CurrencySuffixList.ToImmutableDictionary();
+
+        private static readonly ImmutableList<string> AmbiguousValues = NumbersWithUnitDefinitions.AmbiguousCurrencyUnitList.ToImmutableList();
+
+        public CurrencyExtractorConfiguration()
+            : this(new CultureInfo(Culture.German))
+        {
+        }
+
+        public CurrencyExtractorConfiguration(CultureInfo ci)
+            : base(ci)
+        {
+        }
 
         public override ImmutableDictionary<string, string> SuffixList => CurrencySuffixList;
 
@@ -18,11 +30,5 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.German
         public override ImmutableList<string> AmbiguousUnitList => AmbiguousValues;
 
         public override string ExtractType => Constants.SYS_UNIT_CURRENCY;
-
-        public static readonly ImmutableDictionary<string, string> CurrencySuffixList = NumbersWithUnitDefinitions.CurrencySuffixList.ToImmutableDictionary();
-
-        public static readonly ImmutableDictionary<string, string> CurrencyPrefixList = NumbersWithUnitDefinitions.CurrencyPrefixList.ToImmutableDictionary();
-
-        private static readonly ImmutableList<string> AmbiguousValues = NumbersWithUnitDefinitions.AmbiguousCurrencyUnitList.ToImmutableList();
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/German/Extractors/DimensionExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/German/Extractors/DimensionExtractorConfiguration.cs
@@ -8,18 +8,6 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.German
 {
     public class DimensionExtractorConfiguration : GermanNumberWithUnitExtractorConfiguration
     {
-        public DimensionExtractorConfiguration() : base(new CultureInfo(Culture.German)) { }
-
-        public DimensionExtractorConfiguration(CultureInfo ci) : base(ci) { }
-
-        public override ImmutableDictionary<string, string> SuffixList => DimensionSuffixList;
-
-        public override ImmutableDictionary<string, string> PrefixList => null;
-
-        public override ImmutableList<string> AmbiguousUnitList => AmbiguousValues;
-
-        public override string ExtractType => Constants.SYS_UNIT_DIMENSION;
-
         public static readonly ImmutableDictionary<string, string> DimensionSuffixList = NumbersWithUnitDefinitions.InformationSuffixList
             .Concat(AreaExtractorConfiguration.AreaSuffixList)
             .Concat(LengthExtractorConfiguration.LengthSuffixList)
@@ -29,5 +17,23 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.German
             .ToImmutableDictionary(x => x.Key, x => x.Value);
 
         private static readonly ImmutableList<string> AmbiguousValues = NumbersWithUnitDefinitions.AmbiguousDimensionUnitList.ToImmutableList();
+
+        public DimensionExtractorConfiguration()
+            : base(new CultureInfo(Culture.German))
+        {
+        }
+
+        public DimensionExtractorConfiguration(CultureInfo ci)
+            : base(ci)
+        {
+        }
+
+        public override ImmutableDictionary<string, string> SuffixList => DimensionSuffixList;
+
+        public override ImmutableDictionary<string, string> PrefixList => null;
+
+        public override ImmutableList<string> AmbiguousUnitList => AmbiguousValues;
+
+        public override string ExtractType => Constants.SYS_UNIT_DIMENSION;
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/German/Extractors/GermanNumberWithUnitExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/German/Extractors/GermanNumberWithUnitExtractorConfiguration.cs
@@ -11,6 +11,12 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.German
 {
     public abstract class GermanNumberWithUnitExtractorConfiguration : INumberWithUnitExtractorConfiguration
     {
+        private static readonly Regex CompoundUnitConnRegex =
+            new Regex(NumbersWithUnitDefinitions.CompoundUnitConnectorRegex, RegexOptions.None);
+
+        private static readonly Regex NonUnitsRegex =
+            new Regex(BaseUnits.PmNonUnitRegex, RegexOptions.None);
+
         protected GermanNumberWithUnitExtractorConfiguration(CultureInfo ci)
         {
             this.CultureInfo = ci;
@@ -45,11 +51,5 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.German
         public abstract ImmutableDictionary<string, string> PrefixList { get; }
 
         public abstract ImmutableList<string> AmbiguousUnitList { get; }
-
-        private static readonly Regex CompoundUnitConnRegex =
-            new Regex(NumbersWithUnitDefinitions.CompoundUnitConnectorRegex, RegexOptions.None);
-
-        private static readonly Regex NonUnitsRegex =
-            new Regex(BaseUnits.PmNonUnitRegex, RegexOptions.None);
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/German/Extractors/LengthExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/German/Extractors/LengthExtractorConfiguration.cs
@@ -7,9 +7,19 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.German
 {
     public class LengthExtractorConfiguration : GermanNumberWithUnitExtractorConfiguration
     {
-        public LengthExtractorConfiguration() : base(new CultureInfo(Culture.German)) { }
+        public static readonly ImmutableDictionary<string, string> LengthSuffixList = NumbersWithUnitDefinitions.LengthSuffixList.ToImmutableDictionary();
 
-        public LengthExtractorConfiguration(CultureInfo ci) : base(ci) { }
+        private static readonly ImmutableList<string> AmbiguousValues = NumbersWithUnitDefinitions.AmbiguousLengthUnitList.ToImmutableList();
+
+        public LengthExtractorConfiguration()
+            : base(new CultureInfo(Culture.German))
+        {
+        }
+
+        public LengthExtractorConfiguration(CultureInfo ci)
+            : base(ci)
+        {
+        }
 
         public override ImmutableDictionary<string, string> SuffixList => LengthSuffixList;
 
@@ -18,9 +28,5 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.German
         public override ImmutableList<string> AmbiguousUnitList => AmbiguousValues;
 
         public override string ExtractType => Constants.SYS_UNIT_LENGTH;
-
-        public static readonly ImmutableDictionary<string, string> LengthSuffixList = NumbersWithUnitDefinitions.LengthSuffixList.ToImmutableDictionary();
-
-        private static readonly ImmutableList<string> AmbiguousValues = NumbersWithUnitDefinitions.AmbiguousLengthUnitList.ToImmutableList();
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/German/Extractors/SpeedExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/German/Extractors/SpeedExtractorConfiguration.cs
@@ -7,9 +7,17 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.German
 {
     public class SpeedExtractorConfiguration : GermanNumberWithUnitExtractorConfiguration
     {
-        public SpeedExtractorConfiguration() : base(new CultureInfo(Culture.German)) { }
+        public static readonly ImmutableDictionary<string, string> SpeedSuffixList = NumbersWithUnitDefinitions.SpeedSuffixList.ToImmutableDictionary();
 
-        public SpeedExtractorConfiguration(CultureInfo ci) : base(ci) { }
+        public SpeedExtractorConfiguration()
+            : base(new CultureInfo(Culture.German))
+        {
+        }
+
+        public SpeedExtractorConfiguration(CultureInfo ci)
+            : base(ci)
+        {
+        }
 
         public override ImmutableDictionary<string, string> SuffixList => SpeedSuffixList;
 
@@ -18,7 +26,5 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.German
         public override ImmutableList<string> AmbiguousUnitList => null;
 
         public override string ExtractType => Constants.SYS_UNIT_SPEED;
-
-        public static readonly ImmutableDictionary<string, string> SpeedSuffixList = NumbersWithUnitDefinitions.SpeedSuffixList.ToImmutableDictionary();
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/German/Extractors/TemperatureExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/German/Extractors/TemperatureExtractorConfiguration.cs
@@ -9,9 +9,24 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.German
 {
     public class TemperatureExtractorConfiguration : GermanNumberWithUnitExtractorConfiguration
     {
-        public TemperatureExtractorConfiguration() : this(new CultureInfo(Culture.German)) { }
+        public static readonly ImmutableDictionary<string, string> TemperatureSuffixList =
+               NumbersWithUnitDefinitions.TemperatureSuffixList.ToImmutableDictionary();
 
-        public TemperatureExtractorConfiguration(CultureInfo ci) : base(ci) { }
+        private static readonly ImmutableList<string> AmbiguousValues =
+            NumbersWithUnitDefinitions.AmbiguousTemperatureUnitList.ToImmutableList();
+
+        private static readonly Regex AmbiguousUnitMultiplierRegex =
+            new Regex(BaseUnits.AmbiguousUnitNumberMultiplierRegex, RegexOptions.None);
+
+        public TemperatureExtractorConfiguration()
+            : this(new CultureInfo(Culture.German))
+        {
+        }
+
+        public TemperatureExtractorConfiguration(CultureInfo ci)
+            : base(ci)
+        {
+        }
 
         public override ImmutableDictionary<string, string> SuffixList => TemperatureSuffixList;
 
@@ -21,15 +36,6 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.German
 
         public override string ExtractType => Constants.SYS_UNIT_TEMPERATURE;
 
-        public static readonly ImmutableDictionary<string, string> TemperatureSuffixList = 
-            NumbersWithUnitDefinitions.TemperatureSuffixList.ToImmutableDictionary();
-
-        private static readonly ImmutableList<string> AmbiguousValues = 
-            NumbersWithUnitDefinitions.AmbiguousTemperatureUnitList.ToImmutableList();
-
         public override Regex AmbiguousUnitNumberMultiplierRegex => AmbiguousUnitMultiplierRegex;
-
-        private static readonly Regex AmbiguousUnitMultiplierRegex =
-            new Regex(BaseUnits.AmbiguousUnitNumberMultiplierRegex, RegexOptions.None);
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/German/Extractors/VolumeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/German/Extractors/VolumeExtractorConfiguration.cs
@@ -7,9 +7,19 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.German
 {
     public class VolumeExtractorConfiguration : GermanNumberWithUnitExtractorConfiguration
     {
-        public VolumeExtractorConfiguration() : this(new CultureInfo(Culture.German)) { }
+        public static readonly ImmutableDictionary<string, string> VolumeSuffixList = NumbersWithUnitDefinitions.VolumeSuffixList.ToImmutableDictionary();
 
-        public VolumeExtractorConfiguration(CultureInfo ci) : base(ci) { }
+        private static readonly ImmutableList<string> AmbiguousValues = NumbersWithUnitDefinitions.AmbiguousVolumeUnitList.ToImmutableList();
+
+        public VolumeExtractorConfiguration()
+            : this(new CultureInfo(Culture.German))
+        {
+        }
+
+        public VolumeExtractorConfiguration(CultureInfo ci)
+            : base(ci)
+        {
+        }
 
         public override ImmutableDictionary<string, string> SuffixList => VolumeSuffixList;
 
@@ -18,9 +28,5 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.German
         public override ImmutableList<string> AmbiguousUnitList => AmbiguousValues;
 
         public override string ExtractType => Constants.SYS_UNIT_VOLUME;
-
-        public static readonly ImmutableDictionary<string, string> VolumeSuffixList = NumbersWithUnitDefinitions.VolumeSuffixList.ToImmutableDictionary();
-
-        private static readonly ImmutableList<string> AmbiguousValues = NumbersWithUnitDefinitions.AmbiguousVolumeUnitList.ToImmutableList();
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/German/Extractors/WeightExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/German/Extractors/WeightExtractorConfiguration.cs
@@ -7,9 +7,19 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.German
 {
     public class WeightExtractorConfiguration : GermanNumberWithUnitExtractorConfiguration
     {
-        public WeightExtractorConfiguration() : this(new CultureInfo(Culture.German)) { }
+        public static readonly ImmutableDictionary<string, string> WeightSuffixList = NumbersWithUnitDefinitions.WeightSuffixList.ToImmutableDictionary();
 
-        public WeightExtractorConfiguration(CultureInfo ci) : base(ci) { }
+        private static readonly ImmutableList<string> AmbiguousValues = NumbersWithUnitDefinitions.AmbiguousWeightUnitList.ToImmutableList();
+
+        public WeightExtractorConfiguration()
+            : this(new CultureInfo(Culture.German))
+        {
+        }
+
+        public WeightExtractorConfiguration(CultureInfo ci)
+            : base(ci)
+        {
+        }
 
         public override ImmutableDictionary<string, string> SuffixList => WeightSuffixList;
 
@@ -18,9 +28,5 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.German
         public override ImmutableList<string> AmbiguousUnitList => AmbiguousValues;
 
         public override string ExtractType => Constants.SYS_UNIT_WEIGHT;
-
-        public static readonly ImmutableDictionary<string, string> WeightSuffixList = NumbersWithUnitDefinitions.WeightSuffixList.ToImmutableDictionary();
-
-        private static readonly ImmutableList<string> AmbiguousValues = NumbersWithUnitDefinitions.AmbiguousWeightUnitList.ToImmutableList();
     }
 }


### PR DESCRIPTION
- SA1502: Element should not be on a single line - Move curly braces to different lines
- SA1201: A field should not follow a property - Reorder fields and properties
- SA1128: Put constructor initializers on their own line - Move constructor initializer to a different line