### PR TITLE
[StyleCop] Fix warnings TextNumber Bases files

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.Number/Extractors/BaseNumberExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Extractors/BaseNumberExtractor.cs
@@ -9,20 +9,20 @@ namespace Microsoft.Recognizers.Text.Number
 {
     public abstract class BaseNumberExtractor : IExtractor
     {
+        public static readonly Regex CurrencyRegex =
+            new Regex(BaseNumbers.CurrencyRegex, RegexOptions.Singleline);
+
         internal abstract ImmutableDictionary<Regex, TypeTag> Regexes { get; }
 
         protected virtual ImmutableDictionary<Regex, Regex> AmbiguityFiltersDict { get; } = null;
 
-        protected virtual string ExtractType { get; } = "";
+        protected virtual string ExtractType { get; } = string.Empty;
 
         protected virtual NumberOptions Options { get; } = NumberOptions.None;
 
         protected virtual Regex NegativeNumberTermsRegex { get; } = null;
 
         protected virtual Regex AmbiguousFractionConnectorsRegex { get; } = null;
-
-        public static readonly Regex CurrencyRegex = 
-            new Regex(BaseNumbers.CurrencyRegex, RegexOptions.Singleline);
 
         public virtual List<ExtractResult> Extract(string source)
         {
@@ -90,7 +90,7 @@ namespace Microsoft.Recognizers.Text.Number
                                 Length = length,
                                 Text = substr,
                                 Type = ExtractType,
-                                Data = type
+                                Data = type,
                             };
 
                             result.Add(er);
@@ -108,9 +108,20 @@ namespace Microsoft.Recognizers.Text.Number
             return result;
         }
 
+        protected Regex GenerateLongFormatNumberRegexes(LongFormatType type, string placeholder = BaseNumbers.PlaceHolderDefault)
+        {
+            var thousandsMark = Regex.Escape(type.ThousandsMark.ToString());
+            var decimalsMark = Regex.Escape(type.DecimalsMark.ToString());
+
+            var regexDefinition = type.DecimalsMark.Equals('\0') ?
+                BaseNumbers.IntegerRegexDefinition(placeholder, thousandsMark) :
+                BaseNumbers.DoubleRegexDefinition(placeholder, thousandsMark, decimalsMark);
+
+            return new Regex(regexDefinition, RegexOptions.Singleline);
+        }
+
         private List<ExtractResult> FilterAmbiguity(List<ExtractResult> ers, string text)
         {
-
             if (AmbiguityFiltersDict != null)
             {
                 foreach (var regex in AmbiguityFiltersDict)
@@ -125,81 +136,5 @@ namespace Microsoft.Recognizers.Text.Number
 
             return ers;
         }
-
-        protected Regex GenerateLongFormatNumberRegexes(LongFormatType type, string placeholder = BaseNumbers.PlaceHolderDefault)
-        {
-            var thousandsMark = Regex.Escape(type.ThousandsMark.ToString());
-            var decimalsMark = Regex.Escape(type.DecimalsMark.ToString());
-
-            var regexDefinition = type.DecimalsMark.Equals('\0') ?
-                BaseNumbers.IntegerRegexDefinition(placeholder, thousandsMark) :
-                BaseNumbers.DoubleRegexDefinition(placeholder, thousandsMark, decimalsMark);
-
-            return new Regex(regexDefinition, RegexOptions.Singleline);
-        }
-    }
-
-    public enum NumberMode
-    {
-        //Default is for unit and datetime
-        Default,
-        //Add 67.5 billion & million support.
-        Currency,
-        //Don't extract number from cases like 16ml
-        PureNumber
-    }
-
-    public class LongFormatType
-    {
-        // Reference Value : 1234567.89
-
-        // 1,234,567
-        public static LongFormatType IntegerNumComma = new LongFormatType(',', '\0');
-
-        // 1.234.567
-        public static LongFormatType IntegerNumDot = new LongFormatType('.', '\0');
-
-        // 1 234 567
-        public static LongFormatType IntegerNumBlank = new LongFormatType(' ', '\0');
-
-        // 1 234 567
-        public static LongFormatType IntegerNumNoBreakSpace = new LongFormatType(Constants.NO_BREAK_SPACE, '\0');
-
-        // 1'234'567
-        public static LongFormatType IntegerNumQuote = new LongFormatType('\'', '\0');
-
-        // 1,234,567.89
-        public static LongFormatType DoubleNumCommaDot = new LongFormatType(',', '.');
-
-        // 1,234,567·89
-        public static LongFormatType DoubleNumCommaCdot = new LongFormatType(',', '·');
-
-        // 1 234 567,89
-        public static LongFormatType DoubleNumBlankComma = new LongFormatType(' ', ',');
-
-        // 1 234 567,89
-        public static LongFormatType DoubleNumNoBreakSpaceComma = new LongFormatType(Constants.NO_BREAK_SPACE, ',');
-
-        // 1 234 567.89
-        public static LongFormatType DoubleNumBlankDot = new LongFormatType(' ', '.');
-
-        // 1 234 567.89
-        public static LongFormatType DoubleNumNoBreakSpaceDot = new LongFormatType(Constants.NO_BREAK_SPACE, '.');
-
-        // 1.234.567,89
-        public static LongFormatType DoubleNumDotComma = new LongFormatType('.', ',');
-
-        // 1'234'567,89
-        public static LongFormatType DoubleNumQuoteComma = new LongFormatType('\'', ',');
-
-        private LongFormatType(char thousandsMark, char decimalsMark)
-        {
-            ThousandsMark = thousandsMark;
-            DecimalsMark = decimalsMark;
-        }
-
-        public char DecimalsMark { get; }
-
-        public char ThousandsMark { get; }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.Number/Extractors/BaseNumberRangeExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Extractors/BaseNumberRangeExtractor.cs
@@ -13,14 +13,6 @@ namespace Microsoft.Recognizers.Text.Number
 
         private readonly BaseNumberParser numberParser;
 
-        protected virtual NumberOptions Options { get; } = NumberOptions.None;
-
-        internal abstract System.Collections.Immutable.ImmutableDictionary<Regex, string> Regexes { get; }
-
-        internal abstract Regex AmbiguousFractionConnectorsRegex { get; }
-
-        protected virtual string ExtractType { get; } = "";
-
         public BaseNumberRangeExtractor(BaseNumberExtractor numberExtractor, BaseNumberExtractor ordinalExtractor, BaseNumberParser numberParser, NumberOptions options = NumberOptions.None)
         {
             this.numberExtractor = numberExtractor;
@@ -28,6 +20,14 @@ namespace Microsoft.Recognizers.Text.Number
             this.numberParser = numberParser;
             Options = options;
         }
+
+        internal abstract System.Collections.Immutable.ImmutableDictionary<Regex, string> Regexes { get; }
+
+        internal abstract Regex AmbiguousFractionConnectorsRegex { get; }
+
+        protected virtual NumberOptions Options { get; } = NumberOptions.None;
+
+        protected virtual string ExtractType { get; } = string.Empty;
 
         public virtual List<ExtractResult> Extract(string source)
         {
@@ -80,7 +80,7 @@ namespace Microsoft.Recognizers.Text.Number
                                 Length = length,
                                 Text = substr,
                                 Type = ExtractType,
-                                Data = matchSource.ContainsKey(srcMatch) ? matchSource[srcMatch] : null
+                                Data = matchSource.ContainsKey(srcMatch) ? matchSource[srcMatch] : null,
                             };
                             results.Add(er);
                         }
@@ -293,27 +293,5 @@ namespace Microsoft.Recognizers.Text.Number
 
             return ers;
         }
-    }
-
-    public static class NumberRangeConstants
-    {
-        // Number range regex type
-        public const string TWONUM = "TwoNum";
-        public const string TWONUMBETWEEN = "TwoNumBetween";
-        public const string TWONUMTILL = "TwoNumTill";
-        public const string TWONUMCLOSED = "TwoNumClosed";
-        public const string MORE = "More";
-        public const string LESS = "Less";
-        public const string EQUAL = "Equal";
-
-        // Brackets and comma for number range resolution value
-        public const char LEFT_OPEN = '(';
-        public const char RIGHT_OPEN = ')';
-        public const char LEFT_CLOSED = '[';
-        public const char RIGHT_CLOSED = ']';
-        public const char INTERVAL_SEPARATOR = ',';
-
-        // Invalid number
-        public const int INVALID_NUM = -1;
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.Number/Extractors/LongFormatType.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Extractors/LongFormatType.cs
@@ -1,0 +1,56 @@
+﻿namespace Microsoft.Recognizers.Text.Number
+{
+    public class LongFormatType
+    {
+        private LongFormatType(char thousandsMark, char decimalsMark)
+        {
+            ThousandsMark = thousandsMark;
+            DecimalsMark = decimalsMark;
+        }
+
+        // Reference Value : 1234567.89
+
+        // 1,234,567
+        public static LongFormatType IntegerNumComma { get; set; } = new LongFormatType(',', '\0');
+
+        // 1.234.567
+        public static LongFormatType IntegerNumDot { get; set; } = new LongFormatType('.', '\0');
+
+        // 1 234 567
+        public static LongFormatType IntegerNumBlank { get; set; } = new LongFormatType(' ', '\0');
+
+        // 1 234 567
+        public static LongFormatType IntegerNumNoBreakSpace { get; set; } = new LongFormatType(Constants.NO_BREAK_SPACE, '\0');
+
+        // 1'234'567
+        public static LongFormatType IntegerNumQuote { get; set; } = new LongFormatType('\'', '\0');
+
+        // 1,234,567.89
+        public static LongFormatType DoubleNumCommaDot { get; set; } = new LongFormatType(',', '.');
+
+        // 1,234,567·89
+        public static LongFormatType DoubleNumCommaCdot { get; set; } = new LongFormatType(',', '·');
+
+        // 1 234 567,89
+        public static LongFormatType DoubleNumBlankComma { get; set; } = new LongFormatType(' ', ',');
+
+        // 1 234 567,89
+        public static LongFormatType DoubleNumNoBreakSpaceComma { get; set; } = new LongFormatType(Constants.NO_BREAK_SPACE, ',');
+
+        // 1 234 567.89
+        public static LongFormatType DoubleNumBlankDot { get; set; } = new LongFormatType(' ', '.');
+
+        // 1 234 567.89
+        public static LongFormatType DoubleNumNoBreakSpaceDot { get; set; } = new LongFormatType(Constants.NO_BREAK_SPACE, '.');
+
+        // 1.234.567,89
+        public static LongFormatType DoubleNumDotComma { get; set; } = new LongFormatType('.', ',');
+
+        // 1'234'567,89
+        public static LongFormatType DoubleNumQuoteComma { get; set; } = new LongFormatType('\'', ',');
+
+        public char DecimalsMark { get; }
+
+        public char ThousandsMark { get; }
+    }
+}

--- a/.NET/Microsoft.Recognizers.Text.Number/Extractors/NumberMode.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Extractors/NumberMode.cs
@@ -1,0 +1,20 @@
+﻿namespace Microsoft.Recognizers.Text.Number
+{
+    public enum NumberMode
+    {
+        /// <summary>
+        /// Default is for unit and datetime
+        /// </summary>
+        Default,
+
+        /// <summary>
+        /// Add 67.5 billion & million support.
+        /// </summary>
+        Currency,
+
+        /// <summary>
+        /// Don't extract number from cases like 16ml
+        /// </summary>
+        PureNumber,
+    }
+}

--- a/.NET/Microsoft.Recognizers.Text.Number/Extractors/NumberRangeConstants.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Extractors/NumberRangeConstants.cs
@@ -1,0 +1,27 @@
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.Recognizers.Text.Number
+{
+    [SuppressMessage("StyleCop.CSharp.NamingRules", "SA1310: CSharp.Naming : Field names must not contain underscores.", Justification = "Constant names are written in upper case so they can be readily distinguished from camel case variable names.")]
+    public static class NumberRangeConstants
+    {
+        // Number range regex type
+        public const string TWONUM = "TwoNum";
+        public const string TWONUMBETWEEN = "TwoNumBetween";
+        public const string TWONUMTILL = "TwoNumTill";
+        public const string TWONUMCLOSED = "TwoNumClosed";
+        public const string MORE = "More";
+        public const string LESS = "Less";
+        public const string EQUAL = "Equal";
+
+        // Brackets and comma for number range resolution value
+        public const char LEFT_OPEN = '(';
+        public const char RIGHT_OPEN = ')';
+        public const char LEFT_CLOSED = '[';
+        public const char RIGHT_CLOSED = ']';
+        public const char INTERVAL_SEPARATOR = ',';
+
+        // Invalid number
+        public const int INVALID_NUM = -1;
+    }
+}


### PR DESCRIPTION
-Reordered properties and methods
-Added spaces and trailing commas when needed
-Fixed spacing
-Extract LongFormatType class
-Extract type enum to NumberMode file
-Extract NumberRangeContants
-Suppress StyleCop warning in constants variable names