### PR TITLE
[StyleCop] Fix warnings in TextNumberModels

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.Number/Models/AbstractNumberModel.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Models/AbstractNumberModel.cs
@@ -22,7 +22,6 @@ namespace Microsoft.Recognizers.Text.Number
 
         public List<ModelResult> Parse(string query)
         {
-
             var parsedNumbers = new List<ParseResult>();
 
             // Preprocess the query
@@ -60,7 +59,7 @@ namespace Microsoft.Recognizers.Text.Number
 
                 // Only support "subtype" for English for now
                 // As some languages like German, we miss handling some subtypes between "decimal" and "integer"
-                if (!string.IsNullOrEmpty(o.Type) && 
+                if (!string.IsNullOrEmpty(o.Type) &&
                     Constants.ValidSubTypes.Contains(o.Type) && extractorType.Contains(Constants.ENGLISH))
                 {
                     resolution.Add(ResolutionKey.SubType, o.Type);
@@ -72,9 +71,8 @@ namespace Microsoft.Recognizers.Text.Number
                     End = end,
                     Resolution = resolution,
                     Text = o.Text,
-                    TypeName = ModelTypeName
+                    TypeName = ModelTypeName,
                 };
-
             }).ToList();
         }
     }

--- a/.NET/Microsoft.Recognizers.Text.Number/Models/NumberModel.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Models/NumberModel.cs
@@ -2,7 +2,8 @@
 {
     public class NumberModel : AbstractNumberModel
     {
-        public NumberModel(IParser parser, IExtractor extractor) : base(parser, extractor)
+        public NumberModel(IParser parser, IExtractor extractor)
+            : base(parser, extractor)
         {
         }
 

--- a/.NET/Microsoft.Recognizers.Text.Number/Models/NumberRangeModel.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Models/NumberRangeModel.cs
@@ -2,7 +2,8 @@
 {
     public class NumberRangeModel : AbstractNumberModel
     {
-        public NumberRangeModel(IParser parser, IExtractor extractor) : base(parser, extractor)
+        public NumberRangeModel(IParser parser, IExtractor extractor)
+            : base(parser, extractor)
         {
         }
 

--- a/.NET/Microsoft.Recognizers.Text.Number/Models/OrdinalModel.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Models/OrdinalModel.cs
@@ -2,7 +2,8 @@
 {
     public class OrdinalModel : AbstractNumberModel
     {
-        public OrdinalModel(IParser parser, IExtractor extractor) : base(parser, extractor)
+        public OrdinalModel(IParser parser, IExtractor extractor)
+            : base(parser, extractor)
         {
         }
 

--- a/.NET/Microsoft.Recognizers.Text.Number/Models/PercentModel.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Models/PercentModel.cs
@@ -2,7 +2,8 @@
 {
     public class PercentModel : AbstractNumberModel
     {
-        public PercentModel(IParser parser, IExtractor extractor) : base(parser, extractor)
+        public PercentModel(IParser parser, IExtractor extractor)
+            : base(parser, extractor)
         {
         }
 


### PR DESCRIPTION
-Remove extra spaces
-Add trailing comma
-Put constructor initializer on its own line