### PR TITLE
[StyleCop] Fix all the warnings in Number/Spanish Extractor and Parser files

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.Number/Spanish/Extractors/CardinalExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Spanish/Extractors/CardinalExtractor.cs
@@ -8,24 +8,8 @@ namespace Microsoft.Recognizers.Text.Number.Spanish
 {
     public class CardinalExtractor : BaseNumberExtractor
     {
-        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
-
-        protected sealed override string ExtractType { get; } = Constants.SYS_NUM_CARDINAL; //"Cardinal";
-
-        private static readonly ConcurrentDictionary<string, CardinalExtractor> Instances = 
+        private static readonly ConcurrentDictionary<string, CardinalExtractor> Instances =
             new ConcurrentDictionary<string, CardinalExtractor>();
-
-        public static CardinalExtractor GetInstance(string placeholder = NumbersDefinitions.PlaceHolderDefault)
-        {
-
-            if (!Instances.ContainsKey(placeholder))
-            {
-                var instance = new CardinalExtractor(placeholder);
-                Instances.TryAdd(placeholder, instance);
-            }
-
-            return Instances[placeholder];
-        }
 
         private CardinalExtractor(string placeholder = NumbersDefinitions.PlaceHolderDefault)
         {
@@ -40,6 +24,21 @@ namespace Microsoft.Recognizers.Text.Number.Spanish
             builder.AddRange(douExtract.Regexes);
 
             this.Regexes = builder.ToImmutable();
+        }
+
+        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
+
+        protected sealed override string ExtractType { get; } = Constants.SYS_NUM_CARDINAL; // "Cardinal";
+
+        public static CardinalExtractor GetInstance(string placeholder = NumbersDefinitions.PlaceHolderDefault)
+        {
+            if (!Instances.ContainsKey(placeholder))
+            {
+                var instance = new CardinalExtractor(placeholder);
+                Instances.TryAdd(placeholder, instance);
+            }
+
+            return Instances[placeholder];
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.Number/Spanish/Extractors/DoubleExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Spanish/Extractors/DoubleExtractor.cs
@@ -9,28 +9,13 @@ namespace Microsoft.Recognizers.Text.Number.Spanish
 {
     public class DoubleExtractor : BaseNumberExtractor
     {
-        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
-
-        protected sealed override string ExtractType { get; } = Constants.SYS_NUM_DOUBLE; // "Double";
-
         private static readonly ConcurrentDictionary<string, DoubleExtractor> Instances =
             new ConcurrentDictionary<string, DoubleExtractor>();
 
-        public static DoubleExtractor GetInstance(string placeholder = NumbersDefinitions.PlaceHolderDefault)
-        {
-
-            if (!Instances.ContainsKey(placeholder))
-            {
-                var instance = new DoubleExtractor(placeholder);
-                Instances.TryAdd(placeholder, instance);
-            }
-
-            return Instances[placeholder];
-        }
-
         private DoubleExtractor(string placeholder = NumbersDefinitions.PlaceHolderDefault)
         {
-            var regexes = new Dictionary<Regex, TypeTag> {
+            var regexes = new Dictionary<Regex, TypeTag>
+            {
                 {
                     new Regex(NumbersDefinitions.DoubleDecimalPointRegex(placeholder), RegexOptions.Singleline),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.NUMBER_SUFFIX)
@@ -66,10 +51,25 @@ namespace Microsoft.Recognizers.Text.Number.Spanish
                 {
                     GenerateLongFormatNumberRegexes(LongFormatType.DoubleNumNoBreakSpaceComma, placeholder),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.NUMBER_SUFFIX)
-                }
+                },
             };
 
             this.Regexes = regexes.ToImmutableDictionary();
+        }
+
+        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
+
+        protected sealed override string ExtractType { get; } = Constants.SYS_NUM_DOUBLE; // "Double";
+
+        public static DoubleExtractor GetInstance(string placeholder = NumbersDefinitions.PlaceHolderDefault)
+        {
+            if (!Instances.ContainsKey(placeholder))
+            {
+                var instance = new DoubleExtractor(placeholder);
+                Instances.TryAdd(placeholder, instance);
+            }
+
+            return Instances[placeholder];
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.Number/Spanish/Extractors/FractionExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Spanish/Extractors/FractionExtractor.cs
@@ -9,26 +9,8 @@ namespace Microsoft.Recognizers.Text.Number.Spanish
 {
     public class FractionExtractor : BaseNumberExtractor
     {
-        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
-
-        protected sealed override NumberOptions Options { get; }
-
-        protected sealed override string ExtractType { get; } = Constants.SYS_NUM_FRACTION; // "Fraction";
-
         private static readonly ConcurrentDictionary<(NumberOptions, string), FractionExtractor> Instances =
             new ConcurrentDictionary<(NumberOptions, string), FractionExtractor>();
-
-        public static FractionExtractor GetInstance(NumberOptions options = NumberOptions.None, string placeholder = "")
-        {
-            var cacheKey = (options, placeholder);
-            if (!Instances.ContainsKey(cacheKey))
-            {
-                var instance = new FractionExtractor(options);
-                Instances.TryAdd(cacheKey, instance);
-            }
-
-            return Instances[cacheKey];
-        }
 
         private FractionExtractor(NumberOptions options)
         {
@@ -59,6 +41,24 @@ namespace Microsoft.Recognizers.Text.Number.Spanish
             };
 
             this.Regexes = regexes.ToImmutableDictionary();
+        }
+
+        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
+
+        protected sealed override NumberOptions Options { get; }
+
+        protected sealed override string ExtractType { get; } = Constants.SYS_NUM_FRACTION; // "Fraction";
+
+        public static FractionExtractor GetInstance(NumberOptions options = NumberOptions.None, string placeholder = "")
+        {
+            var cacheKey = (options, placeholder);
+            if (!Instances.ContainsKey(cacheKey))
+            {
+                var instance = new FractionExtractor(options);
+                Instances.TryAdd(cacheKey, instance);
+            }
+
+            return Instances[cacheKey];
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.Number/Spanish/Extractors/IntegerExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Spanish/Extractors/IntegerExtractor.cs
@@ -9,24 +9,8 @@ namespace Microsoft.Recognizers.Text.Number.Spanish
 {
     public class IntegerExtractor : BaseNumberExtractor
     {
-        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
-
-        protected sealed override string ExtractType { get; } = Constants.SYS_NUM_INTEGER;
-
         private static readonly ConcurrentDictionary<string, IntegerExtractor> Instances =
             new ConcurrentDictionary<string, IntegerExtractor>();
-
-        public static IntegerExtractor GetInstance(string placeholder = NumbersDefinitions.PlaceHolderDefault)
-        {
-
-            if (!Instances.ContainsKey(placeholder))
-            {
-                var instance = new IntegerExtractor(placeholder);
-                Instances.TryAdd(placeholder, instance);
-            }
-
-            return Instances[placeholder];
-        }
 
         private IntegerExtractor(string placeholder = NumbersDefinitions.PlaceHolderDefault)
         {
@@ -65,12 +49,27 @@ namespace Microsoft.Recognizers.Text.Number.Spanish
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.SPANISH)
                 },
                 {
-                new Regex(NumbersDefinitions.AllIntRegexWithDozenSuffixLocks, RegexOptions.Singleline),
+                    new Regex(NumbersDefinitions.AllIntRegexWithDozenSuffixLocks, RegexOptions.Singleline),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.SPANISH)
-                }
+                },
             };
 
             this.Regexes = regexes.ToImmutableDictionary();
+        }
+
+        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
+
+        protected sealed override string ExtractType { get; } = Constants.SYS_NUM_INTEGER;
+
+        public static IntegerExtractor GetInstance(string placeholder = NumbersDefinitions.PlaceHolderDefault)
+        {
+            if (!Instances.ContainsKey(placeholder))
+            {
+                var instance = new IntegerExtractor(placeholder);
+                Instances.TryAdd(placeholder, instance);
+            }
+
+            return Instances[placeholder];
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.Number/Spanish/Extractors/NumberExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Spanish/Extractors/NumberExtractor.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Recognizers.Text.Number.Spanish
 
         private NumberExtractor(NumberMode mode = NumberMode.Default, NumberOptions options = NumberOptions.None)
         {
+            NegativeNumberTermsRegex = new Regex(NumbersDefinitions.NegativeNumberTermsRegex + '$', RegexOptions.Singleline);
+
             Options = options;
 
             var builder = ImmutableDictionary.CreateBuilder<Regex, TypeTag>();
@@ -51,6 +53,8 @@ namespace Microsoft.Recognizers.Text.Number.Spanish
 
         // "Number"
         protected sealed override string ExtractType { get; } = Constants.SYS_NUM;
+
+        protected sealed override Regex NegativeNumberTermsRegex { get; }
 
         public static NumberExtractor GetInstance(NumberMode mode = NumberMode.Default, NumberOptions options = NumberOptions.None)
         {

--- a/.NET/Microsoft.Recognizers.Text.Number/Spanish/Extractors/NumberExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Spanish/Extractors/NumberExtractor.cs
@@ -8,30 +8,11 @@ namespace Microsoft.Recognizers.Text.Number.Spanish
 {
     public class NumberExtractor : BaseNumberExtractor
     {
-        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
-
-        protected sealed override NumberOptions Options { get; }
-
-        protected sealed override string ExtractType { get; } = Constants.SYS_NUM; // "Number";
-
         private static readonly ConcurrentDictionary<(NumberMode, NumberOptions), NumberExtractor> Instances =
             new ConcurrentDictionary<(NumberMode, NumberOptions), NumberExtractor>();
 
-        public static NumberExtractor GetInstance(NumberMode mode = NumberMode.Default, NumberOptions options = NumberOptions.None)
-        {
-            var cacheKey = (mode, options);
-            if (!Instances.ContainsKey(cacheKey))
-            {
-                var instance = new NumberExtractor(mode, options);
-                Instances.TryAdd(cacheKey, instance);
-            }
-
-            return Instances[cacheKey];
-        }
-
         private NumberExtractor(NumberMode mode = NumberMode.Default, NumberOptions options = NumberOptions.None)
         {
-
             Options = options;
 
             var builder = ImmutableDictionary.CreateBuilder<Regex, TypeTag>();
@@ -44,8 +25,7 @@ namespace Microsoft.Recognizers.Text.Number.Spanish
                     cardExtract = CardinalExtractor.GetInstance(NumbersDefinitions.PlaceHolderPureNumber);
                     break;
                 case NumberMode.Currency:
-                    builder.Add(BaseNumberExtractor.CurrencyRegex,
-                                RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.NUMBER_SUFFIX));
+                    builder.Add(CurrencyRegex, RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.NUMBER_SUFFIX));
                     break;
                 case NumberMode.Default:
                     break;
@@ -63,6 +43,25 @@ namespace Microsoft.Recognizers.Text.Number.Spanish
             builder.AddRange(fracExtract.Regexes);
 
             Regexes = builder.ToImmutable();
+        }
+
+        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
+
+        protected sealed override NumberOptions Options { get; }
+
+        // "Number"
+        protected sealed override string ExtractType { get; } = Constants.SYS_NUM;
+
+        public static NumberExtractor GetInstance(NumberMode mode = NumberMode.Default, NumberOptions options = NumberOptions.None)
+        {
+            var cacheKey = (mode, options);
+            if (!Instances.ContainsKey(cacheKey))
+            {
+                var instance = new NumberExtractor(mode, options);
+                Instances.TryAdd(cacheKey, instance);
+            }
+
+            return Instances[cacheKey];
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.Number/Spanish/Extractors/NumberRangeExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Spanish/Extractors/NumberRangeExtractor.cs
@@ -8,15 +8,8 @@ namespace Microsoft.Recognizers.Text.Number.Spanish
 {
     public class NumberRangeExtractor : BaseNumberRangeExtractor
     {
-        internal sealed override ImmutableDictionary<Regex, string> Regexes { get; }
-
-        internal sealed override Regex AmbiguousFractionConnectorsRegex { get; }
-
-        protected sealed override string ExtractType { get; } = Constants.SYS_NUMRANGE;
-
         public NumberRangeExtractor(NumberOptions options = NumberOptions.None)
-            : base(NumberExtractor.GetInstance(), OrdinalExtractor.GetInstance(),
-                    new BaseNumberParser(new SpanishNumberParserConfiguration()), options)
+            : base(NumberExtractor.GetInstance(), OrdinalExtractor.GetInstance(), new BaseNumberParser(new SpanishNumberParserConfiguration()), options)
         {
             var regexes = new Dictionary<Regex, string>()
             {
@@ -74,7 +67,7 @@ namespace Microsoft.Recognizers.Text.Number.Spanish
                     // igual a 30 o menos, menos que 30 o igual ...
                     new Regex(NumbersDefinitions.OneNumberRangeLessSeparateRegex, RegexOptions.Singleline),
                     NumberRangeConstants.LESS
-                }
+                },
             };
 
             Regexes = regexes.ToImmutableDictionary();
@@ -82,5 +75,11 @@ namespace Microsoft.Recognizers.Text.Number.Spanish
             AmbiguousFractionConnectorsRegex =
                 new Regex(NumbersDefinitions.AmbiguousFractionConnectorsRegex, RegexOptions.Singleline);
         }
+
+        internal sealed override ImmutableDictionary<Regex, string> Regexes { get; }
+
+        internal sealed override Regex AmbiguousFractionConnectorsRegex { get; }
+
+        protected sealed override string ExtractType { get; } = Constants.SYS_NUMRANGE;
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.Number/Spanish/Extractors/OrdinalExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Spanish/Extractors/OrdinalExtractor.cs
@@ -9,24 +9,8 @@ namespace Microsoft.Recognizers.Text.Number.Spanish
 {
     public class OrdinalExtractor : BaseNumberExtractor
     {
-        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
-
-        protected sealed override string ExtractType { get; } = Constants.SYS_NUM_ORDINAL; // "Ordinal";
-
         private static readonly ConcurrentDictionary<string, OrdinalExtractor> Instances =
             new ConcurrentDictionary<string, OrdinalExtractor>();
-
-        public static OrdinalExtractor GetInstance(string placeholder = "")
-        {
-
-            if (!Instances.ContainsKey(placeholder))
-            {
-                var instance = new OrdinalExtractor();
-                Instances.TryAdd(placeholder, instance);
-            }
-
-            return Instances[placeholder];
-        }
 
         private OrdinalExtractor()
         {
@@ -39,10 +23,25 @@ namespace Microsoft.Recognizers.Text.Number.Spanish
                 {
                     new Regex(NumbersDefinitions.OrdinalNounRegex, RegexOptions.Singleline),
                     RegexTagGenerator.GenerateRegexTag(Constants.ORDINAL_PREFIX, Constants.SPANISH)
-                }
+                },
             };
 
             this.Regexes = regexes.ToImmutableDictionary();
+        }
+
+        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
+
+        protected sealed override string ExtractType { get; } = Constants.SYS_NUM_ORDINAL; // "Ordinal";
+
+        public static OrdinalExtractor GetInstance(string placeholder = "")
+        {
+            if (!Instances.ContainsKey(placeholder))
+            {
+                var instance = new OrdinalExtractor();
+                Instances.TryAdd(placeholder, instance);
+            }
+
+            return Instances[placeholder];
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.Number/Spanish/Parsers/SpanishNumberParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Spanish/Parsers/SpanishNumberParserConfiguration.cs
@@ -10,7 +10,10 @@ namespace Microsoft.Recognizers.Text.Number.Spanish
 {
     public class SpanishNumberParserConfiguration : INumberParserConfiguration
     {
-        public SpanishNumberParserConfiguration() : this(new CultureInfo(Culture.Spanish)) { }
+        public SpanishNumberParserConfiguration()
+               : this(new CultureInfo(Culture.Spanish))
+        {
+        }
 
         public SpanishNumberParserConfiguration(CultureInfo ci)
         {
@@ -35,7 +38,7 @@ namespace Microsoft.Recognizers.Text.Number.Spanish
             this.HalfADozenRegex = new Regex(NumbersDefinitions.HalfADozenRegex, RegexOptions.Singleline);
             this.DigitalNumberRegex = new Regex(NumbersDefinitions.DigitalNumberRegex, RegexOptions.Singleline);
             this.NegativeNumberSignRegex = new Regex(NumbersDefinitions.NegativeNumberSignRegex, RegexOptions.Singleline);
-            this.FractionPrepositionRegex  = new Regex(NumbersDefinitions.FractionPrepositionRegex, RegexOptions.Singleline);
+            this.FractionPrepositionRegex = new Regex(NumbersDefinitions.FractionPrepositionRegex, RegexOptions.Singleline);
         }
 
         public ImmutableDictionary<string, long> CardinalNumberMap { get; private set; }
@@ -142,6 +145,7 @@ namespace Microsoft.Recognizers.Text.Number.Spanish
                     lastGoodChar = i;
                     value = this.CardinalNumberMap[strBuilder.ToString()];
                 }
+
                 if ((i + 1) == numberStr.Length)
                 {
                     finalValue += value;
@@ -150,6 +154,7 @@ namespace Microsoft.Recognizers.Text.Number.Spanish
                     value = 0;
                 }
             }
+
             return finalValue;
         }
     }


### PR DESCRIPTION
Fixes
- Reorder properties
- Add trailing comma
- Add spacing when needed
- Remove trailing whitespace