### PR TITLE
[StyleCop] Fix all the warnings in NumberWithUnit Models

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Models/AbstractNumberWithUnitModel.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Models/AbstractNumberWithUnitModel.cs
@@ -52,18 +52,18 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit
                     {
                         Start = o.Start.Value,
                         End = o.Start.Value + o.Length.Value - 1,
-                        Resolution = (o.Value is UnitValue) ? new SortedDictionary<string, object>
-                            {
-                                { ResolutionKey.Value, ((UnitValue)o.Value).Number },
-                                { ResolutionKey.Unit, ((UnitValue)o.Value).Unit },
-                            }
-                            : (o.Value is CurrencyUnitValue) ? new SortedDictionary<string, object>
+                        Resolution = (o.Value is CurrencyUnitValue) ? new SortedDictionary<string, object>
                             {
                                 { ResolutionKey.Value, ((CurrencyUnitValue)o.Value).Number },
                                 { ResolutionKey.Unit, ((CurrencyUnitValue)o.Value).Unit },
                                 { ResolutionKey.IsoCurrency, ((CurrencyUnitValue)o.Value).IsoCurrency },
                             }
-                                : new SortedDictionary<string, object>
+                            : (o.Value is UnitValue) ? new SortedDictionary<string, object>
+                            {
+                                { ResolutionKey.Value, ((UnitValue)o.Value).Number },
+                                { ResolutionKey.Unit, ((UnitValue)o.Value).Unit },
+                            }
+                            : new SortedDictionary<string, object>
                             {
                                 { ResolutionKey.Value, (string)o.Value },
                             },
@@ -73,17 +73,17 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit
 
                     foreach (var result in modelResults)
                     {
-                        bool resultbAdd = true;
+                        bool shouldAdd = true;
 
                         foreach (var extractionResult in extractionResults)
                         {
                             if (extractionResult.Start == result.Start && extractionResult.End == result.End)
                             {
-                                resultbAdd = false;
+                                shouldAdd = false;
                             }
                         }
 
-                        if (resultbAdd)
+                        if (shouldAdd)
                         {
                             extractionResults.Add(result);
                         }

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Models/AbstractNumberWithUnitModel.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Models/AbstractNumberWithUnitModel.cs
@@ -52,19 +52,20 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit
                     {
                         Start = o.Start.Value,
                         End = o.Start.Value + o.Length.Value - 1,
-                        Resolution = (o.Value is CurrencyUnitValue) ? new SortedDictionary<string, object>
+                        Resolution = (o.Value is UnitValue) ? new SortedDictionary<string, object>
                             {
-                                {ResolutionKey.Value, ((CurrencyUnitValue)o.Value).Number},
-                                {ResolutionKey.Unit, ((CurrencyUnitValue)o.Value).Unit},
-                                {ResolutionKey.IsoCurrency, ((CurrencyUnitValue)o.Value).IsoCurrency},
+                                { ResolutionKey.Value, ((UnitValue)o.Value).Number },
+                                { ResolutionKey.Unit, ((UnitValue)o.Value).Unit },
                             }
-                            : (o.Value is UnitValue) ? new SortedDictionary<string, object>
+                            : (o.Value is CurrencyUnitValue) ? new SortedDictionary<string, object>
                             {
-                                {ResolutionKey.Value, ((UnitValue)o.Value).Number},
-                                {ResolutionKey.Unit, ((UnitValue)o.Value).Unit},
-                            } : new SortedDictionary<string, object>
+                                { ResolutionKey.Value, ((CurrencyUnitValue)o.Value).Number },
+                                { ResolutionKey.Unit, ((CurrencyUnitValue)o.Value).Unit },
+                                { ResolutionKey.IsoCurrency, ((CurrencyUnitValue)o.Value).IsoCurrency },
+                            }
+                                : new SortedDictionary<string, object>
                             {
-                                {ResolutionKey.Value, (string)o.Value},
+                                { ResolutionKey.Value, (string)o.Value },
                             },
                         Text = o.Text,
                         TypeName = ModelTypeName,
@@ -72,17 +73,17 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit
 
                     foreach (var result in modelResults)
                     {
-                        bool bAdd = true;
+                        bool resultbAdd = true;
 
                         foreach (var extractionResult in extractionResults)
                         {
                             if (extractionResult.Start == result.Start && extractionResult.End == result.End)
                             {
-                                bAdd = false;
+                                resultbAdd = false;
                             }
                         }
 
-                        if (bAdd)
+                        if (resultbAdd)
                         {
                             extractionResults.Add(result);
                         }
@@ -97,6 +98,5 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit
 
             return extractionResults;
         }
-
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Models/AgeModel.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Models/AgeModel.cs
@@ -6,7 +6,8 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit
 {
     public class AgeModel : AbstractNumberWithUnitModel
     {
-        public AgeModel(Dictionary<IExtractor, IParser> extractorParserDic) : base(extractorParserDic)
+        public AgeModel(Dictionary<IExtractor, IParser> extractorParserDic)
+            : base(extractorParserDic)
         {
         }
 

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Models/CurrencyModel.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Models/CurrencyModel.cs
@@ -4,7 +4,7 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit
 {
     public class CurrencyModel : AbstractNumberWithUnitModel
     {
-        public CurrencyModel(Dictionary<IExtractor, IParser> extractorParserDic) 
+        public CurrencyModel(Dictionary<IExtractor, IParser> extractorParserDic)
             : base(extractorParserDic)
         {
         }

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Models/DimensionModel.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Models/DimensionModel.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit
 {
     public class DimensionModel : AbstractNumberWithUnitModel
     {
-        public DimensionModel(Dictionary<IExtractor, IParser> extractorParserDic) 
+        public DimensionModel(Dictionary<IExtractor, IParser> extractorParserDic)
             : base(extractorParserDic)
         {
         }


### PR DESCRIPTION
- SA1003:	Operator should not be followed by whitespace. - Remove whitespace
- SA1009:	Closing parenthesis should not be followed by a space - Remove space
- SA1012:	Opening brace should be followed by a space. - Add space
- SA1413:	Use trailing comma in multi-line initializers - Add trailing comma
- SA1500:	Braces for multi-line statements should not share line - Add space
- SA1305: Variable 'bAdd' should not use Hungarian notation - Rename to resultbAdd
- SA1128: Put constructor initializers on their own line - Move constructor initializer to a different line
- SA1028: Code should not contain trailing whitespace - Remove trailing whitespace