### PR TITLE
[StyleCop] Fix all the warnings in Japanese Extractors

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Japanese/Extractors/AgeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Japanese/Extractors/AgeExtractorConfiguration.cs
@@ -6,9 +6,15 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Japanese
 {
     public class AgeExtractorConfiguration : JapaneseNumberWithUnitExtractorConfiguration
     {
-        public AgeExtractorConfiguration() : this(new CultureInfo(Culture.Japanese)) { }
+        public AgeExtractorConfiguration()
+            : this(new CultureInfo(Culture.Japanese))
+        {
+        }
 
-        public AgeExtractorConfiguration(CultureInfo ci) : base(ci) { }
+        public AgeExtractorConfiguration(CultureInfo ci)
+            : base(ci)
+        {
+        }
 
         public override ImmutableDictionary<string, string> SuffixList => NumbersWithUnitDefinitions.AgeSuffixList.ToImmutableDictionary();
 

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Japanese/Extractors/CurrencyExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Japanese/Extractors/CurrencyExtractorConfiguration.cs
@@ -6,9 +6,15 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Japanese
 {
     public class CurrencyExtractorConfiguration : JapaneseNumberWithUnitExtractorConfiguration
     {
-        public CurrencyExtractorConfiguration() : this(new CultureInfo(Culture.Japanese)) { }
+        public CurrencyExtractorConfiguration()
+            : this(new CultureInfo(Culture.Japanese))
+        {
+        }
 
-        public CurrencyExtractorConfiguration(CultureInfo ci) : base(ci) { }
+        public CurrencyExtractorConfiguration(CultureInfo ci)
+            : base(ci)
+        {
+        }
 
         public override ImmutableDictionary<string, string> SuffixList => NumbersWithUnitDefinitions.CurrencySuffixList.ToImmutableDictionary();
 

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Japanese/Extractors/JapaneseNumberWithUnitExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Japanese/Extractors/JapaneseNumberWithUnitExtractorConfiguration.cs
@@ -2,15 +2,20 @@
 using System.Collections.Immutable;
 using System.Globalization;
 using System.Text.RegularExpressions;
-
-using Microsoft.Recognizers.Text.Number.Japanese;
 using Microsoft.Recognizers.Definitions;
 using Microsoft.Recognizers.Definitions.Japanese;
+using Microsoft.Recognizers.Text.Number.Japanese;
 
 namespace Microsoft.Recognizers.Text.NumberWithUnit.Japanese
 {
     public abstract class JapaneseNumberWithUnitExtractorConfiguration : INumberWithUnitExtractorConfiguration
     {
+        private static readonly Regex CompoundUnitConnRegex =
+            new Regex(NumbersWithUnitDefinitions.CompoundUnitConnectorRegex, RegexOptions.None);
+
+        private static readonly Regex NonUnitsRegex =
+            new Regex(BaseUnits.PmNonUnitRegex, RegexOptions.None);
+
         protected JapaneseNumberWithUnitExtractorConfiguration(CultureInfo ci)
         {
             this.CultureInfo = ci;
@@ -47,11 +52,5 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Japanese
         public abstract ImmutableDictionary<string, string> PrefixList { get; }
 
         public abstract ImmutableList<string> AmbiguousUnitList { get; }
-
-        private static readonly Regex CompoundUnitConnRegex =
-            new Regex(NumbersWithUnitDefinitions.CompoundUnitConnectorRegex, RegexOptions.None);
-
-        private static readonly Regex NonUnitsRegex =
-            new Regex(BaseUnits.PmNonUnitRegex, RegexOptions.None);
     }
 }


### PR DESCRIPTION
Warnings:
    -SA1502: Element should not be on a single line - Move curly braces to different lines
    -SA1201: A field should not follow a property - Reorder fields and properties
    -SA1128: Put constructor initializers on their own line - Move constructor initializer to a different line
    -SA1210: Using directives should be ordered alphabetically by the namespaces - Reorder directives