### PR TITLE
[StyleCop] Fix all  warnings in Number/Japanese Extractor and Parser files

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.Number/Japanese/Extractors/CardinalExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Japanese/Extractors/CardinalExtractor.cs
@@ -5,10 +5,6 @@ namespace Microsoft.Recognizers.Text.Number.Japanese
 {
     public class CardinalExtractor : BaseNumberExtractor
     {
-        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
-
-        protected sealed override string ExtractType { get; } = Constants.SYS_NUM_CARDINAL;
-
         // CardinalExtractor = Int + Double
         public CardinalExtractor(JapaneseNumberExtractorMode mode = JapaneseNumberExtractorMode.Default)
         {
@@ -22,5 +18,9 @@ namespace Microsoft.Recognizers.Text.Number.Japanese
 
             Regexes = builder.ToImmutable();
         }
+
+        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
+
+        protected sealed override string ExtractType { get; } = Constants.SYS_NUM_CARDINAL;
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.Number/Japanese/Extractors/DoubleExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Japanese/Extractors/DoubleExtractor.cs
@@ -8,51 +8,51 @@ namespace Microsoft.Recognizers.Text.Number.Japanese
 {
     public class DoubleExtractor : BaseNumberExtractor
     {
-        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
-
-        protected sealed override string ExtractType { get; } = Constants.SYS_NUM_DOUBLE;
-
         public DoubleExtractor()
         {
             var regexes = new Dictionary<Regex, TypeTag>
             {
                 {
-                    new Regex(NumbersDefinitions.DoubleSpecialsChars, RegexOptions.Singleline)
-                    , RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.NUMBER_SUFFIX)
+                    new Regex(NumbersDefinitions.DoubleSpecialsChars, RegexOptions.Singleline),
+                    RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
                     // (-)2.5, can avoid cases like ip address xx.xx.xx.xx
-                    new Regex(NumbersDefinitions.DoubleSpecialsCharsWithNegatives, RegexOptions.Singleline)
-                    , RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.NUMBER_SUFFIX)
+                    new Regex(NumbersDefinitions.DoubleSpecialsCharsWithNegatives, RegexOptions.Singleline),
+                    RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    //(-).2 
-                    new Regex(NumbersDefinitions.SimpleDoubleSpecialsChars, RegexOptions.Singleline)
-                    , RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.NUMBER_SUFFIX)
+                    // (-).2
+                    new Regex(NumbersDefinitions.SimpleDoubleSpecialsChars, RegexOptions.Singleline),
+                    RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
                     // 1.0 K
-                    new Regex(NumbersDefinitions.DoubleWithMultiplierRegex, RegexOptions.Singleline)
-                    , RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.NUMBER_SUFFIX)
+                    new Regex(NumbersDefinitions.DoubleWithMultiplierRegex, RegexOptions.Singleline),
+                    RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    //１５.２万
-                    new Regex(NumbersDefinitions.DoubleWithThousandsRegex, RegexOptions.Singleline)
-                    , RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.JAPANESE)
+                    // １５.２万
+                    new Regex(NumbersDefinitions.DoubleWithThousandsRegex, RegexOptions.Singleline),
+                    RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.JAPANESE)
                 },
                 {
                     // 2e6, 21.2e0
-                    new Regex(NumbersDefinitions.DoubleExponentialNotationRegex, RegexOptions.Singleline)
-                    , RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.POWER_SUFFIX)
+                    new Regex(NumbersDefinitions.DoubleExponentialNotationRegex, RegexOptions.Singleline),
+                    RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.POWER_SUFFIX)
                 },
                 {
-                    //2^5
-                    new Regex(NumbersDefinitions.DoubleScientificNotationRegex, RegexOptions.Singleline)
-                    , RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.POWER_SUFFIX)
-                }
+                    // 2^5
+                    new Regex(NumbersDefinitions.DoubleScientificNotationRegex, RegexOptions.Singleline),
+                    RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.POWER_SUFFIX)
+                },
             };
 
             Regexes = regexes.ToImmutableDictionary();
         }
+
+        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
+
+        protected sealed override string ExtractType { get; } = Constants.SYS_NUM_DOUBLE;
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.Number/Japanese/Extractors/FractionExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Japanese/Extractors/FractionExtractor.cs
@@ -8,32 +8,32 @@ namespace Microsoft.Recognizers.Text.Number.Japanese
 {
     public class FractionExtractor : BaseNumberExtractor
     {
-        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
-
-        protected sealed override string ExtractType { get; } = Constants.SYS_NUM_FRACTION;
-
         public FractionExtractor()
         {
             var regexes = new Dictionary<Regex, TypeTag>
             {
                 {
                     // -4 5/2,       ４ ６／３
-                    new Regex(NumbersDefinitions.FractionNotationSpecialsCharsRegex, RegexOptions.Singleline)
-                    , RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.NUMBER_SUFFIX)
+                    new Regex(NumbersDefinitions.FractionNotationSpecialsCharsRegex, RegexOptions.Singleline),
+                    RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    // 8/3 
-                    new Regex(NumbersDefinitions.FractionNotationRegex, RegexOptions.Singleline)
-                    , RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.NUMBER_SUFFIX)
+                    // 8/3
+                    new Regex(NumbersDefinitions.FractionNotationRegex, RegexOptions.Singleline),
+                    RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    //五分の二   七分の三
-                    new Regex(NumbersDefinitions.AllFractionNumber, RegexOptions.Singleline)
-                    , RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.JAPANESE)
-                }
+                    // 五分の二   七分の三
+                    new Regex(NumbersDefinitions.AllFractionNumber, RegexOptions.Singleline),
+                    RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.JAPANESE)
+                },
             };
 
             Regexes = regexes.ToImmutableDictionary();
         }
+
+        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
+
+        protected sealed override string ExtractType { get; } = Constants.SYS_NUM_FRACTION;
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.Number/Japanese/Extractors/IntegerExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Japanese/Extractors/IntegerExtractor.cs
@@ -8,10 +8,6 @@ namespace Microsoft.Recognizers.Text.Number.Japanese
 {
     public class IntegerExtractor : BaseNumberExtractor
     {
-        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
-
-        protected sealed override string ExtractType { get; } = Constants.SYS_NUM_INTEGER;
-
         public IntegerExtractor(JapaneseNumberExtractorMode mode = JapaneseNumberExtractorMode.Default)
         {
             var regexes = new Dictionary<Regex, TypeTag>
@@ -22,45 +18,51 @@ namespace Microsoft.Recognizers.Text.Number.Japanese
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    //15k,  16 G
+                    // 15k,  16 G
                     new Regex(NumbersDefinitions.NumbersSpecialsCharsWithSuffix, RegexOptions.Singleline),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    //1,234,  ２，３３２，１１１
+                    // 1,234,  ２，３３２，１１１
                     new Regex(NumbersDefinitions.DottedNumbersSpecialsChar, RegexOptions.Singleline),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    //半百  半ダース
+                    // 半百  半ダース
                     new Regex(NumbersDefinitions.NumbersWithHalfDozen, RegexOptions.Singleline),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.JAPANESE)
                 },
                 {
-                    //一ダース  五十ダース
+                    // 一ダース  五十ダース
                     new Regex(NumbersDefinitions.NumbersWithDozen, RegexOptions.Singleline),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.JAPANESE)
-                }
+                },
             };
 
             switch (mode)
             {
                 case JapaneseNumberExtractorMode.Default:
-                    // 一百五十五, 负一亿三百二十二. 
+                    // 一百五十五, 负一亿三百二十二.
                     // Uses an allow list to avoid extracting "西九条" from "九"
-                    regexes.Add(new Regex(NumbersDefinitions.NumbersWithAllowListRegex, RegexOptions.Singleline),
-                    RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.JAPANESE));
+                    regexes.Add(
+                        new Regex(NumbersDefinitions.NumbersWithAllowListRegex, RegexOptions.Singleline),
+                        RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.JAPANESE));
                     break;
 
                 case JapaneseNumberExtractorMode.ExtractAll:
                     // 一百五十五, 负一亿三百二十二, "西九条" from "九"
                     // Uses no allow lists and extracts all potential integers (useful in Units, for example).
-                    regexes.Add(new Regex(NumbersDefinitions.NumbersAggressiveRegex, RegexOptions.Singleline),
-                    RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.JAPANESE));
+                    regexes.Add(
+                        new Regex(NumbersDefinitions.NumbersAggressiveRegex, RegexOptions.Singleline),
+                        RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.JAPANESE));
                     break;
             }
 
             Regexes = regexes.ToImmutableDictionary();
         }
+
+        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
+
+        protected sealed override string ExtractType { get; } = Constants.SYS_NUM_INTEGER;
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.Number/Japanese/Extractors/NumberExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Japanese/Extractors/NumberExtractor.cs
@@ -3,12 +3,25 @@ using System.Text.RegularExpressions;
 
 namespace Microsoft.Recognizers.Text.Number.Japanese
 {
+    // These modes can be applied to JapaneseNumberExtractor.
+    // The default more urilizes an allow list to avoid extracting numbers in ambiguous/undesired combinations of Japanese ideograms.
+    // --> such as "西九条" is a place name in Japanese, should not be extracted.
+    // ExtractAll mode is to be used in cases where extraction should be more aggressive (e.g. in Units extraction).
+    public enum JapaneseNumberExtractorMode
+    {
+        /// <summary>
+        /// Number extraction with an allow list that filters what numbers to extract.
+        /// </summary>
+        Default,
+
+        /// <summary>
+        /// Extract all number-related terms aggressively.
+        /// </summary>
+        ExtractAll,
+    }
+
     public class NumberExtractor : BaseNumberExtractor
     {
-        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
-
-        protected sealed override string ExtractType { get; } = Constants.SYS_NUM;
-
         public NumberExtractor(JapaneseNumberExtractorMode mode = JapaneseNumberExtractorMode.Default)
         {
             var builder = ImmutableDictionary.CreateBuilder<Regex, TypeTag>();
@@ -23,15 +36,9 @@ namespace Microsoft.Recognizers.Text.Number.Japanese
 
             Regexes = builder.ToImmutable();
         }
-    }
 
-    // These modes can be applied to JapaneseNumberExtractor.
-    // The default more urilizes an allow list to avoid extracting numbers in ambiguous/undesired combinations of Japanese ideograms.
-    // --> such as "西九条" is a place name in Japanese, should not be extracted.
-    // ExtractAll mode is to be used in cases where extraction should be more aggressive (e.g. in Units extraction).
-    public enum JapaneseNumberExtractorMode
-    {
-        Default, // Number extraction with an allow list that filters what numbers to extract.
-        ExtractAll, // Extract all number-related terms aggressively.
+        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
+
+        protected sealed override string ExtractType { get; } = Constants.SYS_NUM;
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.Number/Japanese/Extractors/NumberRangeExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Japanese/Extractors/NumberRangeExtractor.cs
@@ -1,19 +1,14 @@
-﻿using Microsoft.Recognizers.Definitions.Japanese;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Text.RegularExpressions;
+using Microsoft.Recognizers.Definitions.Japanese;
 
 namespace Microsoft.Recognizers.Text.Number.Japanese
 {
     public class NumberRangeExtractor : BaseNumberRangeExtractor
     {
-        internal sealed override ImmutableDictionary<Regex, string> Regexes { get; }
-
-        internal sealed override Regex AmbiguousFractionConnectorsRegex { get; }
-
-        protected sealed override string ExtractType { get; } = Constants.SYS_NUMRANGE;
-
-        public NumberRangeExtractor(NumberOptions options = NumberOptions.None) : base(new NumberExtractor(), new OrdinalExtractor(), new BaseCJKNumberParser(new JapaneseNumberParserConfiguration()), options: options)
+        public NumberRangeExtractor(NumberOptions options = NumberOptions.None)
+            : base(new NumberExtractor(), new OrdinalExtractor(), new BaseCJKNumberParser(new JapaneseNumberParserConfiguration()), options: options)
         {
             var regexes = new Dictionary<Regex, string>
             {
@@ -71,13 +66,19 @@ namespace Microsoft.Recognizers.Text.Number.Japanese
                     // イコール...　｜　...等しい|
                     new Regex(NumbersDefinitions.OneNumberRangeEqualRegex, RegexOptions.Singleline),
                     NumberRangeConstants.EQUAL
-                }
+                },
             };
 
             Regexes = regexes.ToImmutableDictionary();
 
-            AmbiguousFractionConnectorsRegex = 
+            AmbiguousFractionConnectorsRegex =
                 new Regex(NumbersDefinitions.AmbiguousFractionConnectorsRegex, RegexOptions.Singleline);
         }
+
+        internal sealed override ImmutableDictionary<Regex, string> Regexes { get; }
+
+        internal sealed override Regex AmbiguousFractionConnectorsRegex { get; }
+
+        protected sealed override string ExtractType { get; } = Constants.SYS_NUMRANGE;
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.Number/Japanese/Extractors/OrdinalExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Japanese/Extractors/OrdinalExtractor.cs
@@ -8,32 +8,32 @@ namespace Microsoft.Recognizers.Text.Number.Japanese
 {
     public class OrdinalExtractor : BaseNumberExtractor
     {
-        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
-
-        protected sealed override string ExtractType { get; } = Constants.SYS_NUM_ORDINAL;
-
         public OrdinalExtractor()
         {
             var regexes = new Dictionary<Regex, TypeTag>
             {
                 {
-                    //だい一百五十四
-                    new Regex(NumbersDefinitions.OrdinalRegex, RegexOptions.Singleline)
-                    , RegexTagGenerator.GenerateRegexTag(Constants.ORDINAL_PREFIX, Constants.JAPANESE)
+                    // だい一百五十四
+                    new Regex(NumbersDefinitions.OrdinalRegex, RegexOptions.Singleline),
+                    RegexTagGenerator.GenerateRegexTag(Constants.ORDINAL_PREFIX, Constants.JAPANESE)
                 },
                 {
-                    //だい２５６５
-                    new Regex(NumbersDefinitions.OrdinalNumbersRegex, RegexOptions.Singleline)
-                    , RegexTagGenerator.GenerateRegexTag(Constants.ORDINAL_PREFIX, Constants.JAPANESE)
+                    // だい２５６５
+                    new Regex(NumbersDefinitions.OrdinalNumbersRegex, RegexOptions.Singleline),
+                    RegexTagGenerator.GenerateRegexTag(Constants.ORDINAL_PREFIX, Constants.JAPANESE)
                 },
                 {
-                    //2折 ２.５折
-                    new Regex(NumbersDefinitions.NumbersFoldsPercentageRegex, RegexOptions.Singleline)
-                    , RegexTagGenerator.GenerateRegexTag(Constants.PERCENT_PREFIX, Constants.SPECIAL_SUFFIX)
-                }
+                    // 2折 ２.５折
+                    new Regex(NumbersDefinitions.NumbersFoldsPercentageRegex, RegexOptions.Singleline),
+                    RegexTagGenerator.GenerateRegexTag(Constants.PERCENT_PREFIX, Constants.SPECIAL_SUFFIX)
+                },
             };
 
             Regexes = regexes.ToImmutableDictionary();
         }
+
+        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
+
+        protected sealed override string ExtractType { get; } = Constants.SYS_NUM_ORDINAL;
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.Number/Japanese/Extractors/PercentageExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Japanese/Extractors/PercentageExtractor.cs
@@ -8,10 +8,6 @@ namespace Microsoft.Recognizers.Text.Number.Japanese
 {
     public class PercentageExtractor : BaseNumberExtractor
     {
-        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
-
-        protected sealed override string ExtractType { get; } = Constants.SYS_NUM_PERCENTAGE;
-
         public PercentageExtractor()
         {
             var regexes = new Dictionary<Regex, TypeTag>
@@ -35,10 +31,9 @@ namespace Microsoft.Recognizers.Text.Number.Japanese
                     // 3.2 k パーセント
                     new Regex(NumbersDefinitions.NumbersPercentageWithMultiplierRegex, RegexOptions.Singleline),
                     RegexTagGenerator.GenerateRegexTag(Constants.PERCENT_PREFIX, Constants.NUMBER_SUFFIX)
-                }
-                ,
+                },
                 {
-                    // 15kパーセント 
+                    // 15kパーセント
                     new Regex(NumbersDefinitions.SimpleNumbersPercentageWithMultiplierRegex, RegexOptions.Singleline),
                     RegexTagGenerator.GenerateRegexTag(Constants.PERCENT_PREFIX, Constants.NUMBER_SUFFIX)
                 },
@@ -81,10 +76,14 @@ namespace Microsoft.Recognizers.Text.Number.Japanese
                     // @TODO Example missing
                     new Regex(NumbersDefinitions.SpecialsFoldsPercentageRegex, RegexOptions.Singleline),
                     RegexTagGenerator.GenerateRegexTag(Constants.PERCENT_PREFIX, Constants.SPECIAL_SUFFIX)
-                }
+                },
             };
 
             Regexes = regexes.ToImmutableDictionary();
         }
+
+        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
+
+        protected sealed override string ExtractType { get; } = Constants.SYS_NUM_PERCENTAGE;
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.Number/Japanese/Parsers/JapaneseNumberParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Japanese/Parsers/JapaneseNumberParserConfiguration.cs
@@ -10,7 +10,8 @@ namespace Microsoft.Recognizers.Text.Number.Japanese
 {
     public class JapaneseNumberParserConfiguration : INumberParserConfiguration, ICJKNumberParserConfiguration
     {
-        public JapaneseNumberParserConfiguration() : this(new CultureInfo(Culture.Japanese))
+        public JapaneseNumberParserConfiguration()
+            : this(new CultureInfo(Culture.Japanese))
         {
         }
 

--- a/.NET/Microsoft.Recognizers.Text.Number/Japanese/Parsers/JapaneseNumberRangeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Japanese/Parsers/JapaneseNumberRangeParserConfiguration.cs
@@ -1,11 +1,31 @@
-﻿using Microsoft.Recognizers.Definitions.Japanese;
-using System.Globalization;
+﻿using System.Globalization;
 using System.Text.RegularExpressions;
+using Microsoft.Recognizers.Definitions.Japanese;
 
 namespace Microsoft.Recognizers.Text.Number.Japanese
 {
     public class JapaneseNumberRangeParserConfiguration : INumberRangeParserConfiguration
     {
+        public JapaneseNumberRangeParserConfiguration()
+            : this(new CultureInfo(Culture.Japanese))
+        {
+        }
+
+        public JapaneseNumberRangeParserConfiguration(CultureInfo ci)
+        {
+            CultureInfo = ci;
+
+            NumberExtractor = new NumberExtractor();
+            OrdinalExtractor = new OrdinalExtractor();
+            NumberParser = new BaseCJKNumberParser(new JapaneseNumberParserConfiguration());
+            MoreOrEqual = new Regex(NumbersDefinitions.MoreOrEqual, RegexOptions.Singleline);
+            LessOrEqual = new Regex(NumbersDefinitions.LessOrEqual, RegexOptions.Singleline);
+            MoreOrEqualSuffix = new Regex(NumbersDefinitions.MoreOrEqualSuffix, RegexOptions.Singleline);
+            LessOrEqualSuffix = new Regex(NumbersDefinitions.LessOrEqualSuffix, RegexOptions.Singleline);
+            MoreOrEqualSeparate = new Regex(NumbersDefinitions.OneNumberRangeMoreSeparateRegex, RegexOptions.Singleline);
+            LessOrEqualSeparate = new Regex(NumbersDefinitions.OneNumberRangeLessSeparateRegex, RegexOptions.Singleline);
+        }
+
         public CultureInfo CultureInfo { get; private set; }
 
         public IExtractor NumberExtractor { get; private set; }
@@ -25,24 +45,5 @@ namespace Microsoft.Recognizers.Text.Number.Japanese
         public Regex MoreOrEqualSeparate { get; private set; }
 
         public Regex LessOrEqualSeparate { get; private set; }
-
-        public JapaneseNumberRangeParserConfiguration() : this(new CultureInfo(Culture.Japanese))
-        {
-        }
-
-        public JapaneseNumberRangeParserConfiguration(CultureInfo ci)
-        {
-            CultureInfo = ci;
-
-            NumberExtractor = new NumberExtractor();
-            OrdinalExtractor = new OrdinalExtractor();
-            NumberParser = new BaseCJKNumberParser(new JapaneseNumberParserConfiguration());
-            MoreOrEqual = new Regex(NumbersDefinitions.MoreOrEqual, RegexOptions.Singleline);
-            LessOrEqual = new Regex(NumbersDefinitions.LessOrEqual, RegexOptions.Singleline);
-            MoreOrEqualSuffix = new Regex(NumbersDefinitions.MoreOrEqualSuffix, RegexOptions.Singleline);
-            LessOrEqualSuffix = new Regex(NumbersDefinitions.LessOrEqualSuffix, RegexOptions.Singleline);
-            MoreOrEqualSeparate = new Regex(NumbersDefinitions.OneNumberRangeMoreSeparateRegex, RegexOptions.Singleline);
-            LessOrEqualSeparate = new Regex(NumbersDefinitions.OneNumberRangeLessSeparateRegex, RegexOptions.Singleline);
-        }
     }
 }


### PR DESCRIPTION
- Fixed spaces and commas.
- Reordered methods, properties and using statements.