### PR TITLE
[StyleCop] Fix all the warnings in Japanese Parsers

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Japanese/Parsers/AgeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Japanese/Parsers/AgeParserConfiguration.cs
@@ -5,9 +5,13 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Japanese
 {
     public class AgeParserConfiguration : JapaneseNumberWithUnitParserConfiguration
     {
-        public AgeParserConfiguration() : this(new CultureInfo(Culture.Chinese)) { }
+        public AgeParserConfiguration()
+            : this(new CultureInfo(Culture.Chinese))
+        {
+        }
 
-        public AgeParserConfiguration(CultureInfo ci) : base(ci)
+        public AgeParserConfiguration(CultureInfo ci)
+            : base(ci)
         {
             this.BindDictionary(NumbersWithUnitDefinitions.AgeSuffixList);
         }

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Japanese/Parsers/CurrencyParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Japanese/Parsers/CurrencyParserConfiguration.cs
@@ -1,14 +1,18 @@
-﻿using System.Globalization;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
+using System.Globalization;
 using Microsoft.Recognizers.Definitions.Japanese;
 
 namespace Microsoft.Recognizers.Text.NumberWithUnit.Japanese
 {
     public class CurrencyParserConfiguration : JapaneseNumberWithUnitParserConfiguration
     {
-        public CurrencyParserConfiguration() : this(new CultureInfo(Culture.Japanese)) { }
+        public CurrencyParserConfiguration()
+            : this(new CultureInfo(Culture.Japanese))
+        {
+        }
 
-        public CurrencyParserConfiguration(CultureInfo ci) : base(ci)
+        public CurrencyParserConfiguration(CultureInfo ci)
+            : base(ci)
         {
             this.BindDictionary(NumbersWithUnitDefinitions.CurrencyPrefixList);
             this.BindDictionary(NumbersWithUnitDefinitions.CurrencySuffixList);

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Japanese/Parsers/JapaneseNumberWithUnitParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Japanese/Parsers/JapaneseNumberWithUnitParserConfiguration.cs
@@ -1,12 +1,13 @@
 ﻿using System.Globalization;
-using Microsoft.Recognizers.Text.Number.Japanese;
 using Microsoft.Recognizers.Text.Number;
+using Microsoft.Recognizers.Text.Number.Japanese;
 
 namespace Microsoft.Recognizers.Text.NumberWithUnit.Japanese
 {
     public class JapaneseNumberWithUnitParserConfiguration : BaseNumberWithUnitParserConfiguration
     {
-        public JapaneseNumberWithUnitParserConfiguration(CultureInfo ci) : base(ci)
+        public JapaneseNumberWithUnitParserConfiguration(CultureInfo ci)
+            : base(ci)
         {
             this.InternalNumberExtractor = new NumberExtractor();
             this.InternalNumberParser = AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Number, new JapaneseNumberParserConfiguration());


### PR DESCRIPTION
Warnings:
    -SA1502: Element should not be on a single line - Move curly braces to different lines
    -SA1128: Put constructor initializers on their own line - Move constructor initializer to a different line
    -SA1210: Using directives should be ordered alphabetically by the namespaces - Reorder directives