### PR TITLE
[StyleCop] Fix warnings TextNumberKorean Extractors

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.Number/Korean/Extractors/CardinalExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Korean/Extractors/CardinalExtractor.cs
@@ -5,10 +5,6 @@ namespace Microsoft.Recognizers.Text.Number.Korean
 {
     public class CardinalExtractor : BaseNumberExtractor
     {
-        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
-
-        protected sealed override string ExtractType { get; } = Constants.SYS_NUM_CARDINAL;
-
         // CardinalExtractor = Int + Double
         public CardinalExtractor(KoreanNumberExtractorMode mode = KoreanNumberExtractorMode.Default)
         {
@@ -22,5 +18,9 @@ namespace Microsoft.Recognizers.Text.Number.Korean
 
             Regexes = builder.ToImmutable();
         }
+
+        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
+
+        protected sealed override string ExtractType { get; } = Constants.SYS_NUM_CARDINAL;
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.Number/Korean/Extractors/DoubleExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Korean/Extractors/DoubleExtractor.cs
@@ -8,10 +8,6 @@ namespace Microsoft.Recognizers.Text.Number.Korean
 {
     public class DoubleExtractor : BaseNumberExtractor
     {
-        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
-
-        protected sealed override string ExtractType { get; } = Constants.SYS_NUM_DOUBLE;
-
         public DoubleExtractor()
         {
             var regexes = new Dictionary<Regex, TypeTag>
@@ -26,7 +22,7 @@ namespace Microsoft.Recognizers.Text.Number.Korean
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    //(-).2 
+                    // (-).2
                     new Regex(NumbersDefinitions.SimpleDoubleSpecialsChars, RegexOptions.Singleline),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.NUMBER_SUFFIX)
                 },
@@ -36,7 +32,7 @@ namespace Microsoft.Recognizers.Text.Number.Korean
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    //１５.２만
+                    // １５.２만
                     new Regex(NumbersDefinitions.DoubleWithThousandsRegex, RegexOptions.Singleline),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.KOREAN)
                 },
@@ -46,13 +42,17 @@ namespace Microsoft.Recognizers.Text.Number.Korean
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.POWER_SUFFIX)
                 },
                 {
-                    //2^5
+                    // 2^5
                     new Regex(NumbersDefinitions.DoubleScientificNotationRegex, RegexOptions.Singleline),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.POWER_SUFFIX)
-                }
+                },
             };
 
             Regexes = regexes.ToImmutableDictionary();
         }
+
+        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
+
+        protected sealed override string ExtractType { get; } = Constants.SYS_NUM_DOUBLE;
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.Number/Korean/Extractors/FractionExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Korean/Extractors/FractionExtractor.cs
@@ -8,10 +8,6 @@ namespace Microsoft.Recognizers.Text.Number.Korean
 {
     public class FractionExtractor : BaseNumberExtractor
     {
-        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
-
-        protected sealed override string ExtractType { get; } = Constants.SYS_NUM_FRACTION;
-
         public FractionExtractor()
         {
             var regexes = new Dictionary<Regex, TypeTag>
@@ -22,18 +18,22 @@ namespace Microsoft.Recognizers.Text.Number.Korean
                     RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    // 8/3 
+                    // 8/3
                     new Regex(NumbersDefinitions.FractionNotationRegex, RegexOptions.Singleline),
                     RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    //오분의 이   칠분의 삼
+                    // 오분의 이   칠분의 삼
                     new Regex(NumbersDefinitions.AllFractionNumber, RegexOptions.Singleline),
                     RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.KOREAN)
-                }
+                },
             };
 
             Regexes = regexes.ToImmutableDictionary();
         }
+
+        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
+
+        protected sealed override string ExtractType { get; } = Constants.SYS_NUM_FRACTION;
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.Number/Korean/Extractors/IntegerExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Korean/Extractors/IntegerExtractor.cs
@@ -8,10 +8,6 @@ namespace Microsoft.Recognizers.Text.Number.Korean
 {
     public class IntegerExtractor : BaseNumberExtractor
     {
-        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
-
-        protected sealed override string ExtractType { get; } = Constants.SYS_NUM_INTEGER;
-
         public IntegerExtractor(KoreanNumberExtractorMode mode = KoreanNumberExtractorMode.Default)
         {
             var regexes = new Dictionary<Regex, TypeTag>
@@ -22,39 +18,45 @@ namespace Microsoft.Recognizers.Text.Number.Korean
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    //15k,  16 G
+                    // 15k,  16 G
                     new Regex(NumbersDefinitions.NumbersSpecialsCharsWithSuffix, RegexOptions.Singleline),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    //1,234,  ２，３３２，１１１
+                    // 1,234,  ２，３３２，１１１
                     new Regex(NumbersDefinitions.DottedNumbersSpecialsChar, RegexOptions.Singleline),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    //마이너스 일, 마이너스 오
+                    // 마이너스 일, 마이너스 오
                     new Regex(NumbersDefinitions.ZeroToNineIntegerSpecialsChars, RegexOptions.Singleline),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.KOREAN)
-                }
+                },
             };
 
             switch (mode)
             {
                 case KoreanNumberExtractorMode.Default:
-                    //일백오십오
-                    regexes.Add(new Regex(NumbersDefinitions.NumbersWithAllowListRegex, RegexOptions.Singleline),
-                    RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.KOREAN));
+                    // 일백오십오
+                    regexes.Add(
+                        new Regex(NumbersDefinitions.NumbersWithAllowListRegex, RegexOptions.Singleline),
+                        RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.KOREAN));
                     break;
 
                 case KoreanNumberExtractorMode.ExtractAll:
                     // 일백오십오, 사직구장, "사직구장" from "사(it is homonym, seems like four(4) or other chinese character)"
                     // Uses no allow lists and extracts all potential integers (useful in Units, for example).
-                    regexes.Add(new Regex(NumbersDefinitions.NumbersAggressiveRegex, RegexOptions.Singleline),
-                   RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.KOREAN));
+                    regexes.Add(
+                        new Regex(NumbersDefinitions.NumbersAggressiveRegex, RegexOptions.Singleline),
+                        RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.KOREAN));
                     break;
             }
 
             Regexes = regexes.ToImmutableDictionary();
         }
+
+        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
+
+        protected sealed override string ExtractType { get; } = Constants.SYS_NUM_INTEGER;
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.Number/Korean/Extractors/NumberExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Korean/Extractors/NumberExtractor.cs
@@ -3,12 +3,27 @@ using System.Text.RegularExpressions;
 
 namespace Microsoft.Recognizers.Text.Number.Korean
 {
+     /// <summary>
+     /// These modes can be applied to KoreanNumberExtractor.
+     /// The default more urilizes an allow list to avoid extracting numbers in ambiguous/undesired combinations of Korean ideograms.
+     /// --> such as "십이지장(十二指腸)" is organ name(duodenum, part of small intestine) in Korean, should not be extracted.
+     /// ExtractAll mode is to be used in cases where extraction should be more aggressive (e.g. in Units extraction).
+     /// </summary>
+    public enum KoreanNumberExtractorMode
+    {
+        /// <summary>
+        /// Number extraction with an allow list that filters what numbers to extract.
+        /// </summary>
+        Default,
+
+        /// <summary>
+        /// Extract all number-related terms aggressively.
+        /// </summary>
+        ExtractAll,
+    }
+
     public class NumberExtractor : BaseNumberExtractor
     {
-        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
-
-        protected sealed override string ExtractType { get; } = Constants.SYS_NUM;
-
         public NumberExtractor(KoreanNumberExtractorMode mode = KoreanNumberExtractorMode.Default)
         {
             var builder = ImmutableDictionary.CreateBuilder<Regex, TypeTag>();
@@ -23,15 +38,9 @@ namespace Microsoft.Recognizers.Text.Number.Korean
 
             Regexes = builder.ToImmutable();
         }
-    }
 
-    // These modes can be applied to KoreanNumberExtractor.
-    // The default more urilizes an allow list to avoid extracting numbers in ambiguous/undesired combinations of Korean ideograms.
-    // --> such as "십이지장(十二指腸)" is organ name(duodenum, part of small intestine) in Korean, should not be extracted.
-    // ExtractAll mode is to be used in cases where extraction should be more aggressive (e.g. in Units extraction).
-    public enum KoreanNumberExtractorMode
-    {
-        Default, // Number extraction with an allow list that filters what numbers to extract.
-        ExtractAll, // Extract all number-related terms aggressively.
+        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
+
+        protected sealed override string ExtractType { get; } = Constants.SYS_NUM;
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.Number/Korean/Extractors/PercentageExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Korean/Extractors/PercentageExtractor.cs
@@ -8,48 +8,47 @@ namespace Microsoft.Recognizers.Text.Number.Korean
 {
     public class PercentageExtractor : BaseNumberExtractor
     {
-        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
-
-        protected sealed override string ExtractType { get; } = Constants.SYS_NUM_PERCENTAGE;
-
         public PercentageExtractor()
         {
             var regexes = new Dictionary<Regex, TypeTag>()
             {
                 {
-                    //백퍼센트 십오퍼센트
+                    // 백퍼센트 십오퍼센트
                     new Regex(NumbersDefinitions.SimplePercentageRegex, RegexOptions.Singleline),
                     RegexTagGenerator.GenerateRegexTag(Constants.PERCENT_PREFIX, Constants.KOREAN)
                 },
                 {
-                    //19퍼센트　１퍼센트
+                    // 19퍼센트　１퍼센트
                     new Regex(NumbersDefinitions.NumbersPercentagePointRegex, RegexOptions.Singleline),
                     RegexTagGenerator.GenerateRegexTag(Constants.PERCENT_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    //3,000퍼센트  １，１２３퍼센트
+                    // 3,000퍼센트  １，１２３퍼센트
                     new Regex(NumbersDefinitions.NumbersPercentageWithSeparatorRegex, RegexOptions.Singleline),
                     RegexTagGenerator.GenerateRegexTag(Constants.PERCENT_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    //3.2 k 퍼센트
+                    // 3.2 k 퍼센트
                     new Regex(NumbersDefinitions.NumbersPercentageWithMultiplierRegex, RegexOptions.Singleline),
                     RegexTagGenerator.GenerateRegexTag(Constants.PERCENT_PREFIX, Constants.NUMBER_SUFFIX)
-                }
-                ,
+                },
                 {
-                    //15k퍼센트 
+                    // 15k퍼센트
                     new Regex(NumbersDefinitions.SimpleNumbersPercentageWithMultiplierRegex, RegexOptions.Singleline),
                     RegexTagGenerator.GenerateRegexTag(Constants.PERCENT_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                //마이너스십삼퍼센트
+                // 마이너스십삼퍼센트
                 new Regex(NumbersDefinitions.SimpleIntegerPercentageRegex, RegexOptions.Singleline),
                 RegexTagGenerator.GenerateRegexTag(Constants.PERCENT_PREFIX, Constants.NUMBER_SUFFIX)
-                }
+                },
             };
 
             Regexes = regexes.ToImmutableDictionary();
         }
+
+        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
+
+        protected sealed override string ExtractType { get; } = Constants.SYS_NUM_PERCENTAGE;
     }
 }


### PR DESCRIPTION
-Reordered properties and methods
-Added spaces and trailing commas when needed
-Fixed spacing
-Fix enum description style