### PR TITLE
[StyleCop] Fix all the warnings in Number/Portuguese Extractor and Parser files 

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.Number/Portuguese/Extractors/CardinalExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Portuguese/Extractors/CardinalExtractor.cs
@@ -8,24 +8,8 @@ namespace Microsoft.Recognizers.Text.Number.Portuguese
 {
     public class CardinalExtractor : BaseNumberExtractor // Same as Spanish.
     {
-        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
-
-        protected sealed override string ExtractType { get; } = Constants.SYS_NUM_CARDINAL; //"Cardinal";
-
-        private static readonly ConcurrentDictionary<string, CardinalExtractor> Instances = 
+        private static readonly ConcurrentDictionary<string, CardinalExtractor> Instances =
             new ConcurrentDictionary<string, CardinalExtractor>();
-
-        public static CardinalExtractor GetInstance(string placeholder = NumbersDefinitions.PlaceHolderDefault)
-        {
-
-            if (!Instances.ContainsKey(placeholder))
-            {
-                var instance = new CardinalExtractor(placeholder);
-                Instances.TryAdd(placeholder, instance);
-            }
-
-            return Instances[placeholder];
-        }
 
         private CardinalExtractor(string placeholder = NumbersDefinitions.PlaceHolderDefault)
         {
@@ -40,6 +24,21 @@ namespace Microsoft.Recognizers.Text.Number.Portuguese
             builder.AddRange(douExtract.Regexes);
 
             Regexes = builder.ToImmutable();
+        }
+
+        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
+
+        protected sealed override string ExtractType { get; } = Constants.SYS_NUM_CARDINAL; // "Cardinal";
+
+        public static CardinalExtractor GetInstance(string placeholder = NumbersDefinitions.PlaceHolderDefault)
+        {
+            if (!Instances.ContainsKey(placeholder))
+            {
+                var instance = new CardinalExtractor(placeholder);
+                Instances.TryAdd(placeholder, instance);
+            }
+
+            return Instances[placeholder];
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.Number/Portuguese/Extractors/DoubleExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Portuguese/Extractors/DoubleExtractor.cs
@@ -9,24 +9,8 @@ namespace Microsoft.Recognizers.Text.Number.Portuguese
 {
     public class DoubleExtractor : BaseNumberExtractor
     {
-        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
-
-        protected sealed override string ExtractType { get; } = Constants.SYS_NUM_DOUBLE; // "Double";
-
         private static readonly ConcurrentDictionary<string, DoubleExtractor> Instances =
             new ConcurrentDictionary<string, DoubleExtractor>();
-
-        public static DoubleExtractor GetInstance(string placeholder = NumbersDefinitions.PlaceHolderDefault)
-        {
-
-            if (!Instances.ContainsKey(placeholder))
-            {
-                var instance = new DoubleExtractor(placeholder);
-                Instances.TryAdd(placeholder, instance);
-            }
-
-            return Instances[placeholder];
-        }
 
         private DoubleExtractor(string placeholder = NumbersDefinitions.PlaceHolderDefault)
         {
@@ -67,10 +51,25 @@ namespace Microsoft.Recognizers.Text.Number.Portuguese
                 {
                     GenerateLongFormatNumberRegexes(LongFormatType.DoubleNumNoBreakSpaceComma, placeholder),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.NUMBER_SUFFIX)
-                }
+                },
             };
 
             Regexes = regexes.ToImmutableDictionary();
+        }
+
+        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
+
+        protected sealed override string ExtractType { get; } = Constants.SYS_NUM_DOUBLE; // "Double";
+
+        public static DoubleExtractor GetInstance(string placeholder = NumbersDefinitions.PlaceHolderDefault)
+        {
+            if (!Instances.ContainsKey(placeholder))
+            {
+                var instance = new DoubleExtractor(placeholder);
+                Instances.TryAdd(placeholder, instance);
+            }
+
+            return Instances[placeholder];
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.Number/Portuguese/Extractors/FractionExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Portuguese/Extractors/FractionExtractor.cs
@@ -9,26 +9,8 @@ namespace Microsoft.Recognizers.Text.Number.Portuguese
 {
     public class FractionExtractor : BaseNumberExtractor
     {
-        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
-
-        protected sealed override NumberOptions Options { get; }
-
-        protected sealed override string ExtractType { get; } = Constants.SYS_NUM_FRACTION; // "Fraction";
-
         private static readonly ConcurrentDictionary<(NumberOptions, string), FractionExtractor> Instances =
             new ConcurrentDictionary<(NumberOptions, string), FractionExtractor>();
-
-        public static FractionExtractor GetInstance(NumberOptions options = NumberOptions.None, string placeholder = "")
-        {
-            var cacheKey = (options, placeholder);
-            if (!Instances.ContainsKey(cacheKey))
-            {
-                var instance = new FractionExtractor(options);
-                Instances.TryAdd(cacheKey, instance);
-            }
-
-            return Instances[cacheKey];
-        }
 
         private FractionExtractor(NumberOptions options)
         {
@@ -59,6 +41,24 @@ namespace Microsoft.Recognizers.Text.Number.Portuguese
             };
 
             this.Regexes = regexes.ToImmutableDictionary();
+        }
+
+        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
+
+        protected sealed override NumberOptions Options { get; }
+
+        protected sealed override string ExtractType { get; } = Constants.SYS_NUM_FRACTION; // "Fraction";
+
+        public static FractionExtractor GetInstance(NumberOptions options = NumberOptions.None, string placeholder = "")
+        {
+            var cacheKey = (options, placeholder);
+            if (!Instances.ContainsKey(cacheKey))
+            {
+                var instance = new FractionExtractor(options);
+                Instances.TryAdd(cacheKey, instance);
+            }
+
+            return Instances[cacheKey];
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.Number/Portuguese/Extractors/IntegerExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Portuguese/Extractors/IntegerExtractor.cs
@@ -9,24 +9,8 @@ namespace Microsoft.Recognizers.Text.Number.Portuguese
 {
     public class IntegerExtractor : BaseNumberExtractor
     {
-        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
-
-        protected sealed override string ExtractType { get; } = Constants.SYS_NUM_INTEGER;
-
         private static readonly ConcurrentDictionary<string, IntegerExtractor> Instances =
             new ConcurrentDictionary<string, IntegerExtractor>();
-
-        public static IntegerExtractor GetInstance(string placeholder = NumbersDefinitions.PlaceHolderDefault)
-        {
-
-            if (!Instances.ContainsKey(placeholder))
-            {
-                var instance = new IntegerExtractor(placeholder);
-                Instances.TryAdd(placeholder, instance);
-            }
-
-            return Instances[placeholder];
-        }
 
         private IntegerExtractor(string placeholder = NumbersDefinitions.PlaceHolderDefault)
         {
@@ -71,10 +55,25 @@ namespace Microsoft.Recognizers.Text.Number.Portuguese
                 {
                     new Regex(NumbersDefinitions.AllIntRegexWithDozenSuffixLocks, RegexOptions.Singleline),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.PORTUGUESE)
-                }
+                },
             };
 
             this.Regexes = regexes.ToImmutableDictionary();
+        }
+
+        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
+
+        protected sealed override string ExtractType { get; } = Constants.SYS_NUM_INTEGER;
+
+        public static IntegerExtractor GetInstance(string placeholder = NumbersDefinitions.PlaceHolderDefault)
+        {
+            if (!Instances.ContainsKey(placeholder))
+            {
+                var instance = new IntegerExtractor(placeholder);
+                Instances.TryAdd(placeholder, instance);
+            }
+
+            return Instances[placeholder];
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.Number/Portuguese/Extractors/OrdinalExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Portuguese/Extractors/OrdinalExtractor.cs
@@ -9,24 +9,8 @@ namespace Microsoft.Recognizers.Text.Number.Portuguese
 {
     public class OrdinalExtractor : BaseNumberExtractor
     {
-        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
-
-        protected sealed override string ExtractType { get; } = Constants.SYS_NUM_ORDINAL; // "Ordinal";
-
         private static readonly ConcurrentDictionary<string, OrdinalExtractor> Instances =
             new ConcurrentDictionary<string, OrdinalExtractor>();
-
-        public static OrdinalExtractor GetInstance(string placeholder = "")
-        {
-
-            if (!Instances.ContainsKey(placeholder))
-            {
-                var instance = new OrdinalExtractor();
-                Instances.TryAdd(placeholder, instance);
-            }
-
-            return Instances[placeholder];
-        }
 
         private OrdinalExtractor()
         {
@@ -39,10 +23,25 @@ namespace Microsoft.Recognizers.Text.Number.Portuguese
                 {
                     new Regex(NumbersDefinitions.OrdinalEnglishRegex, RegexOptions.Singleline),
                     RegexTagGenerator.GenerateRegexTag(Constants.ORDINAL_PREFIX, Constants.PORTUGUESE)
-                }
+                },
             };
 
             this.Regexes = regexes.ToImmutableDictionary();
+        }
+
+        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
+
+        protected sealed override string ExtractType { get; } = Constants.SYS_NUM_ORDINAL; // "Ordinal";
+
+        public static OrdinalExtractor GetInstance(string placeholder = "")
+        {
+            if (!Instances.ContainsKey(placeholder))
+            {
+                var instance = new OrdinalExtractor();
+                Instances.TryAdd(placeholder, instance);
+            }
+
+            return Instances[placeholder];
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.Number/Portuguese/Extractors/PercentageExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Portuguese/Extractors/PercentageExtractor.cs
@@ -8,20 +8,20 @@ namespace Microsoft.Recognizers.Text.Number.Portuguese
 {
     public sealed class PercentageExtractor : BasePercentageExtractor
     {
-        protected override NumberOptions Options { get; }
-
-        public PercentageExtractor(NumberOptions options = NumberOptions.None) : base(
-            NumberExtractor.GetInstance(options: options))
+        public PercentageExtractor(NumberOptions options = NumberOptions.None)
+              : base(NumberExtractor.GetInstance(options: options))
         {
             Options = options;
             Regexes = InitRegexes();
         }
 
+        protected override NumberOptions Options { get; }
+
         protected override ImmutableHashSet<Regex> InitRegexes()
         {
             var regexStrs = new HashSet<string>
             {
-                NumbersDefinitions.NumberWithSuffixPercentage
+                NumbersDefinitions.NumberWithSuffixPercentage,
             };
 
             var regexSet = BuildRegexes(regexStrs);

--- a/.NET/Microsoft.Recognizers.Text.Number/Portuguese/Parsers/PortugueseNumberParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Portuguese/Parsers/PortugueseNumberParserConfiguration.cs
@@ -11,7 +11,10 @@ namespace Microsoft.Recognizers.Text.Number.Portuguese
 {
     public class PortugueseNumberParserConfiguration : INumberParserConfiguration
     {
-        public PortugueseNumberParserConfiguration() : this(new CultureInfo(Culture.Portuguese)) { }
+        public PortugueseNumberParserConfiguration()
+               : this(new CultureInfo(Culture.Portuguese))
+        {
+        }
 
         public PortugueseNumberParserConfiguration(CultureInfo ci)
         {
@@ -36,7 +39,7 @@ namespace Microsoft.Recognizers.Text.Number.Portuguese
             this.HalfADozenRegex = new Regex(NumbersDefinitions.HalfADozenRegex, RegexOptions.Singleline);
             this.DigitalNumberRegex = new Regex(NumbersDefinitions.DigitalNumberRegex, RegexOptions.Singleline);
             this.NegativeNumberSignRegex = new Regex(NumbersDefinitions.NegativeNumberSignRegex, RegexOptions.Singleline);
-            this.FractionPrepositionRegex  = new Regex(NumbersDefinitions.FractionPrepositionRegex, RegexOptions.Singleline);
+            this.FractionPrepositionRegex = new Regex(NumbersDefinitions.FractionPrepositionRegex, RegexOptions.Singleline);
         }
 
         public ImmutableDictionary<string, long> CardinalNumberMap { get; private set; }
@@ -99,7 +102,8 @@ namespace Microsoft.Recognizers.Text.Number.Portuguese
                     var newLength = origTempWord.Length;
                     tempWord = origTempWord.Remove(newLength - 3);
 
-                    if (string.IsNullOrWhiteSpace(tempWord)) {
+                    if (string.IsNullOrWhiteSpace(tempWord))
+                    {
                         // Ignore avos in fractions.
                         continue;
                     }
@@ -158,6 +162,7 @@ namespace Microsoft.Recognizers.Text.Number.Portuguese
                     value = 0;
                 }
             }
+
             return finalValue;
         }
     }


### PR DESCRIPTION
Fixes
- Reorder properties
- Add trailing comma
- Remove trailing whitespace
