### PR TITLE
[StyleCop] Fix all the warnings in Spanish\Parsers

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Spanish/Parsers/AgeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Spanish/Parsers/AgeParserConfiguration.cs
@@ -4,9 +4,13 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Spanish
 {
     public class AgeParserConfiguration : SpanishNumberWithUnitParserConfiguration
     {
-        public AgeParserConfiguration() : this(new CultureInfo(Culture.Spanish)) { }
+        public AgeParserConfiguration()
+               : this(new CultureInfo(Culture.Spanish))
+        {
+        }
 
-        public AgeParserConfiguration(CultureInfo ci) : base(ci)
+        public AgeParserConfiguration(CultureInfo ci)
+               : base(ci)
         {
             this.BindDictionary(AgeExtractorConfiguration.AgeSuffixList);
         }

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Spanish/Parsers/AreaParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Spanish/Parsers/AreaParserConfiguration.cs
@@ -4,9 +4,13 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Spanish
 {
     public class AreaParserConfiguration : SpanishNumberWithUnitParserConfiguration
     {
-        public AreaParserConfiguration() : this(new CultureInfo(Culture.Spanish)) { }
+        public AreaParserConfiguration()
+               : this(new CultureInfo(Culture.Spanish))
+        {
+        }
 
-        public AreaParserConfiguration(CultureInfo ci) : base(ci)
+        public AreaParserConfiguration(CultureInfo ci)
+               : base(ci)
         {
             this.BindDictionary(AreaExtractorConfiguration.AreaSuffixList);
         }

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Spanish/Parsers/CurrencyParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Spanish/Parsers/CurrencyParserConfiguration.cs
@@ -4,9 +4,13 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Spanish
 {
     public class CurrencyParserConfiguration : SpanishNumberWithUnitParserConfiguration
     {
-        public CurrencyParserConfiguration() : this(new CultureInfo(Culture.Spanish)) { }
+        public CurrencyParserConfiguration()
+               : this(new CultureInfo(Culture.Spanish))
+        {
+        }
 
-        public CurrencyParserConfiguration(CultureInfo ci) : base(ci)
+        public CurrencyParserConfiguration(CultureInfo ci)
+               : base(ci)
         {
             this.BindDictionary(CurrencyExtractorConfiguration.CurrencySuffixList);
             this.BindDictionary(CurrencyExtractorConfiguration.CurrencyPrefixList);

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Spanish/Parsers/DimensionParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Spanish/Parsers/DimensionParserConfiguration.cs
@@ -4,9 +4,13 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Spanish
 {
     public class DimensionParserConfiguration : SpanishNumberWithUnitParserConfiguration
     {
-        public DimensionParserConfiguration() : this(new CultureInfo(Culture.Spanish)) { }
+        public DimensionParserConfiguration()
+               : this(new CultureInfo(Culture.Spanish))
+        {
+        }
 
-        public DimensionParserConfiguration(CultureInfo ci) : base(ci)
+        public DimensionParserConfiguration(CultureInfo ci)
+               : base(ci)
         {
             this.BindDictionary(DimensionExtractorConfiguration.DimensionSuffixList);
         }

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Spanish/Parsers/LengthParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Spanish/Parsers/LengthParserConfiguration.cs
@@ -4,9 +4,13 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Spanish
 {
     public class LengthParserConfiguration : SpanishNumberWithUnitParserConfiguration
     {
-        public LengthParserConfiguration() : this(new CultureInfo(Culture.Spanish)) { }
+        public LengthParserConfiguration()
+               : this(new CultureInfo(Culture.Spanish))
+        {
+        }
 
-        public LengthParserConfiguration(CultureInfo ci) : base(ci)
+        public LengthParserConfiguration(CultureInfo ci)
+               : base(ci)
         {
             this.BindDictionary(LengthExtractorConfiguration.LengthSuffixList);
         }

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Spanish/Parsers/SpanishNumberWithUnitParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Spanish/Parsers/SpanishNumberWithUnitParserConfiguration.cs
@@ -8,7 +8,8 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Spanish
 {
     public class SpanishNumberWithUnitParserConfiguration : BaseNumberWithUnitParserConfiguration
     {
-        public SpanishNumberWithUnitParserConfiguration(CultureInfo ci) : base(ci)
+        public SpanishNumberWithUnitParserConfiguration(CultureInfo ci)
+               : base(ci)
         {
             this.InternalNumberExtractor = NumberExtractor.GetInstance();
             this.InternalNumberParser = AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Number, new SpanishNumberParserConfiguration());

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Spanish/Parsers/SpeedParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Spanish/Parsers/SpeedParserConfiguration.cs
@@ -4,9 +4,13 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Spanish
 {
     public class SpeedParserConfiguration : SpanishNumberWithUnitParserConfiguration
     {
-        public SpeedParserConfiguration() : this(new CultureInfo(Culture.Spanish)) { }
+        public SpeedParserConfiguration()
+               : this(new CultureInfo(Culture.Spanish))
+        {
+        }
 
-        public SpeedParserConfiguration(CultureInfo ci) : base(ci)
+        public SpeedParserConfiguration(CultureInfo ci)
+               : base(ci)
         {
             this.BindDictionary(SpeedExtractorConfiguration.SpeedSuffixList);
         }

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Spanish/Parsers/TemperatureParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Spanish/Parsers/TemperatureParserConfiguration.cs
@@ -4,9 +4,13 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Spanish
 {
     public class TemperatureParserConfiguration : SpanishNumberWithUnitParserConfiguration
     {
-        public TemperatureParserConfiguration() : this(new CultureInfo(Culture.Spanish)) { }
+        public TemperatureParserConfiguration()
+               : this(new CultureInfo(Culture.Spanish))
+        {
+        }
 
-        public TemperatureParserConfiguration(CultureInfo ci) : base(ci)
+        public TemperatureParserConfiguration(CultureInfo ci)
+               : base(ci)
         {
             this.BindDictionary(TemperatureExtractorConfiguration.TemperatureSuffixList);
         }

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Spanish/Parsers/VolumeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Spanish/Parsers/VolumeParserConfiguration.cs
@@ -4,9 +4,13 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Spanish
 {
     public class VolumeParserConfiguration : SpanishNumberWithUnitParserConfiguration
     {
-        public VolumeParserConfiguration() : this(new CultureInfo(Culture.Spanish)) { }
+        public VolumeParserConfiguration()
+               : this(new CultureInfo(Culture.Spanish))
+        {
+        }
 
-        public VolumeParserConfiguration(CultureInfo ci) : base(ci)
+        public VolumeParserConfiguration(CultureInfo ci)
+               : base(ci)
         {
             this.BindDictionary(VolumeExtractorConfiguration.VolumeSuffixList);
         }

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Spanish/Parsers/WeightParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Spanish/Parsers/WeightParserConfiguration.cs
@@ -4,9 +4,13 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Spanish
 {
     public class WeightParserConfiguration : SpanishNumberWithUnitParserConfiguration
     {
-        public WeightParserConfiguration() : this(new CultureInfo(Culture.Spanish)) { }
+        public WeightParserConfiguration()
+               : this(new CultureInfo(Culture.Spanish))
+        {
+        }
 
-        public WeightParserConfiguration(CultureInfo ci) : base(ci)
+        public WeightParserConfiguration(CultureInfo ci)
+               : base(ci)
         {
             this.BindDictionary(WeightExtractorConfiguration.WeightSuffixList);
         }


### PR DESCRIPTION
Warnings:
- SA1502: Element should not be on a single line - Move curly braces to different lines
- SA1201: A field should not follow a property - Reorder fields and properties
- SA1128: Put constructor initializers on their own line - Move constructor initializer to a different line
