### PR TITLE
[StyleCop] Fix warnings TextNumberDutch Extractors and Parsers

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.Number/Dutch/Extractors/CardinalExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Dutch/Extractors/CardinalExtractor.cs
@@ -8,15 +8,29 @@ namespace Microsoft.Recognizers.Text.Number.Dutch
 {
     public class CardinalExtractor : BaseNumberExtractor
     {
+        private static readonly ConcurrentDictionary<string, CardinalExtractor> Instances = new ConcurrentDictionary<string, CardinalExtractor>();
+
+        private CardinalExtractor(string placeholder = NumbersDefinitions.PlaceHolderDefault)
+        {
+            var builder = ImmutableDictionary.CreateBuilder<Regex, TypeTag>();
+
+            // Add Integer Regexes
+            var intExtract = IntegerExtractor.GetInstance(placeholder);
+            builder.AddRange(intExtract.Regexes);
+
+            // Add Double Regexes
+            var douExtract = DoubleExtractor.GetInstance(placeholder);
+            builder.AddRange(douExtract.Regexes);
+
+            Regexes = builder.ToImmutable();
+        }
+
         internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
 
-        protected sealed override string ExtractType { get; } = Constants.SYS_NUM_CARDINAL; //"Cardinal";
-
-        private static readonly ConcurrentDictionary<string, CardinalExtractor> Instances = new ConcurrentDictionary<string, CardinalExtractor>();
+        protected sealed override string ExtractType { get; } = Constants.SYS_NUM_CARDINAL; // "Cardinal";
 
         public static CardinalExtractor GetInstance(string placeholder = NumbersDefinitions.PlaceHolderDefault)
         {
-
             if (!Instances.ContainsKey(placeholder))
             {
                 var instance = new CardinalExtractor(placeholder);
@@ -24,21 +38,6 @@ namespace Microsoft.Recognizers.Text.Number.Dutch
             }
 
             return Instances[placeholder];
-        }
-
-        private CardinalExtractor(string placeholder = NumbersDefinitions.PlaceHolderDefault)
-        {
-            var builder = ImmutableDictionary.CreateBuilder<Regex, TypeTag>();
-
-            //Add Integer Regexes
-            var intExtract = IntegerExtractor.GetInstance(placeholder);
-            builder.AddRange(intExtract.Regexes);
-
-            //Add Double Regexes
-            var douExtract = DoubleExtractor.GetInstance(placeholder);
-            builder.AddRange(douExtract.Regexes);
-
-            Regexes = builder.ToImmutable();
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.Number/Dutch/Extractors/DoubleExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Dutch/Extractors/DoubleExtractor.cs
@@ -9,23 +9,7 @@ namespace Microsoft.Recognizers.Text.Number.Dutch
 {
     public class DoubleExtractor : BaseNumberExtractor
     {
-        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
-
-        protected sealed override string ExtractType { get; } = Constants.SYS_NUM_DOUBLE; // "Double";
-
         private static readonly ConcurrentDictionary<string, DoubleExtractor> Instances = new ConcurrentDictionary<string, DoubleExtractor>();
-
-        public static DoubleExtractor GetInstance(string placeholder = NumbersDefinitions.PlaceHolderDefault)
-        {
-
-            if (!Instances.ContainsKey(placeholder))
-            {
-                var instance = new DoubleExtractor(placeholder);
-                Instances.TryAdd(placeholder, instance);
-            }
-
-            return Instances[placeholder];
-        }
 
         private DoubleExtractor(string placeholder = NumbersDefinitions.PlaceHolderDefault)
         {
@@ -70,11 +54,25 @@ namespace Microsoft.Recognizers.Text.Number.Dutch
                 {
                     GenerateLongFormatNumberRegexes(LongFormatType.DoubleNumBlankComma, placeholder),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.NUMBER_SUFFIX)
-                }
-
+                },
             };
 
             Regexes = regexes.ToImmutableDictionary();
+        }
+
+        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
+
+        protected sealed override string ExtractType { get; } = Constants.SYS_NUM_DOUBLE; // "Double";
+
+        public static DoubleExtractor GetInstance(string placeholder = NumbersDefinitions.PlaceHolderDefault)
+        {
+            if (!Instances.ContainsKey(placeholder))
+            {
+                var instance = new DoubleExtractor(placeholder);
+                Instances.TryAdd(placeholder, instance);
+            }
+
+            return Instances[placeholder];
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.Number/Dutch/Extractors/FractionExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Dutch/Extractors/FractionExtractor.cs
@@ -9,26 +9,8 @@ namespace Microsoft.Recognizers.Text.Number.Dutch
 {
     public class FractionExtractor : BaseNumberExtractor
     {
-        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
-
-        protected sealed override NumberOptions Options { get; }
-
-        protected sealed override string ExtractType { get; } = Constants.SYS_NUM_FRACTION; // "Fraction";
-
         private static readonly ConcurrentDictionary<(NumberOptions, string), FractionExtractor> Instances =
             new ConcurrentDictionary<(NumberOptions, string), FractionExtractor>();
-
-        public static FractionExtractor GetInstance(NumberOptions options = NumberOptions.None, string placeholder = "")
-        {
-            var cacheKey = (options, placeholder);
-            if (!Instances.ContainsKey(cacheKey))
-            {
-                var instance = new FractionExtractor(options);
-                Instances.TryAdd(cacheKey, instance);
-            }
-
-            return Instances[cacheKey];
-        }
 
         private FractionExtractor(NumberOptions options)
         {
@@ -52,25 +34,41 @@ namespace Microsoft.Recognizers.Text.Number.Dutch
                 {
                     new Regex(NumbersDefinitions.FractionNounWithArticleRegex, RegexOptions.Singleline),
                     RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.DUTCH)
-                }
+                },
             };
 
             if ((Options & NumberOptions.PercentageMode) != 0)
             {
                 regexes.Add(
-                    new Regex(NumbersDefinitions.FractionPrepositionWithinPercentModeRegex, RegexOptions.Singleline), 
-                    RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.DUTCH)
-                );
+                    new Regex(NumbersDefinitions.FractionPrepositionWithinPercentModeRegex, RegexOptions.Singleline),
+                    RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.DUTCH));
             }
             else
             {
                 regexes.Add(
-                    new Regex(NumbersDefinitions.FractionPrepositionRegex, RegexOptions.Singleline), 
-                    RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.DUTCH)
-                );
+                    new Regex(NumbersDefinitions.FractionPrepositionRegex, RegexOptions.Singleline),
+                    RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.DUTCH));
             }
 
             Regexes = regexes.ToImmutableDictionary();
+        }
+
+        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
+
+        protected sealed override NumberOptions Options { get; }
+
+        protected sealed override string ExtractType { get; } = Constants.SYS_NUM_FRACTION; // "Fraction";
+
+        public static FractionExtractor GetInstance(NumberOptions options = NumberOptions.None, string placeholder = "")
+        {
+            var cacheKey = (options, placeholder);
+            if (!Instances.ContainsKey(cacheKey))
+            {
+                var instance = new FractionExtractor(options);
+                Instances.TryAdd(cacheKey, instance);
+            }
+
+            return Instances[cacheKey];
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.Number/Dutch/Extractors/IntegerExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Dutch/Extractors/IntegerExtractor.cs
@@ -9,23 +9,7 @@ namespace Microsoft.Recognizers.Text.Number.Dutch
 {
     public class IntegerExtractor : BaseNumberExtractor
     {
-        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
-
-        protected sealed override string ExtractType { get; } = Constants.SYS_NUM_INTEGER; // "Integer";
-
         private static readonly ConcurrentDictionary<string, IntegerExtractor> Instances = new ConcurrentDictionary<string, IntegerExtractor>();
-
-        public static IntegerExtractor GetInstance(string placeholder = NumbersDefinitions.PlaceHolderDefault)
-        {
-
-            if (!Instances.ContainsKey(placeholder))
-            {
-                var instance = new IntegerExtractor(placeholder);
-                Instances.TryAdd(placeholder, instance);
-            }
-
-            return Instances[placeholder];
-        }
 
         private IntegerExtractor(string placeholder = NumbersDefinitions.PlaceHolderDefault)
         {
@@ -70,10 +54,25 @@ namespace Microsoft.Recognizers.Text.Number.Dutch
                 {
                     GenerateLongFormatNumberRegexes(LongFormatType.IntegerNumDot, placeholder),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.NUMBER_SUFFIX)
-                }
+                },
             };
 
             Regexes = regexes.ToImmutableDictionary();
+        }
+
+        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
+
+        protected sealed override string ExtractType { get; } = Constants.SYS_NUM_INTEGER; // "Integer";
+
+        public static IntegerExtractor GetInstance(string placeholder = NumbersDefinitions.PlaceHolderDefault)
+        {
+            if (!Instances.ContainsKey(placeholder))
+            {
+                var instance = new IntegerExtractor(placeholder);
+                Instances.TryAdd(placeholder, instance);
+            }
+
+            return Instances[placeholder];
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.Number/Dutch/Extractors/NumberExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Dutch/Extractors/NumberExtractor.cs
@@ -8,28 +8,8 @@ namespace Microsoft.Recognizers.Text.Number.Dutch
 {
     public class NumberExtractor : BaseNumberExtractor
     {
-        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
-
-        protected sealed override NumberOptions Options { get; }
-
-        protected sealed override string ExtractType { get; } = Constants.SYS_NUM; // "Number";
-
-        protected sealed override Regex NegativeNumberTermsRegex { get; }
-
         private static readonly ConcurrentDictionary<(NumberMode, NumberOptions), NumberExtractor> Instances =
             new ConcurrentDictionary<(NumberMode, NumberOptions), NumberExtractor>();
-
-        public static NumberExtractor GetInstance(NumberMode mode = NumberMode.Default, NumberOptions options = NumberOptions.None)
-        {
-            var cacheKey = (mode, options);
-            if (!Instances.ContainsKey(cacheKey))
-            {
-                var instance = new NumberExtractor(mode, options);
-                Instances.TryAdd(cacheKey, instance);
-            }
-
-            return Instances[cacheKey];
-        }
 
         private NumberExtractor(NumberMode mode, NumberOptions options)
         {
@@ -38,7 +18,7 @@ namespace Microsoft.Recognizers.Text.Number.Dutch
             Options = options;
 
             var builder = ImmutableDictionary.CreateBuilder<Regex, TypeTag>();
-            
+
             // Add Cardinal
             CardinalExtractor cardExtract = null;
             switch (mode)
@@ -47,8 +27,7 @@ namespace Microsoft.Recognizers.Text.Number.Dutch
                     cardExtract = CardinalExtractor.GetInstance(NumbersDefinitions.PlaceHolderPureNumber);
                     break;
                 case NumberMode.Currency:
-                    builder.Add(BaseNumberExtractor.CurrencyRegex, 
-                                RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.NUMBER_SUFFIX));
+                    builder.Add(BaseNumberExtractor.CurrencyRegex, RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.NUMBER_SUFFIX));
                     break;
                 case NumberMode.Default:
                     break;
@@ -60,12 +39,32 @@ namespace Microsoft.Recognizers.Text.Number.Dutch
             }
 
             builder.AddRange(cardExtract.Regexes);
-            
+
             // Add Fraction
             var fracExtract = FractionExtractor.GetInstance(Options);
             builder.AddRange(fracExtract.Regexes);
 
             Regexes = builder.ToImmutable();
+        }
+
+        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
+
+        protected sealed override NumberOptions Options { get; }
+
+        protected sealed override string ExtractType { get; } = Constants.SYS_NUM; // "Number";
+
+        protected sealed override Regex NegativeNumberTermsRegex { get; }
+
+        public static NumberExtractor GetInstance(NumberMode mode = NumberMode.Default, NumberOptions options = NumberOptions.None)
+        {
+            var cacheKey = (mode, options);
+            if (!Instances.ContainsKey(cacheKey))
+            {
+                var instance = new NumberExtractor(mode, options);
+                Instances.TryAdd(cacheKey, instance);
+            }
+
+            return Instances[cacheKey];
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.Number/Dutch/Extractors/NumberRangeExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Dutch/Extractors/NumberRangeExtractor.cs
@@ -8,15 +8,8 @@ namespace Microsoft.Recognizers.Text.Number.Dutch
 {
     public class NumberRangeExtractor : BaseNumberRangeExtractor
     {
-        internal sealed override ImmutableDictionary<Regex, string> Regexes { get; }
-
-        internal sealed override Regex AmbiguousFractionConnectorsRegex { get; }
-
-        protected sealed override string ExtractType { get; } = Constants.SYS_NUMRANGE;
-
-        public NumberRangeExtractor(NumberOptions options = NumberOptions.None) 
-            : base(NumberExtractor.GetInstance(), OrdinalExtractor.GetInstance(), 
-                   new BaseNumberParser(new DutchNumberParserConfiguration()), options)
+        public NumberRangeExtractor(NumberOptions options = NumberOptions.None)
+            : base(NumberExtractor.GetInstance(), OrdinalExtractor.GetInstance(), new BaseNumberParser(new DutchNumberParserConfiguration()), options)
         {
             var regexes = new Dictionary<Regex, string>()
             {
@@ -74,13 +67,19 @@ namespace Microsoft.Recognizers.Text.Number.Dutch
                     // equal to 30 or less, smaller than 30 or equal ...
                     new Regex(NumbersDefinitions.OneNumberRangeLessSeparateRegex, RegexOptions.Singleline),
                     NumberRangeConstants.LESS
-                }
+                },
             };
 
             Regexes = regexes.ToImmutableDictionary();
 
-            AmbiguousFractionConnectorsRegex = 
+            AmbiguousFractionConnectorsRegex =
                 new Regex(NumbersDefinitions.AmbiguousFractionConnectorsRegex, RegexOptions.Singleline);
         }
+
+        internal sealed override ImmutableDictionary<Regex, string> Regexes { get; }
+
+        internal sealed override Regex AmbiguousFractionConnectorsRegex { get; }
+
+        protected sealed override string ExtractType { get; } = Constants.SYS_NUMRANGE;
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.Number/Dutch/Extractors/OrdinalExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Dutch/Extractors/OrdinalExtractor.cs
@@ -9,23 +9,7 @@ namespace Microsoft.Recognizers.Text.Number.Dutch
 {
     public class OrdinalExtractor : BaseNumberExtractor
     {
-        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
-
-        protected sealed override string ExtractType { get; } = Constants.SYS_NUM_ORDINAL; // "Ordinal";
-
         private static readonly ConcurrentDictionary<string, OrdinalExtractor> Instances = new ConcurrentDictionary<string, OrdinalExtractor>();
-
-        public static OrdinalExtractor GetInstance(string placeholder = "")
-        {
-
-            if (!Instances.ContainsKey(placeholder))
-            {
-                var instance = new OrdinalExtractor();
-                Instances.TryAdd(placeholder, instance);
-            }
-
-            return Instances[placeholder];
-        }
 
         private OrdinalExtractor()
         {
@@ -46,10 +30,25 @@ namespace Microsoft.Recognizers.Text.Number.Dutch
                 {
                     new Regex(NumbersDefinitions.OrdinalRoundNumberRegex, RegexOptions.Singleline),
                     RegexTagGenerator.GenerateRegexTag(Constants.ORDINAL_PREFIX, Constants.DUTCH)
-                }
+                },
             };
 
             Regexes = regexes.ToImmutableDictionary();
+        }
+
+        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
+
+        protected sealed override string ExtractType { get; } = Constants.SYS_NUM_ORDINAL; // "Ordinal";
+
+        public static OrdinalExtractor GetInstance(string placeholder = "")
+        {
+            if (!Instances.ContainsKey(placeholder))
+            {
+                var instance = new OrdinalExtractor();
+                Instances.TryAdd(placeholder, instance);
+            }
+
+            return Instances[placeholder];
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.Number/Dutch/Extractors/PercentageExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Dutch/Extractors/PercentageExtractor.cs
@@ -8,14 +8,14 @@ namespace Microsoft.Recognizers.Text.Number.Dutch
 {
     public sealed class PercentageExtractor : BasePercentageExtractor
     {
-        protected override NumberOptions Options { get; }
-
-        public PercentageExtractor(NumberOptions options = NumberOptions.None) : base(
-            NumberExtractor.GetInstance(options: options))
+        public PercentageExtractor(NumberOptions options = NumberOptions.None)
+            : base(NumberExtractor.GetInstance(options: options))
         {
             Options = options;
             Regexes = InitRegexes();
         }
+
+        protected override NumberOptions Options { get; }
 
         protected override ImmutableHashSet<Regex> InitRegexes()
         {

--- a/.NET/Microsoft.Recognizers.Text.Number/Dutch/Parsers/DutchNumberParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Dutch/Parsers/DutchNumberParserConfiguration.cs
@@ -10,12 +10,16 @@ namespace Microsoft.Recognizers.Text.Number.Dutch
 {
     public class DutchNumberParserConfiguration : INumberParserConfiguration
     {
-        public DutchNumberParserConfiguration(NumberOptions options) : this()
+        public DutchNumberParserConfiguration(NumberOptions options)
+            : this()
         {
             this.Options = options;
         }
 
-        public DutchNumberParserConfiguration() : this(new CultureInfo(Culture.Dutch)) { }
+        public DutchNumberParserConfiguration()
+            : this(new CultureInfo(Culture.Dutch))
+        {
+        }
 
         public DutchNumberParserConfiguration(CultureInfo ci)
         {
@@ -41,7 +45,7 @@ namespace Microsoft.Recognizers.Text.Number.Dutch
             this.HalfADozenRegex = new Regex(NumbersDefinitions.HalfADozenRegex, RegexOptions.Singleline);
             this.DigitalNumberRegex = new Regex(NumbersDefinitions.DigitalNumberRegex, RegexOptions.Singleline);
             this.NegativeNumberSignRegex = new Regex(NumbersDefinitions.NegativeNumberSignRegex, RegexOptions.Singleline);
-            this.FractionPrepositionRegex  = new Regex(NumbersDefinitions.FractionPrepositionRegex, RegexOptions.Singleline);
+            this.FractionPrepositionRegex = new Regex(NumbersDefinitions.FractionPrepositionRegex, RegexOptions.Singleline);
         }
 
         public ImmutableDictionary<string, long> CardinalNumberMap { get; private set; }
@@ -130,7 +134,6 @@ namespace Microsoft.Recognizers.Text.Number.Dutch
 
         public long ResolveCompositeNumber(string numberStr)
         {
-
             if (numberStr.Contains("-"))
             {
                 var numbers = numberStr.Split('-');

--- a/.NET/Microsoft.Recognizers.Text.Number/Dutch/Parsers/DutchNumberRangeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Dutch/Parsers/DutchNumberRangeParserConfiguration.cs
@@ -1,32 +1,13 @@
-﻿using Microsoft.Recognizers.Definitions.Dutch;
-using System.Globalization;
+﻿using System.Globalization;
 using System.Text.RegularExpressions;
+using Microsoft.Recognizers.Definitions.Dutch;
 
 namespace Microsoft.Recognizers.Text.Number.Dutch
 {
     public class DutchNumberRangeParserConfiguration : INumberRangeParserConfiguration
     {
-        public CultureInfo CultureInfo { get; private set; }
-
-        public IExtractor NumberExtractor { get; private set; }
-
-        public IExtractor OrdinalExtractor { get; private set; }
-
-        public IParser NumberParser { get; private set; }
-
-        public Regex MoreOrEqual { get; private set; }
-
-        public Regex LessOrEqual { get; private set; }
-
-        public Regex MoreOrEqualSuffix { get; private set; }
-
-        public Regex LessOrEqualSuffix { get; private set; }
-
-        public Regex MoreOrEqualSeparate { get; private set; }
-
-        public Regex LessOrEqualSeparate { get; private set; }
-
-        public DutchNumberRangeParserConfiguration() : this(new CultureInfo(Culture.Dutch))
+        public DutchNumberRangeParserConfiguration()
+            : this(new CultureInfo(Culture.Dutch))
         {
         }
 
@@ -46,5 +27,25 @@ namespace Microsoft.Recognizers.Text.Number.Dutch
             MoreOrEqualSeparate = new Regex(NumbersDefinitions.OneNumberRangeMoreSeparateRegex, RegexOptions.Singleline);
             LessOrEqualSeparate = new Regex(NumbersDefinitions.OneNumberRangeLessSeparateRegex, RegexOptions.Singleline);
         }
+
+        public CultureInfo CultureInfo { get; private set; }
+
+        public IExtractor NumberExtractor { get; private set; }
+
+        public IExtractor OrdinalExtractor { get; private set; }
+
+        public IParser NumberParser { get; private set; }
+
+        public Regex MoreOrEqual { get; private set; }
+
+        public Regex LessOrEqual { get; private set; }
+
+        public Regex MoreOrEqualSuffix { get; private set; }
+
+        public Regex LessOrEqualSuffix { get; private set; }
+
+        public Regex MoreOrEqualSeparate { get; private set; }
+
+        public Regex LessOrEqualSeparate { get; private set; }
     }
 }


### PR DESCRIPTION
- Reordered properties and methods
- Added spaces and trailing commas when needed
- Placed all regex parameters in one line
- Fixed spacing