### PR TITLE
[StyleCop] Fix all warnings in DateTime

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/BaseTimePeriodExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/BaseTimePeriodExtractor.cs
@@ -95,12 +95,12 @@ namespace Microsoft.Recognizers.Text.DateTime
                     else
                     {
                         // Is there "pm" or "am"?
-                        var time_pmStr = match.Groups[Constants.PmGroupName].Value;
-                        var time_amStr = match.Groups[Constants.AmGroupName].Value;
+                        var matchPmStr = match.Groups[Constants.PmGroupName].Value;
+                        var matchAmStr = match.Groups[Constants.AmGroupName].Value;
                         var descStr = match.Groups[Constants.DescGroupName].Value;
 
                         // Check "pm", "am"
-                        if (!string.IsNullOrEmpty(time_pmStr) || !string.IsNullOrEmpty(time_amStr) || !string.IsNullOrEmpty(descStr))
+                        if (!string.IsNullOrEmpty(matchPmStr) || !string.IsNullOrEmpty(matchAmStr) || !string.IsNullOrEmpty(descStr))
                         {
                             ret.Add(new Token(match.Index, match.Index + match.Length));
                         }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/BaseTimePeriodExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/BaseTimePeriodExtractor.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Recognizers.Text.DateTime
 {
     public class BaseTimePeriodExtractor : IDateTimeExtractor
     {
-        public static readonly string ExtractorName = Constants.SYS_DATETIME_TIMEPERIOD; //"TimePeriod";
+        public static readonly string ExtractorName = Constants.SYS_DATETIME_TIMEPERIOD; // "TimePeriod";
 
         private readonly ITimePeriodExtractorConfiguration config;
 
@@ -95,12 +95,12 @@ namespace Microsoft.Recognizers.Text.DateTime
                     else
                     {
                         // Is there "pm" or "am"?
-                        var pmStr = match.Groups[Constants.PmGroupName].Value;
-                        var amStr = match.Groups[Constants.AmGroupName].Value;
+                        var time_pmStr = match.Groups[Constants.PmGroupName].Value;
+                        var time_amStr = match.Groups[Constants.AmGroupName].Value;
                         var descStr = match.Groups[Constants.DescGroupName].Value;
 
-                        // Check "pm", "am" 
-                        if (!string.IsNullOrEmpty(pmStr) || !string.IsNullOrEmpty(amStr) || !string.IsNullOrEmpty(descStr))
+                        // Check "pm", "am"
+                        if (!string.IsNullOrEmpty(time_pmStr) || !string.IsNullOrEmpty(time_amStr) || !string.IsNullOrEmpty(descStr))
                         {
                             ret.Add(new Token(match.Index, match.Index + match.Length));
                         }
@@ -194,7 +194,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                     }
 
                     // check connector string
-                    var midStr = text.Substring(numEndPoint?? 0, ers[j].Start-numEndPoint?? 0);
+                    var midStr = text.Substring(numEndPoint ?? 0, ers[j].Start - numEndPoint ?? 0);
 
                     if (config.TillRegex.IsExactMatch(midStr, trim: true) || config.IsConnectorToken(midStr.Trim()))
                     {
@@ -238,7 +238,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                 }
 
                 var middleStr = text.Substring(middleBegin, middleEnd - middleBegin).Trim().ToLowerInvariant();
-                
+
                 // Handle "{TimePoint} to {TimePoint}"
                 if (config.TillRegex.IsExactMatch(middleStr, trim: true))
                 {
@@ -316,6 +316,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                     }
                 }
             }
+
             return ret;
         }
     }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchTimeParserConfiguration.cs
@@ -9,6 +9,17 @@ namespace Microsoft.Recognizers.Text.DateTime.French
 {
     public class FrenchTimeParserConfiguration : BaseOptionsConfiguration, ITimeParserConfiguration
     {
+        public FrenchTimeParserConfiguration(ICommonDateTimeParserConfiguration config)
+            : base(config)
+        {
+            TimeTokenPrefix = DateTimeDefinitions.TimeTokenPrefix;
+            AtRegex = FrenchTimeExtractorConfiguration.AtRegex;
+            TimeRegexes = FrenchTimeExtractorConfiguration.TimeRegexList;
+            UtilityConfiguration = config.UtilityConfiguration;
+            Numbers = config.Numbers;
+            TimeZoneParser = config.TimeZoneParser;
+        }
+
         public string TimeTokenPrefix { get; }
 
         public Regex AtRegex { get; }
@@ -21,22 +32,13 @@ namespace Microsoft.Recognizers.Text.DateTime.French
 
         public IDateTimeParser TimeZoneParser { get; }
 
-        public FrenchTimeParserConfiguration(ICommonDateTimeParserConfiguration config) : base(config)
-        {
-            TimeTokenPrefix = DateTimeDefinitions.TimeTokenPrefix; 
-            AtRegex = FrenchTimeExtractorConfiguration.AtRegex;
-            TimeRegexes = FrenchTimeExtractorConfiguration.TimeRegexList;
-            UtilityConfiguration = config.UtilityConfiguration;
-            Numbers = config.Numbers;
-            TimeZoneParser = config.TimeZoneParser;
-        }
-
         public void AdjustByPrefix(string prefix, ref int hour, ref int min, ref bool hasMin)
         {
             var deltaMin = 0;
             var trimedPrefix = prefix.Trim().ToLowerInvariant();
 
-            if (trimedPrefix.EndsWith("demie"))   // c'este 8 heures et demie, - "it's half past 8"
+            // c'este 8 heures et demie, - "it's half past 8"
+            if (trimedPrefix.EndsWith("demie"))
             {
                 deltaMin = 30;
             }
@@ -63,7 +65,8 @@ namespace Microsoft.Recognizers.Text.DateTime.French
                 }
             }
 
-            if (trimedPrefix.EndsWith("à")) // 'to' i.e 'one to five' = 'un à cinq'
+            // 'to' i.e 'one to five' = 'un à cinq'
+            if (trimedPrefix.EndsWith("à"))
             {
                 deltaMin = -deltaMin;
             }
@@ -74,6 +77,7 @@ namespace Microsoft.Recognizers.Text.DateTime.French
                 min += 60;
                 hour -= 1;
             }
+
             hasMin = true;
         }
 
@@ -88,23 +92,25 @@ namespace Microsoft.Recognizers.Text.DateTime.French
                 var oclockStr = match.Groups["heures"].Value;
                 if (string.IsNullOrEmpty(oclockStr))
                 {
-                    var amStr = match.Groups[Constants.AmGroupName].Value;
-                    if (!string.IsNullOrEmpty(amStr))
+                    var matchAmStr = match.Groups[Constants.AmGroupName].Value;
+                    if (!string.IsNullOrEmpty(matchAmStr))
                     {
                         if (hour >= Constants.HalfDayHourCount)
                         {
                             deltaHour = -Constants.HalfDayHourCount;
                         }
+
                         hasAm = true;
                     }
 
-                    var pmStr = match.Groups[Constants.PmGroupName].Value;
-                    if (!string.IsNullOrEmpty(pmStr))
+                    var matchPmStr = match.Groups[Constants.PmGroupName].Value;
+                    if (!string.IsNullOrEmpty(matchPmStr))
                     {
                         if (hour < Constants.HalfDayHourCount)
                         {
                             deltaHour = Constants.HalfDayHourCount;
                         }
+
                         hasPm = true;
                     }
                 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanTimeParserConfiguration.cs
@@ -9,12 +9,6 @@ namespace Microsoft.Recognizers.Text.DateTime.German
 {
     public class GermanTimeParserConfiguration : BaseOptionsConfiguration, ITimeParserConfiguration
     {
-        public string TimeTokenPrefix { get; }
-
-        public Regex AtRegex { get; }
-
-        public Regex MealTimeRegex { get; }
-
         private static readonly Regex TimeSuffixFull =
             new Regex(
                 DateTimeDefinitions.TimeSuffixFull,
@@ -30,15 +24,8 @@ namespace Microsoft.Recognizers.Text.DateTime.German
                 DateTimeDefinitions.NightRegex,
                 RegexOptions.Singleline);
 
-        public IEnumerable<Regex> TimeRegexes { get; }
-
-        public IImmutableDictionary<string, int> Numbers { get; }
-
-        public IDateTimeUtilityConfiguration UtilityConfiguration { get; }
-
-        public IDateTimeParser TimeZoneParser { get; }
-
-        public GermanTimeParserConfiguration(ICommonDateTimeParserConfiguration config) : base(config)
+        public GermanTimeParserConfiguration(ICommonDateTimeParserConfiguration config)
+               : base(config)
         {
             TimeTokenPrefix = DateTimeDefinitions.TimeTokenPrefix;
             AtRegex = GermanTimeExtractorConfiguration.AtRegex;
@@ -47,6 +34,20 @@ namespace Microsoft.Recognizers.Text.DateTime.German
             Numbers = config.Numbers;
             TimeZoneParser = config.TimeZoneParser;
         }
+
+        public string TimeTokenPrefix { get; }
+
+        public Regex AtRegex { get; }
+
+        public Regex MealTimeRegex { get; }
+
+        public IEnumerable<Regex> TimeRegexes { get; }
+
+        public IImmutableDictionary<string, int> Numbers { get; }
+
+        public IDateTimeUtilityConfiguration UtilityConfiguration { get; }
+
+        public IDateTimeParser TimeZoneParser { get; }
 
         public void AdjustByPrefix(string prefix, ref int hour, ref int min, ref bool hasMin)
         {
@@ -57,7 +58,7 @@ namespace Microsoft.Recognizers.Text.DateTime.German
             {
                 deltaMin = -30;
             }
-            else if ( trimedPrefix.StartsWith("viertel nach"))
+            else if (trimedPrefix.StartsWith("viertel nach"))
             {
                 deltaMin = 15;
             }
@@ -91,6 +92,7 @@ namespace Microsoft.Recognizers.Text.DateTime.German
                 min += 60;
                 hour -= 1;
             }
+
             hasMin = true;
         }
 
@@ -105,8 +107,8 @@ namespace Microsoft.Recognizers.Text.DateTime.German
                 var oclockStr = match.Groups["oclock"].Value;
                 if (string.IsNullOrEmpty(oclockStr))
                 {
-                    var amStr = match.Groups[Constants.AmGroupName].Value;
-                    if (!string.IsNullOrEmpty(amStr))
+                    var matchAmStr = match.Groups[Constants.AmGroupName].Value;
+                    if (!string.IsNullOrEmpty(matchAmStr))
                     {
                         if (hour >= Constants.HalfDayHourCount)
                         {
@@ -118,18 +120,18 @@ namespace Microsoft.Recognizers.Text.DateTime.German
                         }
                     }
 
-                    var pmStr = match.Groups[Constants.PmGroupName].Value;
-                    if (!string.IsNullOrEmpty(pmStr))
+                    var matchPmStr = match.Groups[Constants.PmGroupName].Value;
+                    if (!string.IsNullOrEmpty(matchPmStr))
                     {
                         if (hour < Constants.HalfDayHourCount)
                         {
                             deltaHour = Constants.HalfDayHourCount;
                         }
 
-                        if (LunchRegex.IsMatch(pmStr))
+                        if (LunchRegex.IsMatch(matchPmStr))
                         {
                             // for hour>=10, <12
-                            if (hour >=10 && hour <=Constants.HalfDayHourCount)
+                            if (hour >= 10 && hour <= Constants.HalfDayHourCount)
                             {
                                 deltaHour = 0;
                                 if (hour == Constants.HalfDayHourCount)
@@ -146,15 +148,16 @@ namespace Microsoft.Recognizers.Text.DateTime.German
                                 hasPm = true;
                             }
                         }
-                        else if (NightRegex.IsMatch(pmStr))
+                        else if (NightRegex.IsMatch(matchPmStr))
                         {
-                            //For hour <=3 or ==12, we treat it as am, for example 1 in the night (midnight) == 1am
+                            // For hour <=3 or ==12, we treat it as am, for example 1 in the night (midnight) == 1am
                             if (hour <= 3 || hour == Constants.HalfDayHourCount)
                             {
                                 if (hour == Constants.HalfDayHourCount)
                                 {
                                     hour = 0;
                                 }
+
                                 deltaHour = 0;
                                 hasAm = true;
                             }
@@ -167,7 +170,6 @@ namespace Microsoft.Recognizers.Text.DateTime.German
                         {
                             hasPm = true;
                         }
-                        
                     }
                 }
             }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianTimeParserConfiguration.cs
@@ -80,8 +80,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
                 var oclockStr = match.Groups["heures"].Value;
                 if (string.IsNullOrEmpty(oclockStr))
                 {
-                    var time_amStr = match.Groups["am"].Value;
-                    if (!string.IsNullOrEmpty(time_amStr))
+                    var matchAmStr = match.Groups["am"].Value;
+                    if (!string.IsNullOrEmpty(matchAmStr))
                     {
                         if (hour >= 12)
                         {
@@ -91,8 +91,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
                         hasAm = true;
                     }
 
-                    var time_pmStr = match.Groups["pm"].Value;
-                    if (!string.IsNullOrEmpty(time_pmStr))
+                    var matchPmStr = match.Groups["pm"].Value;
+                    if (!string.IsNullOrEmpty(matchPmStr))
                     {
                         if (hour < 12)
                         {

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianTimeParserConfiguration.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Text.RegularExpressions;
-
 using Microsoft.Recognizers.Definitions.Italian;
 using Microsoft.Recognizers.Text.DateTime.Utilities;
 
@@ -21,22 +20,13 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
 
         public IDateTimeParser TimeZoneParser { get; }
 
-        public ItalianTimeParserConfiguration(ICommonDateTimeParserConfiguration config) : base(config.Options)
-        {
-            TimeTokenPrefix = DateTimeDefinitions.TimeTokenPrefix; 
-            AtRegex = ItalianTimeExtractorConfiguration.AtRegex;
-            TimeRegexes = ItalianTimeExtractorConfiguration.TimeRegexList;
-            UtilityConfiguration = config.UtilityConfiguration;
-            Numbers = config.Numbers;
-            TimeZoneParser = config.TimeZoneParser;
-        }
-
         public void AdjustByPrefix(string prefix, ref int hour, ref int min, ref bool hasMin)
         {
             var deltaMin = 0;
             var trimedPrefix = prefix.Trim().ToLowerInvariant();
 
-            if (trimedPrefix.EndsWith("demie"))   // c'este 8 heures et demie, - "it's half past 8"
+            // c'este 8 heures et demie, - "it's half past 8"
+            if (trimedPrefix.EndsWith("demie"))
             {
                 deltaMin = 30;
             }
@@ -63,7 +53,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
                 }
             }
 
-            if (trimedPrefix.EndsWith("à")) // 'to' i.e 'one to five' = 'un à cinq'
+            // 'to' i.e 'one to five' = 'un à cinq'
+            if (trimedPrefix.EndsWith("à"))
             {
                 deltaMin = -deltaMin;
             }
@@ -74,6 +65,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
                 min += 60;
                 hour -= 1;
             }
+
             hasMin = true;
         }
 
@@ -88,23 +80,25 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
                 var oclockStr = match.Groups["heures"].Value;
                 if (string.IsNullOrEmpty(oclockStr))
                 {
-                    var amStr = match.Groups["am"].Value;
-                    if (!string.IsNullOrEmpty(amStr))
+                    var time_amStr = match.Groups["am"].Value;
+                    if (!string.IsNullOrEmpty(time_amStr))
                     {
                         if (hour >= 12)
                         {
                             deltaHour = -12;
                         }
+
                         hasAm = true;
                     }
 
-                    var pmStr = match.Groups["pm"].Value;
-                    if (!string.IsNullOrEmpty(pmStr))
+                    var time_pmStr = match.Groups["pm"].Value;
+                    if (!string.IsNullOrEmpty(time_pmStr))
                     {
                         if (hour < 12)
                         {
                             deltaHour = 12;
                         }
+
                         hasPm = true;
                     }
                 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Parsers/DateTimeParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Parsers/DateTimeParser.cs
@@ -1,12 +1,10 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Text.RegularExpressions;
-
-using DateObject = System.DateTime;
-
 using Microsoft.Recognizers.Definitions.Japanese;
-using Microsoft.Recognizers.Text.Number.Japanese;
-using System;
 using Microsoft.Recognizers.Text.Number;
+using Microsoft.Recognizers.Text.Number.Japanese;
+using DateObject = System.DateTime;
 
 namespace Microsoft.Recognizers.Text.DateTime.Japanese
 {
@@ -20,9 +18,9 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
 
         private static readonly IDateTimeExtractor SingleDateExtractor = new DateExtractor();
         private static readonly IDateTimeExtractor SingleTimeExtractor = new TimeExtractor();
-        private readonly IDateTimeExtractor DurationExtractor = new DurationExtractor();
-        private readonly IExtractor IntegerExtractor = new IntegerExtractor();
-        private readonly IParser NumberParser = new BaseCJKNumberParser(new JapaneseNumberParserConfiguration());
+        private readonly IDateTimeExtractor durationExtractor = new DurationExtractor();
+        private readonly IExtractor integerExtractor = new IntegerExtractor();
+        private readonly IParser numberParser = new BaseCJKNumberParser(new JapaneseNumberParserConfiguration());
 
         private readonly IFullDateTimeParserConfiguration config;
 
@@ -63,12 +61,12 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
                 {
                     innerResult.FutureResolution = new Dictionary<string, string>
                     {
-                        {TimeTypeConstants.DATETIME, DateTimeFormatUtil.FormatDateTime((DateObject) innerResult.FutureValue)}
+                        { TimeTypeConstants.DATETIME, DateTimeFormatUtil.FormatDateTime((DateObject)innerResult.FutureValue) },
                     };
 
                     innerResult.PastResolution = new Dictionary<string, string>
                     {
-                        {TimeTypeConstants.DATETIME, DateTimeFormatUtil.FormatDateTime((DateObject) innerResult.PastValue)}
+                        { TimeTypeConstants.DATETIME, DateTimeFormatUtil.FormatDateTime((DateObject)innerResult.PastValue) },
                     };
 
                     innerResult.IsLunar = IsLunarCalendar(er.Text);
@@ -85,27 +83,15 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
                 Type = er.Type,
                 Data = er.Data,
                 Value = value,
-                TimexStr = value == null ? "" : ((DateTimeResolutionResult) value).Timex,
-                ResolutionStr = ""
+                TimexStr = value == null ? string.Empty : ((DateTimeResolutionResult)value).Timex,
+                ResolutionStr = string.Empty,
             };
             return ret;
         }
 
-        public List<DateTimeParseResult> FilterResults(string query, List<DateTimeParseResult> candidateResults) {
-            return candidateResults;
-        }
-
-        // parse if lunar contains
-        private bool IsLunarCalendar(string text)
+        public List<DateTimeParseResult> FilterResults(string query, List<DateTimeParseResult> candidateResults)
         {
-            var trimmedText = text.Trim();
-            var match = DateExtractor.LunarRegex.Match(trimmedText);
-            if (match.Success)
-            {
-                return true;
-            }
-
-            return JapaneseHolidayExtractorConfiguration.LunarHolidayRegex.IsMatch(trimmedText);
+            return candidateResults;
         }
 
         private static DateTimeResolutionResult ParseBasicRegex(string text, DateObject referenceTime)
@@ -139,6 +125,19 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
             return ret;
         }
 
+        // parse if lunar contains
+        private bool IsLunarCalendar(string text)
+        {
+            var trimmedText = text.Trim();
+            var match = DateExtractor.LunarRegex.Match(trimmedText);
+            if (match.Success)
+            {
+                return true;
+            }
+
+            return JapaneseHolidayExtractorConfiguration.LunarHolidayRegex.IsMatch(trimmedText);
+        }
+
         // merge a Date entity and a Time entity
         private DateTimeResolutionResult MergeDateAndTime(string text, DateObject referenceTime)
         {
@@ -165,9 +164,9 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
                 return ret;
             }
 
-            var futureDate = (DateObject) ((DateTimeResolutionResult) pr1.Value).FutureValue;
-            var pastDate = (DateObject) ((DateTimeResolutionResult) pr1.Value).PastValue;
-            var time = (DateObject) ((DateTimeResolutionResult) pr2.Value).FutureValue;
+            var futureDate = (DateObject)((DateTimeResolutionResult)pr1.Value).FutureValue;
+            var pastDate = (DateObject)((DateTimeResolutionResult)pr1.Value).PastValue;
+            var time = (DateObject)((DateTimeResolutionResult)pr2.Value).FutureValue;
 
             var hour = time.Hour;
             var min = time.Minute;
@@ -188,15 +187,16 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
             {
                 timeStr = timeStr.Substring(0, timeStr.Length - 4);
             }
+
             timeStr = "T" + hour.ToString("D2") + timeStr.Substring(3);
             ret.Timex = pr1.TimexStr + timeStr;
 
-            var val = (DateTimeResolutionResult) pr2.Value;
+            var val = (DateTimeResolutionResult)pr2.Value;
 
             if (hour <= Constants.HalfDayHourCount && !SimplePmRegex.IsMatch(text) && !SimpleAmRegex.IsMatch(text) &&
                 !string.IsNullOrEmpty(val.Comment))
             {
-                //ret.Timex += "ampm";
+                // ret.Timex += "ampm";
                 ret.Comment = Constants.Comment_AmPm;
             }
 
@@ -223,7 +223,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
                 return ret;
             }
 
-            var time = (DateObject) ((DateTimeResolutionResult) pr.Value).FutureValue;
+            var time = (DateObject)((DateTimeResolutionResult)pr.Value).FutureValue;
 
             var hour = time.Hour;
             var min = time.Minute;
@@ -234,8 +234,6 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
             if (match.Success)
             {
                 var matchStr = match.Value.ToLowerInvariant();
-
-
                 var swift = 0;
                 switch (matchStr)
                 {
@@ -244,6 +242,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
                         {
                             hour += Constants.HalfDayHourCount;
                         }
+
                         break;
                     case "今早":
                     case "今晨":
@@ -251,6 +250,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
                         {
                             hour -= Constants.HalfDayHourCount;
                         }
+
                         break;
                     case "明晚":
                         swift = 1;
@@ -258,6 +258,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
                         {
                             hour += Constants.HalfDayHourCount;
                         }
+
                         break;
                     case "明早":
                     case "明晨":
@@ -266,6 +267,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
                         {
                             hour -= Constants.HalfDayHourCount;
                         }
+
                         break;
                     case "昨晚":
                         swift = -1;
@@ -273,6 +275,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
                         {
                             hour += Constants.HalfDayHourCount;
                         }
+
                         break;
                     default:
                         break;
@@ -286,6 +289,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
                 {
                     timeStr = timeStr.Substring(0, timeStr.Length - 4);
                 }
+
                 timeStr = "T" + hour.ToString("D2") + timeStr.Substring(3);
 
                 ret.Timex = DateTimeFormatUtil.FormatDate(date) + timeStr;
@@ -301,7 +305,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
         private DateTimeResolutionResult ParserDurationWithBeforeAndAfter(string text, DateObject referenceDate)
         {
             var ret = new DateTimeResolutionResult();
-            var durationRes = DurationExtractor.Extract(text, referenceDate);
+            var durationRes = durationExtractor.Extract(text, referenceDate);
             var numStr = string.Empty;
             var unitStr = string.Empty;
             if (durationRes.Count > 0)
@@ -342,6 +346,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
                                 default:
                                     return ret;
                             }
+
                             ret.Timex = $"{DateTimeFormatUtil.LuisDate(date)}";
                             ret.FutureValue = ret.PastValue = date;
                             ret.Success = true;
@@ -383,14 +388,15 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
         private int ConvertJapaneseToNum(string numStr)
         {
             var num = -1;
-            var er = IntegerExtractor.Extract(numStr);
+            var er = integerExtractor.Extract(numStr);
             if (er.Count != 0)
             {
                 if (er[0].Type.Equals(Number.Constants.SYS_NUM_INTEGER))
                 {
-                    num = Convert.ToInt32((double)(NumberParser.Parse(er[0]).Value ?? 0));
+                    num = Convert.ToInt32((double)(numberParser.Parse(er[0]).Value ?? 0));
                 }
             }
+
             return num;
         }
     }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDateTimePeriodParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDateTimePeriodParser.cs
@@ -545,10 +545,10 @@ namespace Microsoft.Recognizers.Text.DateTime
                     ret.TimeZoneResolution = timePeriodResolutionResult.TimeZoneResolution;
                 }
 
-                var timePeriodTimex = timePeriodResolutionResult.Timex;
+                var periodTimex = timePeriodResolutionResult.Timex;
 
                 // If it is a range type timex
-                if (TimexUtility.IsRangeTimex(timePeriodTimex))
+                if (TimexUtility.IsRangeTimex(periodTimex))
                 {
                     var dateResult = this.Config.DateExtractor.Extract(trimmedText.Replace(ers[0].Text, string.Empty), referenceTime);
 
@@ -575,7 +575,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                             return ParsePureNumberCases(text, referenceTime);
                         }
 
-                        var rangeTimexComponents = TimexUtility.GetRangeTimexComponents(timePeriodTimex);
+                        var rangeTimexComponents = TimexUtility.GetRangeTimexComponents(periodTimex);
 
                         if (rangeTimexComponents.IsValid)
                         {

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDateTimePeriodParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDateTimePeriodParser.cs
@@ -727,7 +727,7 @@ namespace Microsoft.Recognizers.Text.DateTime
             }
 
             // Parse "pm"
-            var timePmStr = match.Groups[Constants.PmGroupName].Value;
+            var matchPmStr = match.Groups[Constants.PmGroupName].Value;
             var timeAmStr = match.Groups[Constants.AmGroupName].Value;
             var descStr = match.Groups[Constants.DescGroupName].Value;
             if (!string.IsNullOrEmpty(timeAmStr) || (!string.IsNullOrEmpty(descStr) && descStr.StartsWith("a")))
@@ -744,7 +744,7 @@ namespace Microsoft.Recognizers.Text.DateTime
 
                 hasAm = true;
             }
-            else if (!string.IsNullOrEmpty(timePmStr) || (!string.IsNullOrEmpty(descStr) && descStr.StartsWith("p")))
+            else if (!string.IsNullOrEmpty(matchPmStr) || (!string.IsNullOrEmpty(descStr) && descStr.StartsWith("p")))
             {
                 if (beginHour < Constants.HalfDayHourCount)
                 {

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDateTimePeriodParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDateTimePeriodParser.cs
@@ -10,12 +10,12 @@ namespace Microsoft.Recognizers.Text.DateTime
     {
         public static readonly string ParserName = Constants.SYS_DATETIME_DATETIMEPERIOD;
 
-        protected readonly IDateTimePeriodParserConfiguration Config;
-
         public BaseDateTimePeriodParser(IDateTimePeriodParserConfiguration configuration)
         {
             Config = configuration;
         }
+
+        protected IDateTimePeriodParserConfiguration Config { get;  private set; }
 
         public ParseResult Parse(ExtractResult result)
         {

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDateTimePeriodParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDateTimePeriodParser.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -70,24 +70,24 @@ namespace Microsoft.Recognizers.Text.DateTime
                         {
                             {
                                 TimeTypeConstants.START_DATETIME,
-                                DateTimeFormatUtil.FormatDateTime(((Tuple<DateObject, DateObject>) innerResult.FutureValue).Item1)
+                                DateTimeFormatUtil.FormatDateTime(((Tuple<DateObject, DateObject>)innerResult.FutureValue).Item1)
                             },
                             {
                                 TimeTypeConstants.END_DATETIME,
-                                DateTimeFormatUtil.FormatDateTime(((Tuple<DateObject, DateObject>) innerResult.FutureValue).Item2)
-                            }
+                                DateTimeFormatUtil.FormatDateTime(((Tuple<DateObject, DateObject>)innerResult.FutureValue).Item2)
+                            },
                         };
 
                         innerResult.PastResolution = new Dictionary<string, string>
                         {
                             {
                                 TimeTypeConstants.START_DATETIME,
-                                DateTimeFormatUtil.FormatDateTime(((Tuple<DateObject, DateObject>) innerResult.PastValue).Item1)
+                                DateTimeFormatUtil.FormatDateTime(((Tuple<DateObject, DateObject>)innerResult.PastValue).Item1)
                             },
                             {
                                 TimeTypeConstants.END_DATETIME,
-                                DateTimeFormatUtil.FormatDateTime(((Tuple<DateObject, DateObject>) innerResult.PastValue).Item2)
-                            }
+                                DateTimeFormatUtil.FormatDateTime(((Tuple<DateObject, DateObject>)innerResult.PastValue).Item2)
+                            },
                         };
                     }
                     else
@@ -99,16 +99,16 @@ namespace Microsoft.Recognizers.Text.DateTime
                             {
                                 {
                                     TimeTypeConstants.START_DATETIME,
-                                    DateTimeFormatUtil.FormatDateTime((DateObject)(innerResult.FutureValue))
-                                }
+                                    DateTimeFormatUtil.FormatDateTime((DateObject)innerResult.FutureValue)
+                                },
                             };
 
                             innerResult.PastResolution = new Dictionary<string, string>
                             {
                                 {
                                     TimeTypeConstants.START_DATETIME,
-                                    DateTimeFormatUtil.FormatDateTime((DateObject)(innerResult.PastValue))
-                                }
+                                    DateTimeFormatUtil.FormatDateTime((DateObject)innerResult.PastValue)
+                                },
                             };
                         }
                         else
@@ -118,16 +118,16 @@ namespace Microsoft.Recognizers.Text.DateTime
                             {
                                 {
                                     TimeTypeConstants.END_DATETIME,
-                                    DateTimeFormatUtil.FormatDateTime((DateObject)(innerResult.FutureValue))
-                                }
+                                    DateTimeFormatUtil.FormatDateTime((DateObject)innerResult.FutureValue)
+                                },
                             };
 
                             innerResult.PastResolution = new Dictionary<string, string>
                             {
                                 {
                                     TimeTypeConstants.END_DATETIME,
-                                    DateTimeFormatUtil.FormatDateTime((DateObject)(innerResult.PastValue))
-                                }
+                                    DateTimeFormatUtil.FormatDateTime((DateObject)innerResult.PastValue)
+                                },
                             };
                         }
                     }
@@ -144,9 +144,238 @@ namespace Microsoft.Recognizers.Text.DateTime
                 Type = er.Type,
                 Data = er.Data,
                 Value = value,
-                TimexStr = value == null ? "" : ((DateTimeResolutionResult)value).Timex,
-                ResolutionStr = ""
+                TimexStr = value == null ? string.Empty : ((DateTimeResolutionResult)value).Timex,
+                ResolutionStr = string.Empty,
             };
+
+            return ret;
+        }
+
+        public List<DateTimeParseResult> FilterResults(string query, List<DateTimeParseResult> candidateResults)
+        {
+            return candidateResults;
+        }
+
+        // Parse specific TimeOfDay like "this night", "early morning", "late evening"
+        protected virtual DateTimeResolutionResult ParseSpecificTimeOfDay(string text, DateObject referenceTime)
+        {
+            var ret = new DateTimeResolutionResult();
+            var trimmedText = text.Trim().ToLowerInvariant();
+            var timeText = trimmedText;
+
+            var match = this.Config.PeriodTimeOfDayWithDateRegex.Match(trimmedText);
+
+            // Extract early/late prefix from text if any
+            bool hasEarly = false, hasLate = false;
+            if (match.Success)
+            {
+                timeText = match.Groups[Constants.TimeOfDayGroupName].Value;
+
+                if (!string.IsNullOrEmpty(match.Groups["early"].Value))
+                {
+                    hasEarly = true;
+                    ret.Comment = Constants.Comment_Early;
+                }
+
+                if (!hasEarly && !string.IsNullOrEmpty(match.Groups["late"].Value))
+                {
+                    hasLate = true;
+                    ret.Comment = Constants.Comment_Late;
+                }
+            }
+            else
+            {
+                match = this.Config.AmDescRegex.Match(trimmedText);
+                if (!match.Success)
+                {
+                    match = this.Config.PmDescRegex.Match(trimmedText);
+                }
+
+                if (match.Success)
+                {
+                    timeText = match.Value;
+                }
+            }
+
+            // Handle time of day
+
+            // Late/early only works with time of day
+            // Only standard time of day (morning, afternoon, evening and night) will not directly return
+            if (!this.Config.GetMatchedTimeRange(timeText, out string timeStr, out int beginHour, out int endHour, out int endMin))
+            {
+                return ret;
+            }
+
+            // Modify time period if "early" or "late" exists
+            // Since 'time of day' is defined as four hour periods
+            // the first 2 hours represent early, the later 2 hours represent late
+            if (hasEarly)
+            {
+                endHour = beginHour + 2;
+
+                // Handling speical case: night ends with 23:59
+                if (endMin == 59)
+                {
+                    endMin = 0;
+                }
+            }
+            else if (hasLate)
+            {
+                beginHour = beginHour + 2;
+            }
+
+            if (Config.SpecificTimeOfDayRegex.IsExactMatch(trimmedText, trim: true))
+            {
+                var swift = this.Config.GetSwiftPrefix(trimmedText);
+
+                var date = referenceTime.AddDays(swift).Date;
+                int day = date.Day, month = date.Month, year = date.Year;
+
+                ret.Timex = DateTimeFormatUtil.FormatDate(date) + timeStr;
+
+                ret.FutureValue =
+                    ret.PastValue =
+                        new Tuple<DateObject, DateObject>(
+                            DateObject.MinValue.SafeCreateFromValue(year, month, day, beginHour, 0, 0),
+                            DateObject.MinValue.SafeCreateFromValue(year, month, day, endHour, endMin, endMin));
+
+                ret.Success = true;
+                return ret;
+            }
+
+            // Handle Date followed by morning, afternoon and morning, afternoon followed by Date
+            match = this.Config.PeriodTimeOfDayWithDateRegex.Match(trimmedText);
+
+            if (!match.Success)
+            {
+                match = this.Config.AmDescRegex.Match(trimmedText);
+                if (!match.Success)
+                {
+                    match = this.Config.PmDescRegex.Match(trimmedText);
+                }
+            }
+
+            if (match.Success)
+            {
+                var beforeStr = trimmedText.Substring(0, match.Index).Trim();
+                var afterStr = trimmedText.Substring(match.Index + match.Length).Trim();
+
+                // Eliminate time period, if any
+                var timePeriodErs = this.Config.TimePeriodExtractor.Extract(beforeStr);
+                if (timePeriodErs.Count > 0)
+                {
+                    beforeStr = beforeStr.Remove(timePeriodErs[0].Start ?? 0, timePeriodErs[0].Length ?? 0).Trim();
+                }
+                else
+                {
+                    timePeriodErs = this.Config.TimePeriodExtractor.Extract(afterStr);
+                    if (timePeriodErs.Count > 0)
+                    {
+                        afterStr = afterStr.Remove(timePeriodErs[0].Start ?? 0, timePeriodErs[0].Length ?? 0).Trim();
+                    }
+                }
+
+                var ers = this.Config.DateExtractor.Extract(beforeStr + ' ' + afterStr, referenceTime);
+
+                if (ers.Count == 0 || ers[0].Length < beforeStr.Length)
+                {
+                    var valid = false;
+
+                    if (ers.Count > 0 && ers[0].Start == 0)
+                    {
+                        var midStr = beforeStr.Substring(ers[0].Start + ers[0].Length ?? 0);
+                        if (string.IsNullOrWhiteSpace(midStr.Replace(',', ' ')))
+                        {
+                            valid = true;
+                        }
+                    }
+
+                    if (!valid)
+                    {
+                        ers = this.Config.DateExtractor.Extract(afterStr, referenceTime);
+
+                        if (ers.Count == 0 || ers[0].Length != afterStr.Length)
+                        {
+                            if (ers.Count > 0 && ers[0].Start + ers[0].Length == afterStr.Length)
+                            {
+                                var midStr = afterStr.Substring(0, ers[0].Start ?? 0);
+                                if (string.IsNullOrWhiteSpace(midStr.Replace(',', ' ')))
+                                {
+                                    valid = true;
+                                }
+                            }
+                        }
+                        else
+                        {
+                            valid = true;
+                        }
+                    }
+
+                    if (!valid)
+                    {
+                        return ret;
+                    }
+                }
+
+                var hasSpecificTimePeriod = false;
+                if (timePeriodErs.Count > 0)
+                {
+                    var timePr = this.Config.TimePeriodParser.Parse(timePeriodErs[0], referenceTime);
+                    if (timePr != null)
+                    {
+                        var periodFuture = (Tuple<DateObject, DateObject>)((DateTimeResolutionResult)timePr.Value).FutureValue;
+                        var periodPast = (Tuple<DateObject, DateObject>)((DateTimeResolutionResult)timePr.Value).PastValue;
+
+                        if (periodFuture == periodPast)
+                        {
+                            beginHour = periodFuture.Item1.Hour;
+                            endHour = periodFuture.Item2.Hour;
+                        }
+                        else
+                        {
+                            if (periodFuture.Item1.Hour >= beginHour || periodFuture.Item2.Hour <= endHour)
+                            {
+                                beginHour = periodFuture.Item1.Hour;
+                                endHour = periodFuture.Item2.Hour;
+                            }
+                            else
+                            {
+                                beginHour = periodPast.Item1.Hour;
+                                endHour = periodPast.Item2.Hour;
+                            }
+                        }
+
+                        hasSpecificTimePeriod = true;
+                    }
+                }
+
+                var pr = this.Config.DateParser.Parse(ers[0], referenceTime);
+                var futureDate = (DateObject)((DateTimeResolutionResult)pr.Value).FutureValue;
+                var pastDate = (DateObject)((DateTimeResolutionResult)pr.Value).PastValue;
+
+                if (!hasSpecificTimePeriod)
+                {
+                    ret.Timex = pr.TimexStr + timeStr;
+                }
+                else
+                {
+                    ret.Timex = string.Format("({0}T{1},{0}T{2},PT{3}H)", pr.TimexStr, beginHour, endHour, endHour - beginHour);
+                }
+
+                ret.FutureValue =
+                    new Tuple<DateObject, DateObject>(
+                        DateObject.MinValue.SafeCreateFromValue(futureDate.Year, futureDate.Month, futureDate.Day, beginHour, 0, 0),
+                        DateObject.MinValue.SafeCreateFromValue(futureDate.Year, futureDate.Month, futureDate.Day, endHour, endMin, endMin));
+
+                ret.PastValue =
+                    new Tuple<DateObject, DateObject>(
+                        DateObject.MinValue.SafeCreateFromValue(pastDate.Year, pastDate.Month, pastDate.Day, beginHour, 0, 0),
+                        DateObject.MinValue.SafeCreateFromValue(pastDate.Year, pastDate.Month, pastDate.Day, endHour, endMin, endMin));
+
+                ret.Success = true;
+
+                return ret;
+            }
 
             return ret;
         }
@@ -197,7 +426,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                             ret.SubDateTimeEntities = new List<object>()
                             {
                                 datePr,
-                                timePr
+                                timePr,
                             };
 
                             if (((DateTimeResolutionResult)timePr.Value).TimeZoneResolution != null)
@@ -219,13 +448,13 @@ namespace Microsoft.Recognizers.Text.DateTime
         // Valid connector in English for After include: "after", "later than"
         private bool IsValidConnectorForDateAndTimePeriod(string text)
         {
-            var BeforeAfterRegexes = new List<Regex>()
+            var beforeAfterRegexes = new List<Regex>()
             {
                 this.Config.BeforeRegex,
-                this.Config.AfterRegex
+                this.Config.AfterRegex,
             };
 
-            foreach (var regex in BeforeAfterRegexes)
+            foreach (var regex in beforeAfterRegexes)
             {
                 var match = regex.MatchExact(text, trim: true);
 
@@ -255,7 +484,6 @@ namespace Microsoft.Recognizers.Text.DateTime
                         var startTime = (DateObject)((DateTimeResolutionResult)pr.Value).FutureValue;
                         startTime = new DateObject(startTime.Year, startTime.Month, startTime.Day);
                         var endTime = startTime;
-
 
                         if (match.Groups["EarlyPrefix"].Success)
                         {
@@ -322,15 +550,13 @@ namespace Microsoft.Recognizers.Text.DateTime
                 // If it is a range type timex
                 if (TimexUtility.IsRangeTimex(timePeriodTimex))
                 {
+                    var dateResult = this.Config.DateExtractor.Extract(trimmedText.Replace(ers[0].Text, string.Empty), referenceTime);
 
-                    var dateResult = this.Config.DateExtractor.Extract(trimmedText.Replace(ers[0].Text, ""), referenceTime);
-
-                    var dateText = trimmedText.Replace(ers[0].Text, "").Replace(Config.TokenBeforeDate, "").Trim();
+                    var dateText = trimmedText.Replace(ers[0].Text, string.Empty).Replace(Config.TokenBeforeDate, string.Empty).Trim();
 
                     // If only one Date is extracted and the Date text equals to the rest part of source text
                     if (dateResult.Count == 1 && dateText.Equals(dateResult[0].Text))
                     {
-
                         string dateTimex;
                         DateObject futureTime;
                         DateObject pastTime;
@@ -362,18 +588,16 @@ namespace Microsoft.Recognizers.Text.DateTime
                             var endTime = timePeriodFutureValue.Item2;
 
                             ret.FutureValue = new Tuple<DateObject, DateObject>(
-                                DateObject.MinValue.SafeCreateFromValue(futureTime.Year, futureTime.Month, futureTime.Day,
-                                    beginTime.Hour, beginTime.Minute, beginTime.Second),
-                                DateObject.MinValue.SafeCreateFromValue(futureTime.Year, futureTime.Month, futureTime.Day,
-                                    endTime.Hour, endTime.Minute, endTime.Second)
-                                    );
+                                DateObject.MinValue.SafeCreateFromValue(
+                                    futureTime.Year, futureTime.Month, futureTime.Day, beginTime.Hour, beginTime.Minute, beginTime.Second),
+                                DateObject.MinValue.SafeCreateFromValue(
+                                    futureTime.Year, futureTime.Month, futureTime.Day, endTime.Hour, endTime.Minute, endTime.Second));
 
                             ret.PastValue = new Tuple<DateObject, DateObject>(
-                                DateObject.MinValue.SafeCreateFromValue(pastTime.Year, pastTime.Month, pastTime.Day,
-                                    beginTime.Hour, beginTime.Minute, beginTime.Second),
-                                DateObject.MinValue.SafeCreateFromValue(pastTime.Year, pastTime.Month, pastTime.Day,
-                                    endTime.Hour, endTime.Minute, endTime.Second)
-                                    );
+                                DateObject.MinValue.SafeCreateFromValue(
+                                    pastTime.Year, pastTime.Month, pastTime.Day, beginTime.Hour, beginTime.Minute, beginTime.Second),
+                                DateObject.MinValue.SafeCreateFromValue(
+                                    pastTime.Year, pastTime.Month, pastTime.Day, endTime.Hour, endTime.Minute, endTime.Second));
 
                             if (!string.IsNullOrEmpty(timePeriodResolutionResult.Comment) &&
                                 timePeriodResolutionResult.Comment.Equals(Constants.Comment_AmPm))
@@ -422,7 +646,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                 var dateStr = string.Empty;
 
                 // Parse following date
-                var dateExtractResult = this.Config.DateExtractor.Extract(trimmedText.Replace(match.Value, ""), referenceTime);
+                var dateExtractResult = this.Config.DateExtractor.Extract(trimmedText.Replace(match.Value, string.Empty), referenceTime);
 
                 DateObject futureDate, pastDate;
                 if (dateExtractResult.Count > 0)
@@ -503,10 +727,10 @@ namespace Microsoft.Recognizers.Text.DateTime
             }
 
             // Parse "pm"
-            var pmStr = match.Groups[Constants.PmGroupName].Value;
-            var amStr = match.Groups[Constants.AmGroupName].Value;
+            var timePmStr = match.Groups[Constants.PmGroupName].Value;
+            var timeAmStr = match.Groups[Constants.AmGroupName].Value;
             var descStr = match.Groups[Constants.DescGroupName].Value;
-            if (!string.IsNullOrEmpty(amStr) || !string.IsNullOrEmpty(descStr) && descStr.StartsWith("a"))
+            if (!string.IsNullOrEmpty(timeAmStr) || (!string.IsNullOrEmpty(descStr) && descStr.StartsWith("a")))
             {
                 if (beginHour >= Constants.HalfDayHourCount)
                 {
@@ -520,7 +744,7 @@ namespace Microsoft.Recognizers.Text.DateTime
 
                 hasAm = true;
             }
-            else if (!string.IsNullOrEmpty(pmStr) || !string.IsNullOrEmpty(descStr) && descStr.StartsWith("p"))
+            else if (!string.IsNullOrEmpty(timePmStr) || (!string.IsNullOrEmpty(descStr) && descStr.StartsWith("p")))
             {
                 if (beginHour < Constants.HalfDayHourCount)
                 {
@@ -642,26 +866,27 @@ namespace Microsoft.Recognizers.Text.DateTime
             if (bothHaveDates)
             {
                 ret.Timex = $"({pr1.TimexStr},{pr2.TimexStr},PT{Convert.ToInt32((futureEnd - futureBegin).TotalHours)}H)";
+
                 // Do nothing
             }
             else if (beginHasDate)
             {
-                futureEnd = DateObject.MinValue.SafeCreateFromValue(futureBegin.Year, futureBegin.Month, futureBegin.Day,
-                    futureEnd.Hour, futureEnd.Minute, futureEnd.Second);
+                futureEnd = DateObject.MinValue.SafeCreateFromValue(
+                    futureBegin.Year, futureBegin.Month, futureBegin.Day, futureEnd.Hour, futureEnd.Minute, futureEnd.Second);
 
-                pastEnd = DateObject.MinValue.SafeCreateFromValue(pastBegin.Year, pastBegin.Month, pastBegin.Day,
-                    pastEnd.Hour, pastEnd.Minute, pastEnd.Second);
+                pastEnd = DateObject.MinValue.SafeCreateFromValue(
+                    pastBegin.Year, pastBegin.Month, pastBegin.Day, pastEnd.Hour, pastEnd.Minute, pastEnd.Second);
 
                 var dateStr = pr1.TimexStr.Split('T')[0];
                 ret.Timex = $"({pr1.TimexStr},{dateStr + pr2.TimexStr},PT{Convert.ToInt32((futureEnd - futureBegin).TotalHours)}H)";
             }
             else if (endHasDate)
             {
-                futureBegin = DateObject.MinValue.SafeCreateFromValue(futureEnd.Year, futureEnd.Month, futureEnd.Day,
-                    futureBegin.Hour, futureBegin.Minute, futureBegin.Second);
+                futureBegin = DateObject.MinValue.SafeCreateFromValue(
+                    futureEnd.Year, futureEnd.Month, futureEnd.Day, futureBegin.Hour, futureBegin.Minute, futureBegin.Second);
 
-                pastBegin = DateObject.MinValue.SafeCreateFromValue(pastEnd.Year, pastEnd.Month, pastEnd.Day,
-                    pastBegin.Hour, pastBegin.Minute, pastBegin.Second);
+                pastBegin = DateObject.MinValue.SafeCreateFromValue(
+                    pastEnd.Year, pastEnd.Month, pastEnd.Day, pastBegin.Hour, pastBegin.Minute, pastBegin.Second);
 
                 var dateStr = pr2.TimexStr.Split('T')[0];
                 ret.Timex = $"({dateStr + pr1.TimexStr},{pr2.TimexStr},PT{Convert.ToInt32((futureEnd - futureBegin).TotalHours)}H)";
@@ -689,228 +914,6 @@ namespace Microsoft.Recognizers.Text.DateTime
             ret.Success = true;
 
             ret.SubDateTimeEntities = new List<object> { pr1, pr2 };
-
-            return ret;
-        }
-
-        // Parse specific TimeOfDay like "this night", "early morning", "late evening"
-        protected virtual DateTimeResolutionResult ParseSpecificTimeOfDay(string text, DateObject referenceTime)
-        {
-            var ret = new DateTimeResolutionResult();
-            var trimmedText = text.Trim().ToLowerInvariant();
-            var timeText = trimmedText;
-
-            var match = this.Config.PeriodTimeOfDayWithDateRegex.Match(trimmedText);
-
-            // Extract early/late prefix from text if any
-            bool hasEarly = false, hasLate = false;
-            if (match.Success)
-            {
-                timeText = match.Groups[Constants.TimeOfDayGroupName].Value;
-
-                if (!string.IsNullOrEmpty(match.Groups["early"].Value))
-                {
-                    hasEarly = true;
-                    ret.Comment = Constants.Comment_Early;
-                }
-
-                if (!hasEarly && !string.IsNullOrEmpty(match.Groups["late"].Value))
-                {
-                    hasLate = true;
-                    ret.Comment = Constants.Comment_Late;
-                }
-            }
-            else
-            {
-                match = this.Config.AmDescRegex.Match(trimmedText);
-                if (!match.Success)
-                {
-                    match = this.Config.PmDescRegex.Match(trimmedText);
-                }
-
-                if (match.Success)
-                {
-                    timeText = match.Value;
-                }
-            }
-
-            // Handle time of day
-
-            // Late/early only works with time of day
-            // Only standard time of day (morning, afternoon, evening and night) will not directly return
-            if (!this.Config.GetMatchedTimeRange(timeText, out string timeStr, out int beginHour, out int endHour, out int endMin))
-            {
-                return ret;
-            }
-
-            // Modify time period if "early" or "late" exists
-            // Since 'time of day' is defined as four hour periods, 
-            // the first 2 hours represent early, the later 2 hours represent late
-            if (hasEarly)
-            {
-                endHour = beginHour + 2;
-                // Handling speical case: night ends with 23:59
-                if (endMin == 59)
-                {
-                    endMin = 0;
-                }
-            }
-            else if (hasLate)
-            {
-                beginHour = beginHour + 2;
-            }
-
-            if (Config.SpecificTimeOfDayRegex.IsExactMatch(trimmedText, trim: true))
-            {
-                var swift = this.Config.GetSwiftPrefix(trimmedText);
-
-                var date = referenceTime.AddDays(swift).Date;
-                int day = date.Day, month = date.Month, year = date.Year;
-
-                ret.Timex = DateTimeFormatUtil.FormatDate(date) + timeStr;
-
-                ret.FutureValue =
-                    ret.PastValue =
-                        new Tuple<DateObject, DateObject>(DateObject.MinValue.SafeCreateFromValue(year, month, day, beginHour, 0, 0),
-                            DateObject.MinValue.SafeCreateFromValue(year, month, day, endHour, endMin, endMin));
-
-                ret.Success = true;
-                return ret;
-            }
-
-            // Handle Date followed by morning, afternoon and morning, afternoon followed by Date
-            match = this.Config.PeriodTimeOfDayWithDateRegex.Match(trimmedText);
-
-            if (!match.Success)
-            {
-                match = this.Config.AmDescRegex.Match(trimmedText);
-                if (!match.Success)
-                {
-                    match = this.Config.PmDescRegex.Match(trimmedText);
-                }
-            }
-
-            if (match.Success)
-            {
-                var beforeStr = trimmedText.Substring(0, match.Index).Trim();
-                var afterStr = trimmedText.Substring(match.Index + match.Length).Trim();
-
-                // Eliminate time period, if any
-                var timePeriodErs = this.Config.TimePeriodExtractor.Extract(beforeStr);
-                if (timePeriodErs.Count > 0)
-                {
-                    beforeStr = beforeStr.Remove(timePeriodErs[0].Start ?? 0, timePeriodErs[0].Length ?? 0).Trim();
-                }
-                else
-                {
-                    timePeriodErs = this.Config.TimePeriodExtractor.Extract(afterStr);
-                    if (timePeriodErs.Count > 0)
-                    {
-                        afterStr = afterStr.Remove(timePeriodErs[0].Start ?? 0, timePeriodErs[0].Length ?? 0).Trim();
-                    }
-                }
-
-                var ers = this.Config.DateExtractor.Extract(beforeStr + ' ' + afterStr, referenceTime);
-
-                if (ers.Count == 0 || ers[0].Length < beforeStr.Length)
-                {
-                    var valid = false;
-
-                    if (ers.Count > 0 && ers[0].Start == 0)
-                    {
-                        var midStr = beforeStr.Substring(ers[0].Start + ers[0].Length ?? 0);
-                        if (string.IsNullOrWhiteSpace(midStr.Replace(',', ' ')))
-                        {
-                            valid = true;
-                        }
-                    }
-
-                    if (!valid)
-                    {
-                        ers = this.Config.DateExtractor.Extract(afterStr, referenceTime);
-
-                        if (ers.Count == 0 || ers[0].Length != afterStr.Length)
-                        {
-                            if (ers.Count > 0 && ers[0].Start + ers[0].Length == afterStr.Length)
-                            {
-                                var midStr = afterStr.Substring(0, ers[0].Start ?? 0);
-                                if (string.IsNullOrWhiteSpace(midStr.Replace(',', ' ')))
-                                {
-                                    valid = true;
-                                }
-                            }
-                        }
-                        else
-                        {
-                            valid = true;
-                        }
-                    }
-
-                    if (!valid)
-                    {
-                        return ret;
-                    }
-                }
-
-                var hasSpecificTimePeriod = false;
-                if (timePeriodErs.Count > 0)
-                {
-                    var timePr = this.Config.TimePeriodParser.Parse(timePeriodErs[0], referenceTime);
-                    if (timePr != null)
-                    {
-                        var periodFuture = (Tuple<DateObject, DateObject>)(((DateTimeResolutionResult)timePr.Value).FutureValue);
-                        var periodPast = (Tuple<DateObject, DateObject>)((DateTimeResolutionResult)timePr.Value).PastValue;
-
-                        if (periodFuture == periodPast)
-                        {
-                            beginHour = periodFuture.Item1.Hour;
-                            endHour = periodFuture.Item2.Hour;
-                        }
-                        else
-                        {
-                            if (periodFuture.Item1.Hour >= beginHour || periodFuture.Item2.Hour <= endHour)
-                            {
-                                beginHour = periodFuture.Item1.Hour;
-                                endHour = periodFuture.Item2.Hour;
-                            }
-                            else
-                            {
-                                beginHour = periodPast.Item1.Hour;
-                                endHour = periodPast.Item2.Hour;
-                            }
-                        }
-
-                        hasSpecificTimePeriod = true;
-                    }
-                }
-
-                var pr = this.Config.DateParser.Parse(ers[0], referenceTime);
-                var futureDate = (DateObject)((DateTimeResolutionResult)pr.Value).FutureValue;
-                var pastDate = (DateObject)((DateTimeResolutionResult)pr.Value).PastValue;
-
-                if (!hasSpecificTimePeriod)
-                {
-                    ret.Timex = pr.TimexStr + timeStr;
-                }
-                else
-                {
-                    ret.Timex = string.Format("({0}T{1},{0}T{2},PT{3}H)", pr.TimexStr, beginHour, endHour, endHour - beginHour);
-                }
-
-                ret.FutureValue =
-                    new Tuple<DateObject, DateObject>(
-                        DateObject.MinValue.SafeCreateFromValue(futureDate.Year, futureDate.Month, futureDate.Day, beginHour, 0, 0),
-                        DateObject.MinValue.SafeCreateFromValue(futureDate.Year, futureDate.Month, futureDate.Day, endHour, endMin, endMin));
-
-                ret.PastValue =
-                    new Tuple<DateObject, DateObject>(
-                        DateObject.MinValue.SafeCreateFromValue(pastDate.Year, pastDate.Month, pastDate.Day, beginHour, 0, 0),
-                        DateObject.MinValue.SafeCreateFromValue(pastDate.Year, pastDate.Month, pastDate.Day, endHour, endMin, endMin));
-
-                ret.Success = true;
-
-                return ret;
-            }
 
             return ret;
         }
@@ -958,7 +961,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                 if (pr.Value != null)
                 {
                     var swiftSeconds = 0;
-                    var mod = "";
+                    var mod = string.Empty;
                     var durationResult = (DateTimeResolutionResult)pr.Value;
                     if (durationResult.PastValue is double && durationResult.FutureValue is double)
                     {
@@ -1055,7 +1058,7 @@ namespace Microsoft.Recognizers.Text.DateTime
 
                 DateObject beginTime;
                 var endTime = beginTime = referenceTime;
-                var ptTimex = string.Empty;
+                var sufixPtTimex = string.Empty;
 
                 if (Config.UnitMap.ContainsKey(srcUnit))
                 {
@@ -1064,22 +1067,22 @@ namespace Microsoft.Recognizers.Text.DateTime
                         case "D":
                             endTime = DateObject.MinValue.SafeCreateFromValue(beginTime.Year, beginTime.Month, beginTime.Day);
                             endTime = endTime.AddDays(1).AddSeconds(-1);
-                            ptTimex = "PT" + (endTime - beginTime).TotalSeconds + "S";
+                            sufixPtTimex = "PT" + (endTime - beginTime).TotalSeconds + "S";
                             break;
                         case "H":
                             beginTime = swiftValue > 0 ? beginTime : referenceTime.AddHours(swiftValue);
                             endTime = swiftValue > 0 ? referenceTime.AddHours(swiftValue) : endTime;
-                            ptTimex = "PT1H";
+                            sufixPtTimex = "PT1H";
                             break;
                         case "M":
                             beginTime = swiftValue > 0 ? beginTime : referenceTime.AddMinutes(swiftValue);
                             endTime = swiftValue > 0 ? referenceTime.AddMinutes(swiftValue) : endTime;
-                            ptTimex = "PT1M";
+                            sufixPtTimex = "PT1M";
                             break;
                         case "S":
                             beginTime = swiftValue > 0 ? beginTime : referenceTime.AddSeconds(swiftValue);
                             endTime = swiftValue > 0 ? referenceTime.AddSeconds(swiftValue) : endTime;
-                            ptTimex = "PT1S";
+                            sufixPtTimex = "PT1S";
                             break;
                         default:
                             return ret;
@@ -1087,7 +1090,7 @@ namespace Microsoft.Recognizers.Text.DateTime
 
                     ret.Timex =
                             $"({DateTimeFormatUtil.LuisDate(beginTime)}T{DateTimeFormatUtil.LuisTime(beginTime)}," +
-                            $"{DateTimeFormatUtil.LuisDate(endTime)}T{DateTimeFormatUtil.LuisTime(endTime)},{ptTimex})";
+                            $"{DateTimeFormatUtil.LuisDate(endTime)}T{DateTimeFormatUtil.LuisTime(endTime)},{sufixPtTimex})";
 
                     ret.FutureValue = ret.PastValue = new Tuple<DateObject, DateObject>(beginTime, endTime);
                     ret.Success = true;
@@ -1097,11 +1100,6 @@ namespace Microsoft.Recognizers.Text.DateTime
             }
 
             return ret;
-        }
-
-        public List<DateTimeParseResult> FilterResults(string query, List<DateTimeParseResult> candidateResults)
-        {
-            return candidateResults;
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDateTimePeriodParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDateTimePeriodParser.cs
@@ -728,9 +728,9 @@ namespace Microsoft.Recognizers.Text.DateTime
 
             // Parse "pm"
             var matchPmStr = match.Groups[Constants.PmGroupName].Value;
-            var timeAmStr = match.Groups[Constants.AmGroupName].Value;
+            var matchAmStr = match.Groups[Constants.AmGroupName].Value;
             var descStr = match.Groups[Constants.DescGroupName].Value;
-            if (!string.IsNullOrEmpty(timeAmStr) || (!string.IsNullOrEmpty(descStr) && descStr.StartsWith("a")))
+            if (!string.IsNullOrEmpty(matchAmStr) || (!string.IsNullOrEmpty(descStr) && descStr.StartsWith("a")))
             {
                 if (beginHour >= Constants.HalfDayHourCount)
                 {

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseTimePeriodParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseTimePeriodParser.cs
@@ -178,7 +178,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                         var leftDesc = match.Groups["leftDesc"].Value;
                         var rightDesc = match.Groups["rightDesc"].Value;
                         var matchPmStr = match.Groups[Constants.PmGroupName].Value;
-                        var timeAmStr = match.Groups[Constants.AmGroupName].Value;
+                        var matchAmStr = match.Groups[Constants.AmGroupName].Value;
                         var descStr = match.Groups[Constants.DescGroupName].Value;
 
                         // The "ampm" only occurs in time, we don't have to consider it here
@@ -189,7 +189,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                             var rightPmValid = !string.IsNullOrEmpty(rightDesc) &&
                                             config.UtilityConfiguration.PmDescRegex.Match(rightDesc.ToLower()).Success;
 
-                            if (!string.IsNullOrEmpty(timeAmStr) || rightAmValid)
+                            if (!string.IsNullOrEmpty(matchAmStr) || rightAmValid)
                             {
                                 if (endHour >= Constants.HalfDayHourCount)
                                 {

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseTimePeriodParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseTimePeriodParser.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Recognizers.Text.DateTime
 {
     public class BaseTimePeriodParser : IDateTimeParser
     {
-        public static readonly string ParserName = Constants.SYS_DATETIME_TIMEPERIOD; //"TimePeriod";
+        public static readonly string ParserName = Constants.SYS_DATETIME_TIMEPERIOD; // "TimePeriod";
 
         private readonly ITimePeriodParserConfiguration config;
 
@@ -36,9 +36,10 @@ namespace Microsoft.Recognizers.Text.DateTime
                     var timezoneEr = metadata[Constants.SYS_DATETIME_TIMEZONE] as ExtractResult;
                     var timezonePr = config.TimeZoneParser.Parse(timezoneEr);
 
-                    innerResult = InternalParse(er.Text.Substring(0, (int)(er.Length - timezoneEr.Length)),
+                    innerResult = InternalParse(
+                        er.Text.Substring(0, (int)(er.Length - timezoneEr.Length)),
                         referenceTime);
-                    
+
                     if (timezonePr != null && timezonePr.Value != null)
                     {
                         innerResult.TimeZoneResolution = ((DateTimeResolutionResult)timezonePr.Value).TimeZoneResolution;
@@ -55,24 +56,24 @@ namespace Microsoft.Recognizers.Text.DateTime
                     {
                         {
                             TimeTypeConstants.START_TIME,
-                            DateTimeFormatUtil.FormatTime(((Tuple<DateObject, DateObject>) innerResult.FutureValue).Item1)
+                            DateTimeFormatUtil.FormatTime(((Tuple<DateObject, DateObject>)innerResult.FutureValue).Item1)
                         },
                         {
                             TimeTypeConstants.END_TIME,
-                            DateTimeFormatUtil.FormatTime(((Tuple<DateObject, DateObject>) innerResult.FutureValue).Item2)
-                        }
+                            DateTimeFormatUtil.FormatTime(((Tuple<DateObject, DateObject>)innerResult.FutureValue).Item2)
+                        },
                     };
 
                     innerResult.PastResolution = new Dictionary<string, string>
                     {
                         {
                             TimeTypeConstants.START_TIME,
-                            DateTimeFormatUtil.FormatTime(((Tuple<DateObject, DateObject>) innerResult.PastValue).Item1)
+                            DateTimeFormatUtil.FormatTime(((Tuple<DateObject, DateObject>)innerResult.PastValue).Item1)
                         },
                         {
                             TimeTypeConstants.END_TIME,
-                            DateTimeFormatUtil.FormatTime(((Tuple<DateObject, DateObject>) innerResult.PastValue).Item2)
-                        }
+                            DateTimeFormatUtil.FormatTime(((Tuple<DateObject, DateObject>)innerResult.PastValue).Item2)
+                        },
                     };
 
                     value = innerResult;
@@ -87,11 +88,16 @@ namespace Microsoft.Recognizers.Text.DateTime
                 Type = er.Type,
                 Data = er.Data,
                 Value = value,
-                TimexStr = value == null ? "" : ((DateTimeResolutionResult)value).Timex,
-                ResolutionStr = ""
+                TimexStr = value == null ? string.Empty : ((DateTimeResolutionResult)value).Timex,
+                ResolutionStr = string.Empty,
             };
 
             return ret;
+        }
+
+        public List<DateTimeParseResult> FilterResults(string query, List<DateTimeParseResult> candidateResults)
+        {
+            return candidateResults;
         }
 
         private DateTimeResolutionResult InternalParse(string entityText, DateObject referenceTime)
@@ -153,7 +159,6 @@ namespace Microsoft.Recognizers.Text.DateTime
                 // hard to integrate this part into the regex
                 if (afterHourIndex == trimmedText.Length || !trimmedText.Substring(afterHourIndex).Trim().StartsWith(":"))
                 {
-
                     if (!this.config.Numbers.TryGetValue(hourStr, out int beginHour))
                     {
                         beginHour = int.Parse(hourStr);
@@ -172,20 +177,19 @@ namespace Microsoft.Recognizers.Text.DateTime
                         // parse "pm"
                         var leftDesc = match.Groups["leftDesc"].Value;
                         var rightDesc = match.Groups["rightDesc"].Value;
-                        var pmStr = match.Groups[Constants.PmGroupName].Value;
-                        var amStr = match.Groups[Constants.AmGroupName].Value;
+                        var timePmStr = match.Groups[Constants.PmGroupName].Value;
+                        var timeAmStr = match.Groups[Constants.AmGroupName].Value;
                         var descStr = match.Groups[Constants.DescGroupName].Value;
 
                         // The "ampm" only occurs in time, we don't have to consider it here
                         if (string.IsNullOrEmpty(leftDesc))
                         {
-
                             var rightAmValid = !string.IsNullOrEmpty(rightDesc) &&
                                                     config.UtilityConfiguration.AmDescRegex.Match(rightDesc.ToLower()).Success;
                             var rightPmValid = !string.IsNullOrEmpty(rightDesc) &&
                                             config.UtilityConfiguration.PmDescRegex.Match(rightDesc.ToLower()).Success;
 
-                            if (!string.IsNullOrEmpty(amStr) || rightAmValid)
+                            if (!string.IsNullOrEmpty(timeAmStr) || rightAmValid)
                             {
                                 if (endHour >= Constants.HalfDayHourCount)
                                 {
@@ -204,11 +208,9 @@ namespace Microsoft.Recognizers.Text.DateTime
                                 }
 
                                 isValid = true;
-
                             }
-                            else if (!string.IsNullOrEmpty(pmStr) || rightPmValid)
+                            else if (!string.IsNullOrEmpty(timePmStr) || rightPmValid)
                             {
-
                                 if (endHour < Constants.HalfDayHourCount)
                                 {
                                     endHour += Constants.HalfDayHourCount;
@@ -221,7 +223,6 @@ namespace Microsoft.Recognizers.Text.DateTime
                                 }
 
                                 isValid = true;
-
                             }
                         }
 
@@ -308,7 +309,6 @@ namespace Microsoft.Recognizers.Text.DateTime
                 {
                     beginHour = int.Parse(hourStr);
                 }
-
 
                 hourStr = hourGroup.Captures[1].Value;
 
@@ -506,6 +506,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                             endDateTime = endDateTime.AddHours(Constants.HalfDayHourCount);
                         }
                     }
+
                     ret.Comment = Constants.Comment_AmPm;
                 }
 
@@ -536,7 +537,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                         Start = time1StartIndex,
                         Length = time1EndIndex - time1StartIndex,
                         Text = text.Substring(time1StartIndex, time1EndIndex - time1StartIndex),
-                        Type = $"{Constants.SYS_DATETIME_TIME}"
+                        Type = $"{Constants.SYS_DATETIME_TIME}",
                     };
 
                     var pr = this.config.TimeParser.Parse(er, referenceTime);
@@ -551,7 +552,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                         Start = time2StartIndex,
                         Length = time2EndIndex - time2StartIndex,
                         Text = text.Substring(time2StartIndex, time2EndIndex - time2StartIndex),
-                        Type = $"{Constants.SYS_DATETIME_TIME}"
+                        Type = $"{Constants.SYS_DATETIME_TIME}",
                     };
 
                     var pr = this.config.TimeParser.Parse(er, referenceTime);
@@ -580,6 +581,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                     foreach (var num in numErs)
                     {
                         int midStrBegin = 0, midStrEnd = 0;
+
                         // ending number
                         if (num.Start > ers[0].Start + ers[0].Length)
                         {
@@ -658,11 +660,11 @@ namespace Microsoft.Recognizers.Text.DateTime
             var minutes = (endTime - beginTime).Minutes;
             var hours = (endTime - beginTime).Hours;
             ret.Timex = $"({pr1.TimexStr},{pr2.TimexStr}," +
-                        $"PT{(hours > 0 ? hours + "H" : "")}{(minutes > 0 ? minutes + "M" : "")})";
+                        $"PT{(hours > 0 ? hours + "H" : string.Empty)}{(minutes > 0 ? minutes + "M" : string.Empty)})";
             ret.FutureValue = ret.PastValue = new Tuple<DateObject, DateObject>(beginTime, endTime);
             ret.Success = true;
-            
-            if (!string.IsNullOrEmpty(ampmStr1) && ampmStr1.EndsWith(Constants.Comment_AmPm)  && 
+
+            if (!string.IsNullOrEmpty(ampmStr1) && ampmStr1.EndsWith(Constants.Comment_AmPm) &&
                 !string.IsNullOrEmpty(ampmStr2) && ampmStr2.EndsWith(Constants.Comment_AmPm))
             {
                 ret.Comment = Constants.Comment_AmPm;
@@ -677,7 +679,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                 ret.TimeZoneResolution = ((DateTimeResolutionResult)pr2.Value).TimeZoneResolution;
             }
 
-            ret.SubDateTimeEntities = new List<object> {pr1, pr2};
+            ret.SubDateTimeEntities = new List<object> { pr1, pr2 };
 
             return ret;
         }
@@ -698,7 +700,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                 if (!string.IsNullOrEmpty(match.Groups["early"].Value))
                 {
                     var early = match.Groups["early"].Value;
-                    text = text.Replace(early, "");
+                    text = text.Replace(early, string.Empty);
                     hasEarly = true;
                     ret.Comment = Constants.Comment_Early;
                 }
@@ -706,7 +708,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                 if (!hasEarly && !string.IsNullOrEmpty(match.Groups["late"].Value))
                 {
                     var late = match.Groups["late"].Value;
-                    text = text.Replace(late, "");
+                    text = text.Replace(late, string.Empty);
                     hasLate = true;
                     ret.Comment = Constants.Comment_Late;
                 }
@@ -721,6 +723,7 @@ namespace Microsoft.Recognizers.Text.DateTime
             if (hasEarly)
             {
                 endHour = beginHour + 2;
+
                 // handling case: night end with 23:59
                 if (endMinSeg == 59)
                 {
@@ -736,17 +739,11 @@ namespace Microsoft.Recognizers.Text.DateTime
 
             ret.FutureValue = ret.PastValue = new Tuple<DateObject, DateObject>(
                 DateObject.MinValue.SafeCreateFromValue(year, month, day, beginHour, 0, 0),
-                DateObject.MinValue.SafeCreateFromValue(year, month, day, endHour, endMinSeg, endMinSeg)
-                );
+                DateObject.MinValue.SafeCreateFromValue(year, month, day, endHour, endMinSeg, endMinSeg));
 
             ret.Success = true;
 
             return ret;
-        }
-
-        public List<DateTimeParseResult> FilterResults(string query, List<DateTimeParseResult> candidateResults)
-        {
-            return candidateResults;
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseTimePeriodParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseTimePeriodParser.cs
@@ -177,7 +177,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                         // parse "pm"
                         var leftDesc = match.Groups["leftDesc"].Value;
                         var rightDesc = match.Groups["rightDesc"].Value;
-                        var timePmStr = match.Groups[Constants.PmGroupName].Value;
+                        var matchPmStr = match.Groups[Constants.PmGroupName].Value;
                         var timeAmStr = match.Groups[Constants.AmGroupName].Value;
                         var descStr = match.Groups[Constants.DescGroupName].Value;
 
@@ -209,7 +209,7 @@ namespace Microsoft.Recognizers.Text.DateTime
 
                                 isValid = true;
                             }
-                            else if (!string.IsNullOrEmpty(timePmStr) || rightPmValid)
+                            else if (!string.IsNullOrEmpty(matchPmStr) || rightPmValid)
                             {
                                 if (endHour < Constants.HalfDayHourCount)
                                 {

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseTimeParserConfiguration.cs
@@ -9,6 +9,17 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
 {
     public class PortugueseTimeParserConfiguration : BaseOptionsConfiguration, ITimeParserConfiguration
     {
+        public PortugueseTimeParserConfiguration(ICommonDateTimeParserConfiguration config)
+            : base(config)
+        {
+            TimeTokenPrefix = DateTimeDefinitions.TimeTokenPrefix;
+            AtRegex = PortugueseTimeExtractorConfiguration.AtRegex;
+            TimeRegexes = PortugueseTimeExtractorConfiguration.TimeRegexList;
+            UtilityConfiguration = config.UtilityConfiguration;
+            Numbers = config.Numbers;
+            TimeZoneParser = config.TimeZoneParser;
+        }
+
         public string TimeTokenPrefix { get; }
 
         public Regex AtRegex { get; }
@@ -22,16 +33,6 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
         public IDateTimeUtilityConfiguration UtilityConfiguration { get; }
 
         public IDateTimeParser TimeZoneParser { get; }
-
-        public PortugueseTimeParserConfiguration(ICommonDateTimeParserConfiguration config) : base(config)
-        {
-            TimeTokenPrefix = DateTimeDefinitions.TimeTokenPrefix;
-            AtRegex = PortugueseTimeExtractorConfiguration.AtRegex;
-            TimeRegexes = PortugueseTimeExtractorConfiguration.TimeRegexList;
-            UtilityConfiguration = config.UtilityConfiguration;
-            Numbers = config.Numbers;
-            TimeZoneParser = config.TimeZoneParser;
-        }
 
         public void AdjustByPrefix(string prefix, ref int hour, ref int min, ref bool hasMin)
         {
@@ -70,7 +71,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
                 trimedPrefix.EndsWith("depois das") || trimedPrefix.EndsWith("depois da") || trimedPrefix.EndsWith("depois do") ||
                 trimedPrefix.EndsWith("passadas as") || trimedPrefix.EndsWith("passadas das"))
             {
-                //deltaMin it's positive
+            // deltaMin it's positive
             }
             else if (trimedPrefix.EndsWith("para a") || trimedPrefix.EndsWith("para as") ||
                      trimedPrefix.EndsWith("pra") || trimedPrefix.EndsWith("pras") ||
@@ -102,23 +103,25 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
                 var oclockStr = match.Groups["oclock"].Value;
                 if (string.IsNullOrEmpty(oclockStr))
                 {
-                    var amStr = match.Groups[Constants.AmGroupName].Value;
-                    if (!string.IsNullOrEmpty(amStr))
+                    var strAm = match.Groups[Constants.AmGroupName].Value;
+                    if (!string.IsNullOrEmpty(strAm))
                     {
                         if (hour >= Constants.HalfDayHourCount)
                         {
                             deltaHour = -Constants.HalfDayHourCount;
                         }
+
                         hasAm = true;
                     }
 
-                    var pmStr = match.Groups[Constants.PmGroupName].Value;
-                    if (!string.IsNullOrEmpty(pmStr))
+                    var strPm = match.Groups[Constants.PmGroupName].Value;
+                    if (!string.IsNullOrEmpty(strPm))
                     {
                         if (hour < Constants.HalfDayHourCount)
                         {
                             deltaHour = Constants.HalfDayHourCount;
                         }
+
                         hasPm = true;
                     }
                 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseTimeParserConfiguration.cs
@@ -103,8 +103,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
                 var oclockStr = match.Groups["oclock"].Value;
                 if (string.IsNullOrEmpty(oclockStr))
                 {
-                    var strAm = match.Groups[Constants.AmGroupName].Value;
-                    if (!string.IsNullOrEmpty(strAm))
+                    var matchAmStr = match.Groups[Constants.AmGroupName].Value;
+                    if (!string.IsNullOrEmpty(matchAmStr))
                     {
                         if (hour >= Constants.HalfDayHourCount)
                         {

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseTimeParserConfiguration.cs
@@ -114,8 +114,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
                         hasAm = true;
                     }
 
-                    var strPm = match.Groups[Constants.PmGroupName].Value;
-                    if (!string.IsNullOrEmpty(strPm))
+                    var matchPmStr = match.Groups[Constants.PmGroupName].Value;
+                    if (!string.IsNullOrEmpty(matchPmStr))
                     {
                         if (hour < Constants.HalfDayHourCount)
                         {

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishTimeParserConfiguration.cs
@@ -112,8 +112,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
                         hasAm = true;
                     }
 
-                    var strPm = match.Groups[Constants.PmGroupName].Value;
-                    if (!string.IsNullOrEmpty(strPm))
+                    var matchPmStr = match.Groups[Constants.PmGroupName].Value;
+                    if (!string.IsNullOrEmpty(matchPmStr))
                     {
                         if (hour < Constants.HalfDayHourCount)
                         {

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishTimeParserConfiguration.cs
@@ -101,8 +101,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
                 var oclockStr = match.Groups["oclock"].Value;
                 if (string.IsNullOrEmpty(oclockStr))
                 {
-                    var strAm = match.Groups[Constants.AmGroupName].Value;
-                    if (!string.IsNullOrEmpty(strAm))
+                    var matchAmStr = match.Groups[Constants.AmGroupName].Value;
+                    if (!string.IsNullOrEmpty(matchAmStr))
                     {
                         if (hour >= Constants.HalfDayHourCount)
                         {

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishTimeParserConfiguration.cs
@@ -9,6 +9,17 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
 {
     public class SpanishTimeParserConfiguration : BaseOptionsConfiguration, ITimeParserConfiguration
     {
+        public SpanishTimeParserConfiguration(ICommonDateTimeParserConfiguration config)
+            : base(config)
+        {
+            TimeTokenPrefix = DateTimeDefinitions.TimeTokenPrefix;
+            AtRegex = SpanishTimeExtractorConfiguration.AtRegex;
+            TimeRegexes = SpanishTimeExtractorConfiguration.TimeRegexList;
+            UtilityConfiguration = config.UtilityConfiguration;
+            Numbers = config.Numbers;
+            TimeZoneParser = config.TimeZoneParser;
+        }
+
         public string TimeTokenPrefix { get; }
 
         public Regex AtRegex { get; }
@@ -22,16 +33,6 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
         public IDateTimeUtilityConfiguration UtilityConfiguration { get; }
 
         public IDateTimeParser TimeZoneParser { get; }
-
-        public SpanishTimeParserConfiguration(ICommonDateTimeParserConfiguration config) : base(config)
-        {
-            TimeTokenPrefix = DateTimeDefinitions.TimeTokenPrefix;
-            AtRegex = SpanishTimeExtractorConfiguration.AtRegex;
-            TimeRegexes = SpanishTimeExtractorConfiguration.TimeRegexList;
-            UtilityConfiguration = config.UtilityConfiguration;
-            Numbers = config.Numbers;
-            TimeZoneParser = config.TimeZoneParser;
-        }
 
         public void AdjustByPrefix(string prefix, ref int hour, ref int min, ref bool hasMin)
         {
@@ -69,7 +70,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
                 trimedPrefix.EndsWith("pasadas las") || trimedPrefix.EndsWith("pasados las") ||
                 trimedPrefix.EndsWith("pasadas de las") || trimedPrefix.EndsWith("pasados de las"))
             {
-                //deltaMin it's positive
+            // deltaMin it's positive
             }
             else if (trimedPrefix.EndsWith("para la") || trimedPrefix.EndsWith("para las") ||
                      trimedPrefix.EndsWith("antes de la") || trimedPrefix.EndsWith("antes de las"))
@@ -100,23 +101,25 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
                 var oclockStr = match.Groups["oclock"].Value;
                 if (string.IsNullOrEmpty(oclockStr))
                 {
-                    var amStr = match.Groups[Constants.AmGroupName].Value;
-                    if (!string.IsNullOrEmpty(amStr))
+                    var strAm = match.Groups[Constants.AmGroupName].Value;
+                    if (!string.IsNullOrEmpty(strAm))
                     {
                         if (hour >= Constants.HalfDayHourCount)
                         {
                             deltaHour = -Constants.HalfDayHourCount;
                         }
+
                         hasAm = true;
                     }
 
-                    var pmStr = match.Groups[Constants.PmGroupName].Value;
-                    if (!string.IsNullOrEmpty(pmStr))
+                    var strPm = match.Groups[Constants.PmGroupName].Value;
+                    if (!string.IsNullOrEmpty(strPm))
                     {
                         if (hour < Constants.HalfDayHourCount)
                         {
                             deltaHour = Constants.HalfDayHourCount;
                         }
+
                         hasPm = true;
                     }
                 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/Token.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/Token.cs
@@ -13,9 +13,10 @@ namespace Microsoft.Recognizers.Text.DateTime
         }
 
         public int Start { get; }
-        public int End { get; }
-        public Metadata Metadata { get; }
 
+        public int End { get; }
+
+        public Metadata Metadata { get; }
 
         public int Length
         {
@@ -25,6 +26,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                 {
                     return 0;
                 }
+
                 return End - Start;
             }
         }
@@ -39,30 +41,30 @@ namespace Microsoft.Recognizers.Text.DateTime
             {
                 if (token != null)
                 {
-                    var bAdd = true;
-                    for (var index = 0; index < mergedTokens.Count && bAdd; index++)
+                    bool shouldAdd = true;
+                    for (var index = 0; index < mergedTokens.Count && shouldAdd; index++)
                     {
                         // It is included in one of the current tokens
                         if (token.Start >= mergedTokens[index].Start && token.End <= mergedTokens[index].End)
                         {
-                            bAdd = false;
+                            shouldAdd = false;
                         }
 
                         // If it contains overlaps
                         if (token.Start > mergedTokens[index].Start && token.Start < mergedTokens[index].End)
                         {
-                            bAdd = false;
+                            shouldAdd = false;
                         }
 
                         // It includes one of the tokens and should replace the included one
                         if (token.Start <= mergedTokens[index].Start && token.End >= mergedTokens[index].End)
                         {
-                            bAdd = false;
+                            shouldAdd = false;
                             mergedTokens[index] = token;
                         }
                     }
 
-                    if (bAdd)
+                    if (shouldAdd)
                     {
                         mergedTokens.Add(token);
                     }
@@ -82,7 +84,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                     Text = substr,
                     Type = extractorName,
                     Data = null,
-                    Metadata = token.Metadata
+                    Metadata = token.Metadata,
                 };
 
                 ret.Add(er);


### PR DESCRIPTION
- Renamed variables.
- Fixed spacing.
- Reordered methods, properties and using statements.
- Added parenthesis and trailing commas when needed.