### PR TITLE
[Java][Datetime] Port SpanishDateTimeAltParserConfiguration and SpanishSetParserConfiguration from C# to Java

### DIFF
--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/english/parsers/EnglishCommonDateTimeParserConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/english/parsers/EnglishCommonDateTimeParserConfiguration.java
@@ -44,8 +44,6 @@ import java.util.regex.Pattern;
 
 public class EnglishCommonDateTimeParserConfiguration extends BaseDateParserConfiguration implements ICommonDateTimeParserConfiguration {
 
-    public static final Pattern AmbiguousMonthP0Regex = RegExpUtility.getSafeRegExp(EnglishDateTime.AmbiguousMonthP0Regex);
-
     private final IDateTimeUtilityConfiguration utilityConfiguration;
 
     private final ImmutableMap<String, String> unitMap;
@@ -223,11 +221,6 @@ public class EnglishCommonDateTimeParserConfiguration extends BaseDateParserConf
     @Override
     public IDateTimeParser getTimeZoneParser() {
         return timeZoneParser;
-    }
-
-    @Override
-    public Pattern getAmbiguousMonthP0Regex() {
-        return AmbiguousMonthP0Regex;
     }
 
     @Override

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/parsers/BaseDateTimePeriodParser.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/parsers/BaseDateTimePeriodParser.java
@@ -32,7 +32,7 @@ import org.javatuples.Pair;
 
 public class BaseDateTimePeriodParser implements IDateTimeParser {
 
-    private final IDateTimePeriodParserConfiguration config;
+    protected final IDateTimePeriodParserConfiguration config;
 
     public BaseDateTimePeriodParser(IDateTimePeriodParserConfiguration config) {
         this.config = config;
@@ -504,7 +504,7 @@ public class BaseDateTimePeriodParser implements IDateTimeParser {
     }
 
     // Parse specific TimeOfDay like "this night", "early morning", "late evening"
-    private DateTimeResolutionResult parseSpecificTimeOfDay(String text, LocalDateTime referenceDate) {
+    protected DateTimeResolutionResult parseSpecificTimeOfDay(String text, LocalDateTime referenceDate) {
         DateTimeResolutionResult result = new DateTimeResolutionResult();
         String trimmedText = text.trim().toLowerCase();
         String timeText = trimmedText;

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/parsers/BaseMergedDateTimeParser.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/parsers/BaseMergedDateTimeParser.java
@@ -263,21 +263,6 @@ public class BaseMergedDateTimeParser implements IDateTimeParser {
 
     @Override
     public List<DateTimeParseResult> filterResults(String query, List<DateTimeParseResult> candidateResults) {
-        if (config.getAmbiguousMonthP0Regex() != null) {
-            if (candidateResults != null && !candidateResults.isEmpty()) {
-
-                List<Match> matches = Arrays.asList(RegExpUtility.getMatches(config.getAmbiguousMonthP0Regex(), query));
-
-                for (Match match : matches) {
-                    // Check for intersections/overlaps
-                    candidateResults = candidateResults.stream().filter(
-                        c -> filterResultsPredicate(c, match))
-                        .collect(Collectors.toList());
-                }
-
-            }
-        }
-
         return candidateResults;
     }
 

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/parsers/BaseSetParser.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/parsers/BaseSetParser.java
@@ -93,7 +93,7 @@ public class BaseSetParser implements IDateTimeParser {
                 er.getData(),
                 value,
                 "",
-                value.getTimex()
+                value == null ? "" : value.getTimex()
         );
 
         return ret;

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/parsers/config/ICommonDateTimeParserConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/parsers/config/ICommonDateTimeParserConfiguration.java
@@ -52,8 +52,6 @@ public interface ICommonDateTimeParserConfiguration extends IOptionsConfiguratio
 
     IDateTimeParser getTimeZoneParser();
 
-    Pattern getAmbiguousMonthP0Regex();
-
     ImmutableMap<String, Integer> getMonthOfYear();
 
     ImmutableMap<String, Integer> getNumbers();

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/resources/SpanishDateTime.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/resources/SpanishDateTime.java
@@ -49,9 +49,9 @@ public class SpanishDateTime {
             .replace("{BaseDateTime.FourDigitYearRegex}", BaseDateTime.FourDigitYearRegex)
             .replace("{FullTextYearRegex}", FullTextYearRegex);
 
-    public static final String RelativeMonthRegex = "(?<relmonth>(este|pr[oó]ximo|[uú]ltimo)\\s+mes)\\b";
+    public static final String RelativeMonthRegex = "(?<relmonth>((este|pr[oó]ximo|[uú]ltimo)\\s+mes)|(mes\\s+que\\s+viene))\\b";
 
-    public static final String MonthRegex = "\\b(?<month>abril|abr|agosto|ago|diciembre|dic|febrero|feb|enero|ene|julio|jul|junio|jun|marzo|mar|mayo|may|noviembre|nov|octubre|oct|septiembre|setiembre|sept|set)\\b";
+    public static final String MonthRegex = "\\b(?<month>abril|abr|agosto|ago|diciembre|dic|febrero|feb|enero|ene|julio|jul|junio|jun|marzo|mar|mayo|may|noviembre|nov|octubre|oct|septiembre|setiembre|sept|set|sep)\\b";
 
     public static final String MonthSuffixRegex = "(?<msuf>(en\\s+|del\\s+|de\\s+)?({RelativeMonthRegex}|{MonthRegex}))"
             .replace("{RelativeMonthRegex}", RelativeMonthRegex)
@@ -63,33 +63,35 @@ public class SpanishDateTime {
 
     public static final String FutureRegex = "(?<past>\\b(siguiente(s)?|pr[oó]xim[oa](s)?|dentro\\s+de|en)\\b)";
 
-    public static final String SimpleCasesRegex = "\\b((desde\\s+el|desde|del)\\s+)?({DayRegex})\\s*{TillRegex}\\s*({DayRegex})\\s+{MonthSuffixRegex}((\\s+|\\s*,\\s*){YearRegex})?\\b"
+    public static final String SimpleCasesRegex = "\\b((desde\\s+el|desde|del|de)\\s+)?({DayRegex})\\s*{TillRegex}\\s*({DayRegex})\\s+{MonthSuffixRegex}((\\s+|\\s*,\\s*)(en\\s+|del\\s+|de\\s+)?{YearRegex})?\\b"
             .replace("{DayRegex}", DayRegex)
             .replace("{TillRegex}", TillRegex)
             .replace("{MonthSuffixRegex}", MonthSuffixRegex)
             .replace("{YearRegex}", YearRegex);
 
-    public static final String MonthFrontSimpleCasesRegex = "\\b{MonthSuffixRegex}\\s+((desde\\s+el|desde|del)\\s+)?({DayRegex})\\s*{TillRegex}\\s*({DayRegex})((\\s+|\\s*,\\s*){YearRegex})?\\b"
+    public static final String MonthFrontSimpleCasesRegex = "\\b{MonthSuffixRegex}\\s+((desde\\s+el|desde|del)\\s+)?({DayRegex})\\s*{TillRegex}\\s*({DayRegex})((\\s+|\\s*,\\s*)(en\\s+|del\\s+|de\\s+)?{YearRegex})?\\b"
             .replace("{MonthSuffixRegex}", MonthSuffixRegex)
             .replace("{DayRegex}", DayRegex)
             .replace("{TillRegex}", TillRegex)
             .replace("{YearRegex}", YearRegex);
 
-    public static final String MonthFrontBetweenRegex = "\\b{MonthSuffixRegex}\\s+((entre|entre\\s+el)\\s+)({DayRegex})\\s*{AndRegex}\\s*({DayRegex})((\\s+|\\s*,\\s*){YearRegex})?\\b"
+    public static final String MonthFrontBetweenRegex = "\\b{MonthSuffixRegex}\\s+((entre|entre\\s+el)\\s+)({DayRegex})\\s*{AndRegex}\\s*({DayRegex})((\\s+|\\s*,\\s*)(en\\s+|del\\s+|de\\s+)?{YearRegex})?\\b"
             .replace("{DayRegex}", DayRegex)
             .replace("{AndRegex}", AndRegex)
             .replace("{MonthSuffixRegex}", MonthSuffixRegex)
             .replace("{YearRegex}", YearRegex);
 
-    public static final String DayBetweenRegex = "\\b((entre|entre\\s+el)\\s+)({DayRegex})\\s*{AndRegex}\\s*({DayRegex})\\s+{MonthSuffixRegex}((\\s+|\\s*,\\s*){YearRegex})?\\b"
+    public static final String DayBetweenRegex = "\\b((entre|entre\\s+el)\\s+)({DayRegex})(\\s+{MonthSuffixRegex})?\\s*{AndRegex}\\s*({DayRegex})\\s+{MonthSuffixRegex}((\\s+|\\s*,\\s*)(en\\s+|del\\s+|de\\s+)?{YearRegex})?\\b"
             .replace("{DayRegex}", DayRegex)
             .replace("{AndRegex}", AndRegex)
             .replace("{MonthSuffixRegex}", MonthSuffixRegex)
             .replace("{YearRegex}", YearRegex);
 
-    public static final String OneWordPeriodRegex = "\\b(((pr[oó]xim[oa]?|est[ea]|[uú]ltim[oa]?|en)\\s+)?(?<month>abril|abr|agosto|ago|diciembre|dic|febrero|feb|enero|ene|julio|jul|junio|jun|marzo|mar|mayo|may|noviembre|nov|octubre|oct|septiembre|setiembre|sept|set)|(?<=\\b(del|de la|el|la)\\s+)?(pr[oó]xim[oa](s)?|[uú]ltim[oa]?|est(e|a))\\s+(fin de semana|semana|mes|año)|fin de semana|(mes|años)? a la fecha)\\b";
+    public static final String OneWordPeriodRegex = "\\b(((pr[oó]xim[oa]?|est[ea]|[uú]ltim[oa]?)\\s+)?({MonthRegex})|(?<=\\b(del|de la|el|la)\\s+)?(pr[oó]xim[oa](s)?|[uú]ltim[oa]?|est(e|a))\\s+(fin de semana|semana|mes|año)|fin de semana|(mes|años)? a la fecha)\\b"
+            .replace("{MonthRegex}", MonthRegex);
 
-    public static final String MonthWithYearRegex = "\\b(((pr[oó]xim[oa](s)?|este|esta|[uú]ltim[oa]?|en)\\s+)?(?<month>abril|abr|agosto|ago|diciembre|dic|febrero|feb|enero|ene|julio|jul|junio|jun|marzo|mar|mayo|may|noviembre|nov|octubre|oct|septiembre|setiembre|sept|set)\\s+((de|del|de la)\\s+)?({YearRegex}|(?<order>pr[oó]ximo(s)?|[uú]ltimo?|este)\\s+año))\\b"
+    public static final String MonthWithYearRegex = "\\b(((pr[oó]xim[oa](s)?|este|esta|[uú]ltim[oa]?)\\s+)?({MonthRegex})\\s+((de|del|de la)\\s+)?({YearRegex}|(?<order>pr[oó]ximo(s)?|[uú]ltimo?|este)\\s+año))\\b"
+            .replace("{MonthRegex}", MonthRegex)
             .replace("{YearRegex}", YearRegex);
 
     public static final String MonthNumWithYearRegex = "({YearRegex}(\\s*?)[/\\-\\.](\\s*?){MonthNumRegex})|({MonthNumRegex}(\\s*?)[/\\-](\\s*?){YearRegex})"
@@ -129,7 +131,8 @@ public class SpanishDateTime {
 
     public static final String WeekOfRegex = "(semana)(\\s*)((do|da|de))";
 
-    public static final String MonthOfRegex = "(mes)(\\s*)((do|da|de))";
+    public static final String MonthOfRegex = "(mes)(\\s+)((do|da|de)\\s+){MonthRegex}"
+            .replace("{MonthRegex}", MonthRegex);
 
     public static final String RangeUnitRegex = "\\b(?<unit>años|año|meses|mes|semanas|semana)\\b";
 
@@ -143,7 +146,7 @@ public class SpanishDateTime {
 
     public static final String BetweenRegex = "(entre\\s*(la(s)?)?)";
 
-    public static final String WeekDayRegex = "\\b(?<weekday>domingos?|lunes|martes|mi[eé]rcoles|jueves|viernes|s[aá]bados?|lu|ma|mi|ju|vi|sa|do)\\b";
+    public static final String WeekDayRegex = "\\b(?<weekday>domingos?|lunes|martes|mi[eé]rcoles|jueves|viernes|s[aá]bados?|lun|mar|mi[eé]|jue|vie|s[aá]b|dom|lu|ma|mi|ju|vi|sa|do)\\b";
 
     public static final String OnRegex = "(?<=\\ben\\s+)({DayRegex}s?)\\b"
             .replace("{DayRegex}", DayRegex);
@@ -370,7 +373,7 @@ public class SpanishDateTime {
 
     public static final String TimeOfDayRegex = "\\b(?<timeOfDay>mañana|madrugada|(pasado\\s+(el\\s+)?)?medio\\s?d[ií]a|tarde|noche|anoche)\\b";
 
-    public static final String SpecificTimeOfDayRegex = "\\b(((((a)?\\s+la|esta|siguiente|pr[oó]xim[oa]|[uú]ltim[oa])\\s+)?{TimeOfDayRegex}))\\b"
+    public static final String SpecificTimeOfDayRegex = "\\b(((((a\\s+)?la|esta|siguiente|pr[oó]xim[oa]|[uú]ltim[oa])\\s+)?{TimeOfDayRegex}))\\b"
             .replace("{TimeOfDayRegex}", TimeOfDayRegex);
 
     public static final String TimeOfTodayAfterRegex = "^\\s*(,\\s*)?(en|de(l)?\\s+)?{SpecificTimeOfDayRegex}"

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/extractors/SpanishDateTimePeriodExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/extractors/SpanishDateTimePeriodExtractorConfiguration.java
@@ -26,7 +26,7 @@ public class SpanishDateTimePeriodExtractorConfiguration extends BaseOptionsConf
     implements IDateTimePeriodExtractorConfiguration {
 
     public static final Pattern weekDayRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.WeekDayRegex);
-    public static final Pattern TimeNumberCombinedWithUnit = RegExpUtility.getSafeRegExp(SpanishDateTime.TimeNumberCombinedWithUnit);
+    public static final Pattern NumberCombinedWithUnit = RegExpUtility.getSafeRegExp(SpanishDateTime.DateTimePeriodNumberCombinedWithUnit);
     public static final Pattern RestOfDateTimeRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.RestOfDateTimeRegex);
     public static final Pattern PeriodTimeOfDayWithDateRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.PeriodTimeOfDayWithDateRegex);
     public static final Pattern RelativeTimeUnitRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.RelativeTimeUnitRegex);
@@ -173,7 +173,7 @@ public class SpanishDateTimePeriodExtractorConfiguration extends BaseOptionsConf
 
     @Override
     public Pattern getNumberCombinedWithUnit() {
-        return TimeNumberCombinedWithUnit;
+        return NumberCombinedWithUnit;
     }
 
     @Override

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/parsers/DateTimePeriodParser.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/parsers/DateTimePeriodParser.java
@@ -1,0 +1,156 @@
+package com.microsoft.recognizers.text.datetime.spanish.parsers;
+
+import com.microsoft.recognizers.text.ExtractResult;
+import com.microsoft.recognizers.text.datetime.parsers.BaseDateTimePeriodParser;
+import com.microsoft.recognizers.text.datetime.parsers.DateTimeParseResult;
+import com.microsoft.recognizers.text.datetime.parsers.config.IDateTimePeriodParserConfiguration;
+import com.microsoft.recognizers.text.datetime.parsers.config.MatchedTimeRangeResult;
+import com.microsoft.recognizers.text.datetime.resources.SpanishDateTime;
+import com.microsoft.recognizers.text.datetime.utilities.DateTimeFormatUtil;
+import com.microsoft.recognizers.text.datetime.utilities.DateTimeResolutionResult;
+import com.microsoft.recognizers.text.datetime.utilities.DateUtil;
+import com.microsoft.recognizers.text.datetime.utilities.RegexExtension;
+import com.microsoft.recognizers.text.utilities.Match;
+import com.microsoft.recognizers.text.utilities.RegExpUtility;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+
+import org.javatuples.Pair;
+
+public class DateTimePeriodParser extends BaseDateTimePeriodParser {
+
+    public DateTimePeriodParser(IDateTimePeriodParserConfiguration configuration) {
+
+        super(configuration);
+    }
+
+    @Override
+    protected DateTimeResolutionResult parseSpecificTimeOfDay(String text, LocalDateTime referenceTime) {
+        DateTimeResolutionResult ret = new DateTimeResolutionResult();
+        String trimmedText = text.trim().toLowerCase(Locale.ROOT);
+
+        // handle morning, afternoon..
+        MatchedTimeRangeResult matchedTimeRangeResult = this.config.getMatchedTimeRange(trimmedText, "-1", -1, -1, -1);
+        if (!matchedTimeRangeResult.getMatched()) {
+            return ret;
+        }
+
+        boolean exactMatch = RegexExtension.isExactMatch(this.config.getSpecificTimeOfDayRegex(),trimmedText, true);
+
+        if (exactMatch) {
+            int swift = this.config.getSwiftPrefix(trimmedText);
+            LocalDateTime date = referenceTime.plusDays(swift);
+            int day = date.getDayOfMonth();
+            int month = date.getMonthValue();
+            int year = date.getYear();
+
+            ret.setTimex(DateTimeFormatUtil.formatDate(date) + matchedTimeRangeResult.getTimeStr());
+            ret.setFutureValue(new Pair<>(
+                DateUtil.safeCreateFromValue(
+                    date,
+                    year,
+                    month,
+                    day,
+                    matchedTimeRangeResult.getBeginHour(),
+                    0,
+                    0),
+                DateUtil.safeCreateFromValue(
+                    date,
+                    year,
+                    month,
+                    day,
+                    matchedTimeRangeResult.getEndHour(),
+                    matchedTimeRangeResult.getEndMin(),
+                    matchedTimeRangeResult.getEndMin())));
+            ret.setPastValue(new Pair<>(
+                DateUtil.safeCreateFromValue(
+                    date,
+                    year,
+                    month,
+                    day,
+                    matchedTimeRangeResult.getBeginHour(),
+                    0,
+                    0),
+                DateUtil.safeCreateFromValue(date,
+                    year,
+                    month,
+                    day,
+                    matchedTimeRangeResult.getEndHour(),
+                    matchedTimeRangeResult.getEndMin(),
+                    matchedTimeRangeResult.getEndMin())));
+            ret.setSuccess(true);
+
+            return ret;
+        }
+
+        int startIndex = trimmedText.indexOf(SpanishDateTime.Tomorrow);
+        if (startIndex == 0) {
+            startIndex = SpanishDateTime.Tomorrow.length();
+        } else {
+            startIndex = 0;
+        }
+
+        // handle Date followed by morning, afternoon
+        // Add handling code to handle morning, afternoon followed by Date
+        // Add handling code to handle early/late morning, afternoon
+        Optional<Match> match = Arrays.stream(RegExpUtility.getMatches(this.config .getTimeOfDayRegex(), trimmedText.substring(startIndex))).findFirst();
+        if (match.isPresent()) {
+            String beforeStr = trimmedText.substring(0, match.get().index).trim();
+            List<ExtractResult> ers = this.config.getDateExtractor().extract(beforeStr, referenceTime);
+
+            if (ers.size() == 0) {
+                return ret;
+            }
+
+            DateTimeParseResult pr = this.config.getDateParser().parse(ers.get(0), referenceTime);
+            LocalDateTime futureDate = (LocalDateTime)((DateTimeResolutionResult)pr.getValue()).getFutureValue();
+            LocalDateTime pastDate = (LocalDateTime)((DateTimeResolutionResult)pr.getValue()).getPastValue();
+
+            ret.setTimex(pr.getTimexStr() + matchedTimeRangeResult.getTimeStr());
+
+            ret.setFutureValue(new Pair<>(
+                DateUtil.safeCreateFromValue(
+                    futureDate,
+                    futureDate.getYear(),
+                    futureDate.getMonthValue(),
+                    futureDate.getDayOfMonth(),
+                    matchedTimeRangeResult.getBeginHour(),
+                    0,
+                    0),
+                DateUtil.safeCreateFromValue(
+                    futureDate,
+                    futureDate.getYear(),
+                    futureDate.getMonthValue(),
+                    futureDate.getDayOfMonth(),
+                    matchedTimeRangeResult.getEndHour(),
+                    matchedTimeRangeResult.getEndMin(),
+                    matchedTimeRangeResult.getEndMin())));
+            ret.setPastValue(new Pair<>(
+                DateUtil.safeCreateFromValue(pastDate,
+                    pastDate.getYear(),
+                    pastDate.getMonthValue(),
+                    pastDate.getDayOfMonth(),
+                    matchedTimeRangeResult.getBeginHour(),
+                    0,
+                    0),
+                DateUtil.safeCreateFromValue(
+                    pastDate,
+                    pastDate.getYear(),
+                    pastDate.getMonthValue(),
+                    pastDate.getDayOfMonth(),
+                    matchedTimeRangeResult.getEndHour(),
+                    matchedTimeRangeResult.getEndMin(),
+                    matchedTimeRangeResult.getEndMin())));
+            ret.setSuccess(true);
+
+            return ret;
+        }
+
+        return ret;
+    }
+
+}

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/parsers/DateTimePeriodParser.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/parsers/DateTimePeriodParser.java
@@ -51,37 +51,14 @@ public class DateTimePeriodParser extends BaseDateTimePeriodParser {
             ret.setTimex(DateTimeFormatUtil.formatDate(date) + matchedTimeRangeResult.getTimeStr());
             ret.setFutureValue(new Pair<>(
                 DateUtil.safeCreateFromValue(
-                    date,
-                    year,
-                    month,
-                    day,
-                    matchedTimeRangeResult.getBeginHour(),
-                    0,
-                    0),
+                    date, year, month, day, matchedTimeRangeResult.getBeginHour(), 0, 0),
                 DateUtil.safeCreateFromValue(
-                    date,
-                    year,
-                    month,
-                    day,
-                    matchedTimeRangeResult.getEndHour(),
-                    matchedTimeRangeResult.getEndMin(),
-                    matchedTimeRangeResult.getEndMin())));
+                    date, year, month, day, matchedTimeRangeResult.getEndHour(), matchedTimeRangeResult.getEndMin(), matchedTimeRangeResult.getEndMin())));
             ret.setPastValue(new Pair<>(
                 DateUtil.safeCreateFromValue(
-                    date,
-                    year,
-                    month,
-                    day,
-                    matchedTimeRangeResult.getBeginHour(),
-                    0,
-                    0),
-                DateUtil.safeCreateFromValue(date,
-                    year,
-                    month,
-                    day,
-                    matchedTimeRangeResult.getEndHour(),
-                    matchedTimeRangeResult.getEndMin(),
-                    matchedTimeRangeResult.getEndMin())));
+                    date, year, month, day, matchedTimeRangeResult.getBeginHour(), 0, 0),
+                DateUtil.safeCreateFromValue(
+                    date, year, month, day, matchedTimeRangeResult.getEndHour(), matchedTimeRangeResult.getEndMin(), matchedTimeRangeResult.getEndMin())));
             ret.setSuccess(true);
 
             return ret;

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/parsers/SpanishCommonDateTimeParserConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/parsers/SpanishCommonDateTimeParserConfiguration.java
@@ -72,6 +72,7 @@ public class SpanishCommonDateTimeParserConfiguration extends BaseDateParserConf
     private final IDateTimeExtractor timePeriodExtractor;
     private final IDateTimeExtractor dateTimePeriodExtractor;
 
+    private final IDateTimeParser timeZoneParser;
     private final IDateTimeParser dateParser;
     private final IDateTimeParser timeParser;
     private final IDateTimeParser dateTimeParser;
@@ -79,7 +80,7 @@ public class SpanishCommonDateTimeParserConfiguration extends BaseDateParserConf
     private final IDateTimeParser datePeriodParser;
     private final IDateTimeParser timePeriodParser;
     private final IDateTimeParser dateTimePeriodParser;
-    //private final IDateTimeParser dateTimeAltParser;
+    private final IDateTimeParser dateTimeAltParser;
 
     public SpanishCommonDateTimeParserConfiguration(DateTimeOptions options) {
 
@@ -112,6 +113,7 @@ public class SpanishCommonDateTimeParserConfiguration extends BaseDateParserConf
         timePeriodExtractor = new BaseTimePeriodExtractor(new SpanishTimePeriodExtractorConfiguration(options));
         dateTimePeriodExtractor = new BaseDateTimePeriodExtractor(new SpanishDateTimePeriodExtractorConfiguration(options));
 
+        timeZoneParser = new BaseTimeZoneParser();
         dateParser = new BaseDateParser(new SpanishDateParserConfiguration(this));
         timeParser = new TimeParser(new SpanishTimeParserConfiguration(this));
         dateTimeParser = new BaseDateTimeParser(new SpanishDateTimeParserConfiguration(this));
@@ -119,7 +121,7 @@ public class SpanishCommonDateTimeParserConfiguration extends BaseDateParserConf
         datePeriodParser = new BaseDatePeriodParser(new SpanishDatePeriodParserConfiguration(this));
         timePeriodParser = new BaseTimePeriodParser(new SpanishTimePeriodParserConfiguration(this));
         dateTimePeriodParser = new BaseDateTimePeriodParser(new SpanishDateTimePeriodParserConfiguration(this));
-        //dateTimeAltParser = new BaseDateTimeAltParser(new SpanishDateTimeAltParserConfiguration(this));
+        dateTimeAltParser = new BaseDateTimeAltParser(new SpanishDateTimeAltParserConfiguration(this));
     }
 
     @Override
@@ -214,17 +216,11 @@ public class SpanishCommonDateTimeParserConfiguration extends BaseDateParserConf
 
     @Override
     public IDateTimeParser getDateTimeAltParser() {
-        //return dateTimeAltParser;
-        return null;
+        return dateTimeAltParser;
     }
 
     @Override public IDateTimeParser getTimeZoneParser() {
-        return null;
-    }
-
-    @Override
-    public Pattern getAmbiguousMonthP0Regex() {
-        return null;
+        return timeZoneParser;
     }
 
     @Override

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/parsers/SpanishCommonDateTimeParserConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/parsers/SpanishCommonDateTimeParserConfiguration.java
@@ -78,7 +78,7 @@ public class SpanishCommonDateTimeParserConfiguration extends BaseDateParserConf
     private final IDateTimeParser durationParser;
     private final IDateTimeParser datePeriodParser;
     private final IDateTimeParser timePeriodParser;
-    //private final IDateTimeParser dateTimePeriodParser;
+    private final IDateTimeParser dateTimePeriodParser;
     //private final IDateTimeParser dateTimeAltParser;
 
     public SpanishCommonDateTimeParserConfiguration(DateTimeOptions options) {
@@ -118,7 +118,7 @@ public class SpanishCommonDateTimeParserConfiguration extends BaseDateParserConf
         durationParser = new BaseDurationParser(new SpanishDurationParserConfiguration(this));
         datePeriodParser = new BaseDatePeriodParser(new SpanishDatePeriodParserConfiguration(this));
         timePeriodParser = new BaseTimePeriodParser(new SpanishTimePeriodParserConfiguration(this));
-        //dateTimePeriodParser = new BaseDateTimePeriodParser(new SpanishDateTimePeriodParserConfiguration(this));
+        dateTimePeriodParser = new BaseDateTimePeriodParser(new SpanishDateTimePeriodParserConfiguration(this));
         //dateTimeAltParser = new BaseDateTimeAltParser(new SpanishDateTimeAltParserConfiguration(this));
     }
 
@@ -209,8 +209,7 @@ public class SpanishCommonDateTimeParserConfiguration extends BaseDateParserConf
 
     @Override
     public IDateTimeParser getDateTimePeriodParser() {
-        //return dateTimePeriodParser;
-        return null;
+        return dateTimePeriodParser;
     }
 
     @Override

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/parsers/SpanishCommonDateTimeParserConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/parsers/SpanishCommonDateTimeParserConfiguration.java
@@ -74,7 +74,7 @@ public class SpanishCommonDateTimeParserConfiguration extends BaseDateParserConf
 
     private final IDateTimeParser dateParser;
     private final IDateTimeParser timeParser;
-    //private final IDateTimeParser dateTimeParser;
+    private final IDateTimeParser dateTimeParser;
     private final IDateTimeParser durationParser;
     private final IDateTimeParser datePeriodParser;
     private final IDateTimeParser timePeriodParser;
@@ -114,7 +114,7 @@ public class SpanishCommonDateTimeParserConfiguration extends BaseDateParserConf
 
         dateParser = new BaseDateParser(new SpanishDateParserConfiguration(this));
         timeParser = new TimeParser(new SpanishTimeParserConfiguration(this));
-        //dateTimeParser = new BaseDateTimeParser(new SpanishDateTimeParserConfiguration(this));
+        dateTimeParser = new BaseDateTimeParser(new SpanishDateTimeParserConfiguration(this));
         durationParser = new BaseDurationParser(new SpanishDurationParserConfiguration(this));
         datePeriodParser = new BaseDatePeriodParser(new SpanishDatePeriodParserConfiguration(this));
         timePeriodParser = new BaseTimePeriodParser(new SpanishTimePeriodParserConfiguration(this));
@@ -189,8 +189,7 @@ public class SpanishCommonDateTimeParserConfiguration extends BaseDateParserConf
 
     @Override
     public IDateTimeParser getDateTimeParser() {
-        //return dateTimeParser;
-        return null;
+        return dateTimeParser;
     }
 
     @Override

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/parsers/SpanishCommonDateTimeParserConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/parsers/SpanishCommonDateTimeParserConfiguration.java
@@ -284,7 +284,3 @@ public class SpanishCommonDateTimeParserConfiguration extends BaseDateParserConf
         return utilityConfiguration;
     }
 }
-    public IDateTimeUtilityConfiguration getUtilityConfiguration() {
-        return utilityConfiguration;
-    }
-}

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/parsers/SpanishCommonDateTimeParserConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/parsers/SpanishCommonDateTimeParserConfiguration.java
@@ -285,3 +285,7 @@ public class SpanishCommonDateTimeParserConfiguration extends BaseDateParserConf
         return utilityConfiguration;
     }
 }
+    public IDateTimeUtilityConfiguration getUtilityConfiguration() {
+        return utilityConfiguration;
+    }
+}

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/parsers/SpanishCommonDateTimeParserConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/parsers/SpanishCommonDateTimeParserConfiguration.java
@@ -76,7 +76,7 @@ public class SpanishCommonDateTimeParserConfiguration extends BaseDateParserConf
     private final IDateTimeParser timeParser;
     //private final IDateTimeParser dateTimeParser;
     private final IDateTimeParser durationParser;
-    //private final IDateTimeParser datePeriodParser;
+    private final IDateTimeParser datePeriodParser;
     private final IDateTimeParser timePeriodParser;
     //private final IDateTimeParser dateTimePeriodParser;
     //private final IDateTimeParser dateTimeAltParser;
@@ -116,7 +116,7 @@ public class SpanishCommonDateTimeParserConfiguration extends BaseDateParserConf
         timeParser = new TimeParser(new SpanishTimeParserConfiguration(this));
         //dateTimeParser = new BaseDateTimeParser(new SpanishDateTimeParserConfiguration(this));
         durationParser = new BaseDurationParser(new SpanishDurationParserConfiguration(this));
-        //datePeriodParser = new BaseDatePeriodParser(new SpanishDatePeriodParserConfiguration(this));
+        datePeriodParser = new BaseDatePeriodParser(new SpanishDatePeriodParserConfiguration(this));
         timePeriodParser = new BaseTimePeriodParser(new SpanishTimePeriodParserConfiguration(this));
         //dateTimePeriodParser = new BaseDateTimePeriodParser(new SpanishDateTimePeriodParserConfiguration(this));
         //dateTimeAltParser = new BaseDateTimeAltParser(new SpanishDateTimeAltParserConfiguration(this));
@@ -200,8 +200,7 @@ public class SpanishCommonDateTimeParserConfiguration extends BaseDateParserConf
 
     @Override
     public IDateTimeParser getDatePeriodParser() {
-        //return datePeriodParser;
-        return null;
+        return datePeriodParser;
     }
 
     @Override

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/parsers/SpanishDatePeriodParserConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/parsers/SpanishDatePeriodParserConfiguration.java
@@ -22,6 +22,12 @@ import java.util.regex.Pattern;
 
 public class SpanishDatePeriodParserConfiguration extends BaseOptionsConfiguration implements IDatePeriodParserConfiguration {
 
+    public static final Pattern nextPrefixRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.NextPrefixRegex);
+    public static final Pattern pastPrefixRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.PastPrefixRegex);
+    public static final Pattern thisPrefixRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.ThisPrefixRegex);
+    public static final Pattern relativeRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.RelativeRegex);
+    public static final Pattern unspecificEndOfRangeRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.UnspecificEndOfRangeRegex);
+
     public SpanishDatePeriodParserConfiguration(ICommonDateTimeParserConfiguration config) {
         super(config.getOptions());
 
@@ -80,13 +86,6 @@ public class SpanishDatePeriodParserConfiguration extends BaseOptionsConfigurati
         numbers = config.getNumbers();
         writtenDecades = config.getWrittenDecades();
         specialDecadeCases = config.getSpecialDecadeCases();
-
-        nextPrefixRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.NextPrefixRegex);
-        pastPrefixRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.PastPrefixRegex);
-        thisPrefixRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.ThisPrefixRegex);
-        relativeRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.RelativeRegex);
-        unspecificEndOfRangeRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.UnspecificEndOfRangeRegex);
-        afterNextSuffixRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.AfterNextSuffixRegex);
     }
 
     // Regex
@@ -182,18 +181,6 @@ public class SpanishDatePeriodParserConfiguration extends BaseOptionsConfigurati
     private final Pattern moreThanRegex;
 
     private final Pattern centurySuffixRegex;
-
-    private final Pattern nextPrefixRegex;
-
-    private final Pattern pastPrefixRegex;
-
-    private final Pattern thisPrefixRegex;
-
-    private final Pattern relativeRegex;
-
-    private final Pattern unspecificEndOfRangeRegex;
-
-    private final Pattern afterNextSuffixRegex;
 
     // Dictionaries
     private final ImmutableMap<String, String> unitMap;

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/parsers/SpanishDatePeriodParserConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/parsers/SpanishDatePeriodParserConfiguration.java
@@ -1,0 +1,596 @@
+package com.microsoft.recognizers.text.datetime.spanish.parsers;
+
+import com.google.common.collect.ImmutableMap;
+import com.microsoft.recognizers.text.IExtractor;
+import com.microsoft.recognizers.text.IParser;
+import com.microsoft.recognizers.text.datetime.config.BaseOptionsConfiguration;
+import com.microsoft.recognizers.text.datetime.extractors.IDateExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.IDateTimeExtractor;
+import com.microsoft.recognizers.text.datetime.parsers.IDateTimeParser;
+import com.microsoft.recognizers.text.datetime.parsers.config.ICommonDateTimeParserConfiguration;
+import com.microsoft.recognizers.text.datetime.parsers.config.IDatePeriodParserConfiguration;
+import com.microsoft.recognizers.text.datetime.resources.EnglishDateTime;
+import com.microsoft.recognizers.text.datetime.resources.SpanishDateTime;
+import com.microsoft.recognizers.text.datetime.spanish.extractors.SpanishDatePeriodExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.spanish.extractors.SpanishDurationExtractorConfiguration;
+import com.microsoft.recognizers.text.utilities.Match;
+import com.microsoft.recognizers.text.utilities.RegExpUtility;
+
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+public class SpanishDatePeriodParserConfiguration extends BaseOptionsConfiguration implements IDatePeriodParserConfiguration {
+
+    public SpanishDatePeriodParserConfiguration(ICommonDateTimeParserConfiguration config) {
+        super(config.getOptions());
+
+        tokenBeforeDate = SpanishDateTime.TokenBeforeDate;
+        cardinalExtractor = config.getCardinalExtractor();
+        ordinalExtractor = config.getOrdinalExtractor();
+        integerExtractor = config.getIntegerExtractor();
+        numberParser = config.getNumberParser();
+        durationExtractor = config.getDurationExtractor();
+        dateExtractor = config.getDateExtractor();
+        durationParser = config.getDurationParser();
+        dateParser = config.getDateParser();
+        monthFrontBetweenRegex = SpanishDatePeriodExtractorConfiguration.MonthFrontBetweenRegex;
+        betweenRegex = SpanishDatePeriodExtractorConfiguration.DayBetweenRegex;
+        monthFrontSimpleCasesRegex = SpanishDatePeriodExtractorConfiguration.MonthFrontSimpleCasesRegex;
+        simpleCasesRegex = SpanishDatePeriodExtractorConfiguration.SimpleCasesRegex;
+        oneWordPeriodRegex = SpanishDatePeriodExtractorConfiguration.OneWordPeriodRegex;
+        monthWithYear = SpanishDatePeriodExtractorConfiguration.MonthWithYearRegex;
+        monthNumWithYear = SpanishDatePeriodExtractorConfiguration.MonthNumWithYearRegex;
+        yearRegex = SpanishDatePeriodExtractorConfiguration.YearRegex;
+        pastRegex = SpanishDatePeriodExtractorConfiguration.PastRegex;
+        futureRegex = SpanishDatePeriodExtractorConfiguration.FutureRegex;
+        futureSuffixRegex = SpanishDatePeriodExtractorConfiguration.FutureSuffixRegex;
+        numberCombinedWithUnit = SpanishDurationExtractorConfiguration.NumberCombinedWithUnit;
+        weekOfMonthRegex = SpanishDatePeriodExtractorConfiguration.WeekOfMonthRegex;
+        weekOfYearRegex = SpanishDatePeriodExtractorConfiguration.WeekOfYearRegex;
+        quarterRegex = SpanishDatePeriodExtractorConfiguration.QuarterRegex;
+        quarterRegexYearFront = SpanishDatePeriodExtractorConfiguration.QuarterRegexYearFront;
+        allHalfYearRegex = SpanishDatePeriodExtractorConfiguration.AllHalfYearRegex;
+        seasonRegex = SpanishDatePeriodExtractorConfiguration.SeasonRegex;
+        whichWeekRegex = SpanishDatePeriodExtractorConfiguration.WhichWeekRegex;
+        weekOfRegex = SpanishDatePeriodExtractorConfiguration.WeekOfRegex;
+        monthOfRegex = SpanishDatePeriodExtractorConfiguration.MonthOfRegex;
+        restOfDateRegex = SpanishDatePeriodExtractorConfiguration.RestOfDateRegex;
+        laterEarlyPeriodRegex = SpanishDatePeriodExtractorConfiguration.LaterEarlyPeriodRegex;
+        weekWithWeekDayRangeRegex = SpanishDatePeriodExtractorConfiguration.WeekWithWeekDayRangeRegex;
+        yearPlusNumberRegex = SpanishDatePeriodExtractorConfiguration.YearPlusNumberRegex;
+        decadeWithCenturyRegex = SpanishDatePeriodExtractorConfiguration.DecadeWithCenturyRegex;
+        yearPeriodRegex = SpanishDatePeriodExtractorConfiguration.YearPeriodRegex;
+        complexDatePeriodRegex = SpanishDatePeriodExtractorConfiguration.ComplexDatePeriodRegex;
+        relativeDecadeRegex = SpanishDatePeriodExtractorConfiguration.RelativeDecadeRegex;
+        inConnectorRegex = config.getUtilityConfiguration().getInConnectorRegex();
+        withinNextPrefixRegex = SpanishDatePeriodExtractorConfiguration.WithinNextPrefixRegex;
+        referenceDatePeriodRegex = SpanishDatePeriodExtractorConfiguration.ReferenceDatePeriodRegex;
+        agoRegex = SpanishDatePeriodExtractorConfiguration.AgoRegex;
+        laterRegex = SpanishDatePeriodExtractorConfiguration.LaterRegex;
+        lessThanRegex = SpanishDatePeriodExtractorConfiguration.LessThanRegex;
+        moreThanRegex = SpanishDatePeriodExtractorConfiguration.MoreThanRegex;
+        centurySuffixRegex = SpanishDatePeriodExtractorConfiguration.CenturySuffixRegex;
+
+        unitMap = config.getUnitMap();
+        cardinalMap = config.getCardinalMap();
+        dayOfMonth = config.getDayOfMonth();
+        monthOfYear = config.getMonthOfYear();
+        seasonMap = config.getSeasonMap();
+        numbers = config.getNumbers();
+        writtenDecades = config.getWrittenDecades();
+        specialDecadeCases = config.getSpecialDecadeCases();
+
+        nextPrefixRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.NextPrefixRegex);
+        pastPrefixRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.PastPrefixRegex);
+        thisPrefixRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.ThisPrefixRegex);
+        relativeRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.RelativeRegex);
+        unspecificEndOfRangeRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.UnspecificEndOfRangeRegex);
+        afterNextSuffixRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.AfterNextSuffixRegex);
+    }
+
+    // Regex
+
+    private final String tokenBeforeDate;
+
+    private final IDateExtractor dateExtractor;
+
+    private final IExtractor cardinalExtractor;
+
+    private final IExtractor ordinalExtractor;
+
+    private final IDateTimeExtractor durationExtractor;
+
+    private final IExtractor integerExtractor;
+
+    private final IParser numberParser;
+
+    private final IDateTimeParser dateParser;
+
+    private final IDateTimeParser durationParser;
+
+    private final Pattern monthFrontBetweenRegex;
+
+    private final Pattern betweenRegex;
+
+    private final Pattern monthFrontSimpleCasesRegex;
+
+    private final Pattern simpleCasesRegex;
+
+    private final Pattern oneWordPeriodRegex;
+
+    private final Pattern monthWithYear;
+
+    private final Pattern monthNumWithYear;
+
+    private final Pattern yearRegex;
+
+    private final Pattern pastRegex;
+
+    private final Pattern futureRegex;
+
+    private final Pattern futureSuffixRegex;
+
+    private final Pattern numberCombinedWithUnit;
+
+    private final Pattern weekOfMonthRegex;
+
+    private final Pattern weekOfYearRegex;
+
+    private final Pattern quarterRegex;
+
+    private final Pattern quarterRegexYearFront;
+
+    private final Pattern allHalfYearRegex;
+
+    private final Pattern seasonRegex;
+
+    private final Pattern whichWeekRegex;
+
+    private final Pattern weekOfRegex;
+
+    private final Pattern monthOfRegex;
+
+    private final Pattern inConnectorRegex;
+
+    private final Pattern withinNextPrefixRegex;
+
+    private final Pattern restOfDateRegex;
+
+    private final Pattern laterEarlyPeriodRegex;
+
+    private final Pattern weekWithWeekDayRangeRegex;
+
+    private final Pattern yearPlusNumberRegex;
+
+    private final Pattern decadeWithCenturyRegex;
+
+    private final Pattern yearPeriodRegex;
+
+    private final Pattern complexDatePeriodRegex;
+
+    private final Pattern relativeDecadeRegex;
+
+    private final Pattern referenceDatePeriodRegex;
+
+    private final Pattern agoRegex;
+
+    private final Pattern laterRegex;
+
+    private final Pattern lessThanRegex;
+
+    private final Pattern moreThanRegex;
+
+    private final Pattern centurySuffixRegex;
+
+    private final Pattern nextPrefixRegex;
+
+    private final Pattern pastPrefixRegex;
+
+    private final Pattern thisPrefixRegex;
+
+    private final Pattern relativeRegex;
+
+    private final Pattern unspecificEndOfRangeRegex;
+
+    private final Pattern afterNextSuffixRegex;
+
+    // Dictionaries
+    private final ImmutableMap<String, String> unitMap;
+    private final ImmutableMap<String, Integer> cardinalMap;
+    private final ImmutableMap<String, Integer> dayOfMonth;
+    private final ImmutableMap<String, Integer> monthOfYear;
+    private final ImmutableMap<String, String> seasonMap;
+    private final ImmutableMap<String, Integer> writtenDecades;
+    private final ImmutableMap<String, Integer> numbers;
+    private final ImmutableMap<String, Integer> specialDecadeCases;
+
+    @Override
+    public final String getTokenBeforeDate() {
+        return tokenBeforeDate;
+    }
+
+    @Override
+    public final IDateExtractor getDateExtractor() {
+        return dateExtractor;
+    }
+
+    @Override
+    public final IExtractor getCardinalExtractor() {
+        return cardinalExtractor;
+    }
+
+    @Override
+    public final IExtractor getOrdinalExtractor() {
+        return ordinalExtractor;
+    }
+
+    @Override
+    public final IDateTimeExtractor getDurationExtractor() {
+        return durationExtractor;
+    }
+
+    @Override
+    public final IExtractor getIntegerExtractor() {
+        return integerExtractor;
+    }
+
+    @Override
+    public final IParser getNumberParser() {
+        return numberParser;
+    }
+
+    @Override
+    public final IDateTimeParser getDateParser() {
+        return dateParser;
+    }
+
+    @Override
+    public final IDateTimeParser getDurationParser() {
+        return durationParser;
+    }
+
+    @Override
+    public final Pattern getMonthFrontBetweenRegex() {
+        return monthFrontBetweenRegex;
+    }
+
+    @Override
+    public final Pattern getBetweenRegex() {
+        return betweenRegex;
+    }
+
+    @Override
+    public final Pattern getMonthFrontSimpleCasesRegex() {
+        return monthFrontSimpleCasesRegex;
+    }
+
+    @Override
+    public final Pattern getSimpleCasesRegex() {
+        return simpleCasesRegex;
+    }
+
+    @Override
+    public final Pattern getOneWordPeriodRegex() {
+        return oneWordPeriodRegex;
+    }
+
+    @Override
+    public final Pattern getMonthWithYear() {
+        return monthWithYear;
+    }
+
+    @Override
+    public final Pattern getMonthNumWithYear() {
+        return monthNumWithYear;
+    }
+
+    @Override
+    public final Pattern getYearRegex() {
+        return yearRegex;
+    }
+
+    @Override
+    public final Pattern getPastRegex() {
+        return pastRegex;
+    }
+
+    @Override
+    public final Pattern getFutureRegex() {
+        return futureRegex;
+    }
+
+    @Override
+    public final Pattern getFutureSuffixRegex() {
+        return futureSuffixRegex;
+    }
+
+    @Override
+    public final Pattern getNumberCombinedWithUnit() {
+        return numberCombinedWithUnit;
+    }
+
+    @Override
+    public final Pattern getWeekOfMonthRegex() {
+        return weekOfMonthRegex;
+    }
+
+    @Override
+    public final Pattern getWeekOfYearRegex() {
+        return weekOfYearRegex;
+    }
+
+    @Override
+    public final Pattern getQuarterRegex() {
+        return quarterRegex;
+    }
+
+    @Override
+    public final Pattern getQuarterRegexYearFront() {
+        return quarterRegexYearFront;
+    }
+
+    @Override
+    public final Pattern getAllHalfYearRegex() {
+        return allHalfYearRegex;
+    }
+
+    @Override
+    public final Pattern getSeasonRegex() {
+        return seasonRegex;
+    }
+
+    @Override
+    public final Pattern getWhichWeekRegex() {
+        return whichWeekRegex;
+    }
+
+    @Override
+    public final Pattern getWeekOfRegex() {
+        return weekOfRegex;
+    }
+
+    @Override
+    public final Pattern getMonthOfRegex() {
+        return monthOfRegex;
+    }
+
+    @Override
+    public final Pattern getInConnectorRegex() {
+        return inConnectorRegex;
+    }
+
+    @Override
+    public final Pattern getWithinNextPrefixRegex() {
+        return withinNextPrefixRegex;
+    }
+
+    @Override
+    public final Pattern getRestOfDateRegex() {
+        return restOfDateRegex;
+    }
+
+    @Override
+    public final Pattern getLaterEarlyPeriodRegex() {
+        return laterEarlyPeriodRegex;
+    }
+
+    @Override
+    public final Pattern getWeekWithWeekDayRangeRegex() {
+        return laterEarlyPeriodRegex;
+    }
+
+    @Override
+    public final Pattern getYearPlusNumberRegex() {
+        return yearPlusNumberRegex;
+    }
+
+    @Override
+    public final Pattern getDecadeWithCenturyRegex() {
+        return decadeWithCenturyRegex;
+    }
+
+    @Override
+    public final Pattern getYearPeriodRegex() {
+        return yearPeriodRegex;
+    }
+
+    @Override
+    public final Pattern getComplexDatePeriodRegex() {
+        return complexDatePeriodRegex;
+    }
+
+    @Override
+    public final Pattern getRelativeDecadeRegex() {
+        return complexDatePeriodRegex;
+    }
+
+    @Override
+    public final Pattern getReferenceDatePeriodRegex() {
+        return referenceDatePeriodRegex;
+    }
+
+    @Override
+    public final Pattern getAgoRegex() {
+        return agoRegex;
+    }
+
+    @Override
+    public final Pattern getLaterRegex() {
+        return laterRegex;
+    }
+
+    @Override
+    public final Pattern getLessThanRegex() {
+        return lessThanRegex;
+    }
+
+    @Override
+    public final Pattern getMoreThanRegex() {
+        return moreThanRegex;
+    }
+
+    @Override
+    public final Pattern getCenturySuffixRegex() {
+        return centurySuffixRegex;
+    }
+
+    @Override
+    public final Pattern getNextPrefixRegex() {
+        return nextPrefixRegex;
+    }
+
+    @Override
+    public final Pattern getPastPrefixRegex() {
+        return pastPrefixRegex;
+    }
+
+    @Override
+    public final Pattern getThisPrefixRegex() {
+        return thisPrefixRegex;
+    }
+
+    @Override
+    public final Pattern getRelativeRegex() {
+        return relativeRegex;
+    }
+
+    @Override
+    public final Pattern getUnspecificEndOfRangeRegex() {
+        return unspecificEndOfRangeRegex;
+    }
+
+    @Override
+    public ImmutableMap<String, String> getUnitMap() {
+        return unitMap;
+    }
+
+    @Override
+    public ImmutableMap<String, Integer> getCardinalMap() {
+        return cardinalMap;
+    }
+
+    @Override
+    public ImmutableMap<String, Integer> getDayOfMonth() {
+        return dayOfMonth;
+    }
+
+    @Override
+    public ImmutableMap<String, Integer> getMonthOfYear() {
+        return monthOfYear;
+    }
+
+    @Override
+    public ImmutableMap<String, String> getSeasonMap() {
+        return seasonMap;
+    }
+
+    @Override
+    public ImmutableMap<String, Integer> getWrittenDecades() {
+        return writtenDecades;
+    }
+
+    @Override
+    public ImmutableMap<String, Integer> getNumbers() {
+        return numbers;
+    }
+
+    @Override
+    public ImmutableMap<String, Integer> getSpecialDecadeCases() {
+        return specialDecadeCases;
+    }
+
+    @Override
+    public int getSwiftDayOrMonth(String text) {
+
+        String trimmedText = text.trim().toLowerCase();
+        int swift = 0;
+
+        Optional<Match> matchNext = Arrays.stream(RegExpUtility.getMatches(nextPrefixRegex, trimmedText)).findFirst();
+        Optional<Match> matchPast = Arrays.stream(RegExpUtility.getMatches(pastPrefixRegex, trimmedText)).findFirst();
+
+        if (matchNext.isPresent()) {
+            swift = 1;
+        } else if (matchPast.isPresent()) {
+            swift = -1;
+        }
+
+        return swift;
+    }
+
+    @Override
+    public int getSwiftYear(String text) {
+
+        String trimmedText = text.trim().toLowerCase();
+        int swift = -10;
+
+        Optional<Match> matchNext = Arrays.stream(RegExpUtility.getMatches(nextPrefixRegex, trimmedText)).findFirst();
+        Optional<Match> matchPast = Arrays.stream(RegExpUtility.getMatches(pastPrefixRegex, trimmedText)).findFirst();
+        Optional<Match> matchThisPresent = Arrays.stream(RegExpUtility.getMatches(thisPrefixRegex, trimmedText)).findFirst();
+
+        if (matchNext.isPresent()) {
+            swift = 1;
+        } else if (matchPast.isPresent()) {
+            swift = -1;
+        } else if (matchThisPresent.isPresent()) {
+            swift = 0;
+        }
+
+        return swift;
+    }
+
+    @Override
+    public boolean isFuture(String text) {
+        String trimmedText = text.trim().toLowerCase();
+
+        Optional<Match> matchThis = Arrays.stream(RegExpUtility.getMatches(thisPrefixRegex, trimmedText)).findFirst();
+        Optional<Match> matchNext = Arrays.stream(RegExpUtility.getMatches(nextPrefixRegex, trimmedText)).findFirst();
+        return matchThis.isPresent() || matchNext.isPresent();
+    }
+
+    @Override
+    public boolean isLastCardinal(String text) {
+        String trimmedText = text.trim().toLowerCase();
+
+        Optional<Match> matchLast = Arrays.stream(RegExpUtility.getMatches(pastPrefixRegex, trimmedText)).findFirst();
+        return matchLast.isPresent();
+    }
+
+    @Override
+    public boolean isMonthOnly(String text) {
+        String trimmedText = text.trim().toLowerCase();
+        return SpanishDateTime.MonthTerms.stream().anyMatch(o -> trimmedText.endsWith(o));
+    }
+
+    @Override
+    public boolean isMonthToDate(String text) {
+        String trimmedText = text.trim().toLowerCase();
+        return SpanishDateTime.MonthToDateTerms.stream().anyMatch(o -> trimmedText.endsWith(o));
+    }
+
+    @Override
+    public boolean isWeekend(String text) {
+        String trimmedText = text.trim().toLowerCase();
+        return SpanishDateTime.WeekendTerms.stream().anyMatch(o -> trimmedText.endsWith(o));
+    }
+
+    @Override
+    public boolean isWeekOnly(String text) {
+        String trimmedText = text.trim().toLowerCase();
+        return SpanishDateTime.WeekTerms.stream().anyMatch(o -> trimmedText.endsWith(o)) &&
+                !SpanishDateTime.WeekendTerms.stream().anyMatch(o -> trimmedText.endsWith(o));
+    }
+
+    @Override
+    public boolean isYearOnly(String text) {
+        String trimmedText = text.trim().toLowerCase();
+        return SpanishDateTime.YearTerms.stream().anyMatch(o -> trimmedText.endsWith(o));
+    }
+
+    @Override
+    public boolean isYearToDate(String text) {
+        String trimmedText = text.trim().toLowerCase();
+
+        return SpanishDateTime.YearToDateTerms.stream().anyMatch(o -> trimmedText.endsWith(o));
+    }
+}

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/parsers/SpanishDateTimeAltParserConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/parsers/SpanishDateTimeAltParserConfiguration.java
@@ -1,0 +1,48 @@
+package com.microsoft.recognizers.text.datetime.spanish.parsers;
+
+import com.microsoft.recognizers.text.datetime.parsers.IDateTimeParser;
+import com.microsoft.recognizers.text.datetime.parsers.config.ICommonDateTimeParserConfiguration;
+import com.microsoft.recognizers.text.datetime.parsers.config.IDateTimeAltParserConfiguration;
+
+public class SpanishDateTimeAltParserConfiguration implements IDateTimeAltParserConfiguration {
+
+    private final IDateTimeParser dateTimeParser;
+    private final IDateTimeParser dateParser;
+    private final IDateTimeParser timeParser;
+    private final IDateTimeParser dateTimePeriodParser;
+    private final IDateTimeParser timePeriodParser;
+    private final IDateTimeParser datePeriodParser;
+
+    public SpanishDateTimeAltParserConfiguration(ICommonDateTimeParserConfiguration config) {
+        dateTimeParser = config.getDateTimeParser();
+        dateParser = config.getDateParser();
+        timeParser = config.getTimeParser();
+        dateTimePeriodParser = config.getDateTimePeriodParser();
+        timePeriodParser = config.getTimePeriodParser();
+        datePeriodParser = config.getDatePeriodParser();
+    }
+
+    public IDateTimeParser getDateTimeParser() {
+        return dateTimeParser;
+    }
+
+    public IDateTimeParser getDateParser() {
+        return dateParser;
+    }
+
+    public IDateTimeParser getTimeParser() {
+        return timeParser;
+    }
+
+    public IDateTimeParser getDateTimePeriodParser() {
+        return dateTimePeriodParser;
+    }
+
+    public IDateTimeParser getTimePeriodParser() {
+        return timePeriodParser;
+    }
+
+    public IDateTimeParser getDatePeriodParser() {
+        return datePeriodParser;
+    }
+}

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/parsers/SpanishDateTimeParserConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/parsers/SpanishDateTimeParserConfiguration.java
@@ -1,0 +1,237 @@
+package com.microsoft.recognizers.text.datetime.spanish.parsers;
+
+import com.google.common.collect.ImmutableMap;
+import com.microsoft.recognizers.text.IExtractor;
+import com.microsoft.recognizers.text.IParser;
+import com.microsoft.recognizers.text.datetime.Constants;
+import com.microsoft.recognizers.text.datetime.config.BaseOptionsConfiguration;
+import com.microsoft.recognizers.text.datetime.extractors.IDateTimeExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.config.ResultTimex;
+import com.microsoft.recognizers.text.datetime.parsers.IDateTimeParser;
+import com.microsoft.recognizers.text.datetime.parsers.config.ICommonDateTimeParserConfiguration;
+import com.microsoft.recognizers.text.datetime.parsers.config.IDateTimeParserConfiguration;
+import com.microsoft.recognizers.text.datetime.resources.SpanishDateTime;
+import com.microsoft.recognizers.text.datetime.spanish.extractors.SpanishDateTimeExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.utilities.IDateTimeUtilityConfiguration;
+import com.microsoft.recognizers.text.utilities.RegExpUtility;
+
+import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class SpanishDateTimeParserConfiguration extends BaseOptionsConfiguration implements IDateTimeParserConfiguration {
+
+    public final String tokenBeforeDate;
+    public final String tokenBeforeTime;
+
+    public final IDateTimeExtractor dateExtractor;
+    public final IDateTimeExtractor timeExtractor;
+    public final IDateTimeParser dateParser;
+    public final IDateTimeParser timeParser;
+    public final IExtractor cardinalExtractor;
+    public final IExtractor integerExtractor;
+    public final IParser numberParser;
+    public final IDateTimeExtractor durationExtractor;
+    public final IDateTimeParser durationParser;
+
+    public final ImmutableMap<String, String> unitMap;
+    public final ImmutableMap<String, Integer> numbers;
+
+    public final Pattern nowRegex;
+    public final Pattern amTimeRegex;
+    public final Pattern pmTimeRegex;
+    public final Pattern simpleTimeOfTodayAfterRegex;
+    public final Pattern simpleTimeOfTodayBeforeRegex;
+    public final Pattern specificTimeOfDayRegex;
+    public final Pattern specificEndOfRegex;
+    public final Pattern unspecificEndOfRegex;
+    public final Pattern unitRegex;
+    public final Pattern dateNumberConnectorRegex;
+    
+    public final IDateTimeUtilityConfiguration utilityConfiguration;
+
+    public SpanishDateTimeParserConfiguration(ICommonDateTimeParserConfiguration config) {
+        super(config.getOptions());
+
+        unitMap = config.getUnitMap();
+        numbers = config.getNumbers();
+        dateParser = config.getDateParser();
+        timeParser = config.getTimeParser();
+        numberParser = config.getNumberParser();
+        dateExtractor = config.getDateExtractor();
+        timeExtractor = config.getTimeExtractor();
+        durationParser = config.getDurationParser();
+        integerExtractor = config.getIntegerExtractor();
+        cardinalExtractor = config.getCardinalExtractor();
+        durationExtractor = config.getDurationExtractor();
+        utilityConfiguration = config.getUtilityConfiguration();
+
+        tokenBeforeDate = SpanishDateTime.TokenBeforeDate;
+        tokenBeforeTime = SpanishDateTime.TokenBeforeTime;
+
+        nowRegex = SpanishDateTimeExtractorConfiguration.NowRegex;
+        unitRegex = SpanishDateTimeExtractorConfiguration.UnitRegex;
+        specificEndOfRegex = SpanishDateTimeExtractorConfiguration.SpecificEndOfRegex;
+        unspecificEndOfRegex = SpanishDateTimeExtractorConfiguration.UnspecificEndOfRegex;
+        specificTimeOfDayRegex = SpanishDateTimeExtractorConfiguration.SpecificTimeOfDayRegex;
+        dateNumberConnectorRegex = SpanishDateTimeExtractorConfiguration.DateNumberConnectorRegex;
+        simpleTimeOfTodayAfterRegex = SpanishDateTimeExtractorConfiguration.SimpleTimeOfTodayAfterRegex;
+        simpleTimeOfTodayBeforeRegex = SpanishDateTimeExtractorConfiguration.SimpleTimeOfTodayBeforeRegex;
+
+        pmTimeRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.PmRegex);
+        amTimeRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.AmTimeRegex);
+    }
+
+    @Override
+    public int getHour(String text, int hour) {
+
+        String trimmedText = text.trim().toLowerCase();
+        int result = hour;
+
+        //TODO: Replace with a regex
+        if ((trimmedText.endsWith("mañana") || trimmedText.endsWith("madrugada")) && hour >= Constants.HalfDayHourCount) {
+            result -= Constants.HalfDayHourCount;
+        } else if (!(trimmedText.endsWith("mañana") || trimmedText.endsWith("madrugada")) && hour < Constants.HalfDayHourCount) {
+            result += Constants.HalfDayHourCount;
+        }
+
+        return result;
+    }
+
+    @Override
+    public ResultTimex getMatchedNowTimex(String text) {
+
+        String trimmedText = text.trim().toLowerCase();
+
+        if (trimmedText.endsWith("ahora") || trimmedText.endsWith("mismo") || trimmedText.endsWith("momento")) {
+            return new ResultTimex(true, "PRESENT_REF");
+        } else if (trimmedText.endsWith("posible") || trimmedText.endsWith("pueda") || trimmedText.endsWith("puedas") ||
+                trimmedText.endsWith("podamos") || trimmedText.endsWith("puedan")) {
+            return new ResultTimex(true, "FUTURE_REF");
+        } else if (trimmedText.endsWith("mente")) {
+            return new ResultTimex(true, "PAST_REF");
+        }
+
+        return new ResultTimex(false, null);
+    }
+
+    @Override
+    public int getSwiftDay(String text) {
+
+        String trimmedText = text.trim().toLowerCase(Locale.ROOT);
+        Matcher regexMatcher = SpanishDatePeriodParserConfiguration.pastPrefixRegex.matcher(trimmedText);
+
+        int swift = 0;
+        if (regexMatcher.find()) {
+            swift = 1;
+        } else {
+            regexMatcher = SpanishDatePeriodParserConfiguration.nextPrefixRegex.matcher(trimmedText);
+            if (regexMatcher.find()) {
+                swift = -1;
+            }
+        }
+
+        return swift;
+    }
+
+    @Override
+    public boolean containsAmbiguousToken(String text, String matchedText) {
+        return text.contains("esta mañana") && matchedText.contains("mañana");
+    }
+
+    @Override public String getTokenBeforeDate() {
+        return tokenBeforeDate;
+    }
+
+    @Override public String getTokenBeforeTime() {
+        return tokenBeforeTime;
+    }
+
+    @Override public IDateTimeExtractor getDateExtractor() {
+        return dateExtractor;
+    }
+
+    @Override public IDateTimeExtractor getTimeExtractor() {
+        return timeExtractor;
+    }
+
+    @Override public IDateTimeParser getDateParser() {
+        return dateParser;
+    }
+
+    @Override public IDateTimeParser getTimeParser() {
+        return timeParser;
+    }
+
+    @Override public IExtractor getCardinalExtractor() {
+        return cardinalExtractor;
+    }
+
+    @Override public IExtractor getIntegerExtractor() {
+        return integerExtractor;
+    }
+
+    @Override public IParser getNumberParser() {
+        return numberParser;
+    }
+
+    @Override public IDateTimeExtractor getDurationExtractor() {
+        return durationExtractor;
+    }
+
+    @Override public IDateTimeParser getDurationParser() {
+        return durationParser;
+    }
+
+    @Override public ImmutableMap<String, String> getUnitMap() {
+        return unitMap;
+    }
+
+    @Override public ImmutableMap<String, Integer> getNumbers() {
+        return numbers;
+    }
+
+    @Override public Pattern getNowRegex() {
+        return nowRegex;
+    }
+
+    public Pattern getAMTimeRegex() {
+        return amTimeRegex;
+    }
+
+    public Pattern getPMTimeRegex() {
+        return pmTimeRegex;
+    }
+
+    @Override public Pattern getSimpleTimeOfTodayAfterRegex() {
+        return simpleTimeOfTodayAfterRegex;
+    }
+
+    @Override public Pattern getSimpleTimeOfTodayBeforeRegex() {
+        return simpleTimeOfTodayBeforeRegex;
+    }
+
+    @Override public Pattern getSpecificTimeOfDayRegex() {
+        return specificTimeOfDayRegex;
+    }
+
+    @Override public Pattern getSpecificEndOfRegex() {
+        return specificEndOfRegex;
+    }
+
+    @Override public Pattern getUnspecificEndOfRegex() {
+        return unspecificEndOfRegex;
+    }
+
+    @Override public Pattern getUnitRegex() {
+        return unitRegex;
+    }
+
+    @Override public Pattern getDateNumberConnectorRegex() {
+        return dateNumberConnectorRegex;
+    }
+
+    @Override public IDateTimeUtilityConfiguration getUtilityConfiguration() {
+        return utilityConfiguration;
+    }
+}

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/parsers/SpanishDateTimePeriodParserConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/parsers/SpanishDateTimePeriodParserConfiguration.java
@@ -1,0 +1,340 @@
+package com.microsoft.recognizers.text.datetime.spanish.parsers;
+
+import com.google.common.collect.ImmutableMap;
+import com.microsoft.recognizers.text.IExtractor;
+import com.microsoft.recognizers.text.IParser;
+import com.microsoft.recognizers.text.datetime.Constants;
+import com.microsoft.recognizers.text.datetime.config.BaseOptionsConfiguration;
+import com.microsoft.recognizers.text.datetime.extractors.IDateTimeExtractor;
+import com.microsoft.recognizers.text.datetime.parsers.IDateTimeParser;
+import com.microsoft.recognizers.text.datetime.parsers.config.ICommonDateTimeParserConfiguration;
+import com.microsoft.recognizers.text.datetime.parsers.config.IDateTimePeriodParserConfiguration;
+import com.microsoft.recognizers.text.datetime.parsers.config.MatchedTimeRangeResult;
+import com.microsoft.recognizers.text.datetime.resources.SpanishDateTime;
+import com.microsoft.recognizers.text.datetime.spanish.extractors.SpanishDatePeriodExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.spanish.extractors.SpanishDateTimeExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.spanish.extractors.SpanishDateTimePeriodExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.spanish.extractors.SpanishTimePeriodExtractorConfiguration;
+import com.microsoft.recognizers.text.utilities.RegExpUtility;
+
+import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class SpanishDateTimePeriodParserConfiguration extends BaseOptionsConfiguration implements IDateTimePeriodParserConfiguration {
+
+    private final String tokenBeforeDate;
+
+    private final IDateTimeExtractor dateExtractor;
+    private final IDateTimeExtractor timeExtractor;
+    private final IDateTimeExtractor dateTimeExtractor;
+    private final IDateTimeExtractor timePeriodExtractor;
+    private final IDateTimeExtractor durationExtractor;
+    private final IExtractor cardinalExtractor;
+
+    private final IParser numberParser;
+    private final IDateTimeParser dateParser;
+    private final IDateTimeParser timeParser;
+    private final IDateTimeParser dateTimeParser;
+    private final IDateTimeParser timePeriodParser;
+    private final IDateTimeParser durationParser;
+
+    private final Pattern pureNumberFromToRegex;
+    private final Pattern pureNumberBetweenAndRegex;
+    private final Pattern specificTimeOfDayRegex;
+    private final Pattern timeOfDayRegex;
+    private final Pattern pastRegex;
+    private final Pattern futureRegex;
+    private final Pattern futureSuffixRegex;
+    private final Pattern numberCombinedWithUnitRegex;
+    private final Pattern unitRegex;
+    private final Pattern periodTimeOfDayWithDateRegex;
+    private final Pattern relativeTimeUnitRegex;
+    private final Pattern restOfDateTimeRegex;
+    private final Pattern amDescRegex;
+    private final Pattern pmDescRegex;
+    private final Pattern withinNextPrefixRegex;
+    private final Pattern prefixDayRegex;
+    private final Pattern beforeRegex;
+    private final Pattern afterRegex;
+
+    private final ImmutableMap<String, String> unitMap;
+    private final ImmutableMap<String, Integer> numbers;
+
+    /*public static final Pattern MorningStartEndRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.MorningStartEndRegex);
+    public static final Pattern AfternoonStartEndRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.AfternoonStartEndRegex);
+    public static final Pattern EveningStartEndRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.EveningStartEndRegex);
+    public static final Pattern NightStartEndRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.NightStartEndRegex);*/
+
+    public SpanishDateTimePeriodParserConfiguration(ICommonDateTimeParserConfiguration config) {
+
+        super(config.getOptions());
+
+        tokenBeforeDate = SpanishDateTime.TokenBeforeDate;
+
+        dateExtractor = config.getDateExtractor();
+        timeExtractor = config.getTimeExtractor();
+        dateTimeExtractor = config.getDateTimeExtractor();
+        timePeriodExtractor = config.getTimePeriodExtractor();
+        cardinalExtractor = config.getCardinalExtractor();
+        durationExtractor = config.getDurationExtractor();
+        numberParser = config.getNumberParser();
+        dateParser = config.getDateParser();
+        timeParser = config.getTimeParser();
+        timePeriodParser = config.getTimePeriodParser();
+        durationParser = config.getDurationParser();
+        dateTimeParser = config.getDateTimeParser();
+
+        pureNumberFromToRegex = SpanishTimePeriodExtractorConfiguration.PureNumFromTo;
+        pureNumberBetweenAndRegex = SpanishTimePeriodExtractorConfiguration.PureNumBetweenAnd;
+        specificTimeOfDayRegex = SpanishDateTimeExtractorConfiguration.SpecificTimeOfDayRegex;
+        timeOfDayRegex = SpanishDateTimeExtractorConfiguration.TimeOfDayRegex;
+        pastRegex = SpanishDatePeriodExtractorConfiguration.PastRegex;
+        futureRegex = SpanishDatePeriodExtractorConfiguration.FutureRegex;
+        futureSuffixRegex = SpanishDatePeriodExtractorConfiguration.FutureSuffixRegex;
+        numberCombinedWithUnitRegex = SpanishDateTimePeriodExtractorConfiguration.TimeNumberCombinedWithUnit;
+        unitRegex = SpanishTimePeriodExtractorConfiguration.UnitRegex;
+        periodTimeOfDayWithDateRegex = SpanishDateTimePeriodExtractorConfiguration.PeriodTimeOfDayWithDateRegex;
+        relativeTimeUnitRegex = SpanishDateTimePeriodExtractorConfiguration.RelativeTimeUnitRegex;
+        restOfDateTimeRegex = SpanishDateTimePeriodExtractorConfiguration.RestOfDateTimeRegex;
+        amDescRegex = SpanishDateTimePeriodExtractorConfiguration.AmDescRegex;
+        pmDescRegex = SpanishDateTimePeriodExtractorConfiguration.PmDescRegex;
+        withinNextPrefixRegex = SpanishDateTimePeriodExtractorConfiguration.WithinNextPrefixRegex;
+        prefixDayRegex = SpanishDateTimePeriodExtractorConfiguration.PrefixDayRegex;
+        beforeRegex = SpanishDateTimePeriodExtractorConfiguration.BeforeRegex;
+        afterRegex = SpanishDateTimePeriodExtractorConfiguration.AfterRegex;
+
+        unitMap = config.getUnitMap();
+        numbers = config.getNumbers();
+    }
+
+    @Override
+    public String getTokenBeforeDate() {
+        return tokenBeforeDate;
+    }
+
+    @Override
+    public IDateTimeExtractor getDateExtractor() {
+        return dateExtractor;
+    }
+
+    @Override
+    public IDateTimeExtractor getTimeExtractor() {
+        return timeExtractor;
+    }
+
+    @Override
+    public IDateTimeExtractor getDateTimeExtractor() {
+        return dateTimeExtractor;
+    }
+
+    @Override
+    public IDateTimeExtractor getTimePeriodExtractor() {
+        return timePeriodExtractor;
+    }
+
+    @Override
+    public IDateTimeExtractor getDurationExtractor() {
+        return durationExtractor;
+    }
+
+    @Override
+    public IExtractor getCardinalExtractor() {
+        return cardinalExtractor;
+    }
+
+    @Override
+    public IParser getNumberParser() {
+        return numberParser;
+    }
+
+    @Override
+    public IDateTimeParser getDateParser() {
+        return dateParser;
+    }
+
+    @Override
+    public IDateTimeParser getTimeParser() {
+        return timeParser;
+    }
+
+    @Override
+    public IDateTimeParser getDateTimeParser() {
+        return dateTimeParser;
+    }
+
+    @Override
+    public IDateTimeParser getTimePeriodParser() {
+        return timePeriodParser;
+    }
+
+    @Override
+    public IDateTimeParser getDurationParser() {
+        return durationParser;
+    }
+
+    @Override
+    public Pattern getPureNumberFromToRegex() {
+        return pureNumberFromToRegex;
+    }
+
+    @Override
+    public Pattern getPureNumberBetweenAndRegex() {
+        return pureNumberBetweenAndRegex;
+    }
+
+    @Override
+    public Pattern getSpecificTimeOfDayRegex() {
+        return specificTimeOfDayRegex;
+    }
+
+    @Override
+    public Pattern getTimeOfDayRegex() {
+        return timeOfDayRegex;
+    }
+
+    @Override
+    public Pattern getPastRegex() {
+        return pastRegex;
+    }
+
+    @Override
+    public Pattern getFutureRegex() {
+        return futureRegex;
+    }
+
+    @Override
+    public Pattern getFutureSuffixRegex() {
+        return futureSuffixRegex;
+    }
+
+    @Override
+    public Pattern getNumberCombinedWithUnitRegex() {
+        return numberCombinedWithUnitRegex;
+    }
+
+    @Override
+    public Pattern getUnitRegex() {
+        return unitRegex;
+    }
+
+    @Override
+    public Pattern getPeriodTimeOfDayWithDateRegex() {
+        return periodTimeOfDayWithDateRegex;
+    }
+
+    @Override
+    public Pattern getRelativeTimeUnitRegex() {
+        return relativeTimeUnitRegex;
+    }
+
+    @Override
+    public Pattern getRestOfDateTimeRegex() {
+        return restOfDateTimeRegex;
+    }
+
+    @Override
+    public Pattern getAmDescRegex() {
+        return amDescRegex;
+    }
+
+    @Override
+    public Pattern getPmDescRegex() {
+        return pmDescRegex;
+    }
+
+    @Override
+    public Pattern getWithinNextPrefixRegex() {
+        return withinNextPrefixRegex;
+    }
+
+    @Override
+    public Pattern getPrefixDayRegex() {
+        return prefixDayRegex;
+    }
+
+    @Override
+    public Pattern getBeforeRegex() {
+        return beforeRegex;
+    }
+
+    @Override
+    public Pattern getAfterRegex() {
+        return afterRegex;
+    }
+
+    @Override
+    public ImmutableMap<String, String> getUnitMap() {
+        return unitMap;
+    }
+
+    @Override
+    public ImmutableMap<String, Integer> getNumbers() {
+        return numbers;
+    }
+
+    @Override
+    public MatchedTimeRangeResult getMatchedTimeRange(String text, String timeStr, int beginHour, int endHour, int endMin) {
+
+        String trimmedText = text.trim().toLowerCase(Locale.ROOT);
+        beginHour = 0;
+        endHour = 0;
+        endMin = 0;
+        boolean result = false;
+
+        // TODO: modify it according to the coresponding function in English part
+        if (trimmedText.endsWith("madrugada")) {
+            timeStr = "TDA";
+            beginHour = 4;
+            endHour = 8;
+            result = true;
+        } else if (trimmedText.endsWith("mañana")) {
+            timeStr = "TMO";
+            beginHour = 8;
+            endHour = Constants.HalfDayHourCount;
+            result = true;
+        } else if (trimmedText.contains("pasado mediodia") || trimmedText.contains("pasado el mediodia")) {
+            timeStr = "TAF";
+            beginHour = Constants.HalfDayHourCount;
+            endHour = 16;
+            result = true;
+        } else if (trimmedText.endsWith("tarde")) {
+            timeStr = "TEV";
+            beginHour = 16;
+            endHour = 20;
+            result = true;
+        } else if (trimmedText.endsWith("noche")) {
+            timeStr = "TNI";
+            beginHour = 20;
+            endHour = 23;
+            endMin = 59;
+            result = true;
+        } else {
+            timeStr = null;
+        }
+
+        return new MatchedTimeRangeResult(result, timeStr, beginHour, endHour, endMin);
+    }
+
+    @Override
+    public int getSwiftPrefix(String text) {
+
+        String trimmedText = text.trim().toLowerCase();
+
+        Pattern regex = Pattern.compile(SpanishDateTime.PastPrefixRegex);
+        Matcher regexMatcher = regex.matcher(trimmedText);
+
+        int swift = 0;
+        if (regexMatcher.find() || trimmedText.equals("anoche")) {
+            swift = -1;
+        } else {
+            regex = Pattern.compile(SpanishDateTime.NextPrefixRegex);
+            regexMatcher = regex.matcher(text);
+            if (regexMatcher.find()) {
+                swift = 1;
+            }
+        }
+
+        return swift;
+    }
+}

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/parsers/SpanishDateTimePeriodParserConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/parsers/SpanishDateTimePeriodParserConfiguration.java
@@ -92,7 +92,7 @@ public class SpanishDateTimePeriodParserConfiguration extends BaseOptionsConfigu
         pastRegex = SpanishDatePeriodExtractorConfiguration.PastRegex;
         futureRegex = SpanishDatePeriodExtractorConfiguration.FutureRegex;
         futureSuffixRegex = SpanishDatePeriodExtractorConfiguration.FutureSuffixRegex;
-        numberCombinedWithUnitRegex = SpanishDateTimePeriodExtractorConfiguration.TimeNumberCombinedWithUnit;
+        numberCombinedWithUnitRegex = SpanishDateTimePeriodExtractorConfiguration.NumberCombinedWithUnit;
         unitRegex = SpanishTimePeriodExtractorConfiguration.UnitRegex;
         periodTimeOfDayWithDateRegex = SpanishDateTimePeriodExtractorConfiguration.PeriodTimeOfDayWithDateRegex;
         relativeTimeUnitRegex = SpanishDateTimePeriodExtractorConfiguration.RelativeTimeUnitRegex;

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/parsers/SpanishHolidayParserConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/parsers/SpanishHolidayParserConfiguration.java
@@ -1,0 +1,136 @@
+package com.microsoft.recognizers.text.datetime.spanish.parsers;
+
+import com.google.common.collect.ImmutableMap;
+import com.microsoft.recognizers.text.datetime.parsers.BaseHolidayParserConfiguration;
+import com.microsoft.recognizers.text.datetime.resources.SpanishDateTime;
+import com.microsoft.recognizers.text.datetime.spanish.extractors.SpanishHolidayExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.utilities.DateUtil;
+import com.microsoft.recognizers.text.utilities.Match;
+import com.microsoft.recognizers.text.utilities.RegExpUtility;
+import com.microsoft.recognizers.text.utilities.StringUtility;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.IntFunction;
+
+public class SpanishHolidayParserConfiguration extends BaseHolidayParserConfiguration {
+
+    public SpanishHolidayParserConfiguration() {
+
+        super();
+
+        this.setHolidayRegexList(SpanishHolidayExtractorConfiguration.HolidayRegexList);
+
+        HashMap<String, Iterable<String>> holidayNamesMap = new HashMap<>();
+        for (Map.Entry<String, String[]> entry : SpanishDateTime.HolidayNames.entrySet()) {
+            if (entry.getValue() instanceof String[]) {
+                holidayNamesMap.put(entry.getKey(), Arrays.asList(entry.getValue()));
+            }
+        }
+        this.setHolidayNames(ImmutableMap.copyOf(holidayNamesMap));
+
+        HashMap<String, String> variableHolidaysTimexMap = new HashMap<>();
+        for (Map.Entry<String, String> entry : SpanishDateTime.VariableHolidaysTimexDictionary.entrySet()) {
+            if (entry.getValue() instanceof String) {
+                variableHolidaysTimexMap.put(entry.getKey(), entry.getValue());
+            }
+        }
+        this.setVariableHolidaysTimexDictionary(ImmutableMap.copyOf(variableHolidaysTimexMap));
+    }
+
+    @Override
+    public int getSwiftYear(String text) {
+
+        String trimmedText = StringUtility
+            .trimStart(StringUtility.trimEnd(text)).toLowerCase(Locale.ROOT);
+        int swift = -10;
+        Optional<Match> matchNextPrefixRegex = Arrays.stream(RegExpUtility.getMatches(
+            SpanishDatePeriodParserConfiguration.nextPrefixRegex, text)).findFirst();
+        Optional<Match> matchPastPrefixRegex = Arrays.stream(RegExpUtility.getMatches(
+            SpanishDatePeriodParserConfiguration.pastPrefixRegex, text)).findFirst();
+        Optional<Match> matchThisPrefixRegex = Arrays.stream(RegExpUtility.getMatches(
+            SpanishDatePeriodParserConfiguration.thisPrefixRegex, text)).findFirst();
+        if (matchNextPrefixRegex.isPresent() && matchNextPrefixRegex.get().length == text.trim().length()) {
+            swift = 1;
+        } else if (matchPastPrefixRegex.isPresent() && matchPastPrefixRegex.get().length == text.trim().length()) {
+            swift = -1;
+        } else if (matchThisPrefixRegex.isPresent() && matchThisPrefixRegex.get().length == text.trim().length()) {
+            swift = 0;
+        }
+
+        return swift;
+    }
+
+    public String sanitizeHolidayToken(String holiday) {
+        return holiday.replace(" ", "")
+            .replace("á", "a")
+            .replace("é", "e")
+            .replace("í", "i")
+            .replace("ó", "o")
+            .replace("ú", "u");
+    }
+
+    @Override
+    protected HashMap<String, IntFunction<LocalDateTime>> initHolidayFuncs() {
+
+        HashMap<String, IntFunction<LocalDateTime>> holidays = new HashMap<>(super.initHolidayFuncs());
+        holidays.put("padres", SpanishHolidayParserConfiguration::fathersDay);
+        holidays.put("madres", SpanishHolidayParserConfiguration::mothersDay);
+        holidays.put("acciondegracias", SpanishHolidayParserConfiguration::thanksgivingDay);
+        holidays.put("trabajador", SpanishHolidayParserConfiguration::labourDay);
+        holidays.put("delaraza", SpanishHolidayParserConfiguration::columbusDay);
+        holidays.put("memoria", SpanishHolidayParserConfiguration::memorialDay);
+        holidays.put("pascuas", SpanishHolidayParserConfiguration::pascuas);
+        holidays.put("navidad", SpanishHolidayParserConfiguration::christmasDay);
+        holidays.put("nochebuena", SpanishHolidayParserConfiguration::christmasEve);
+        holidays.put("añonuevo", SpanishHolidayParserConfiguration::newYear);
+        holidays.put("nochevieja", SpanishHolidayParserConfiguration::newYearEve);
+        holidays.put("yuandan", SpanishHolidayParserConfiguration::newYear);
+        holidays.put("maestro", SpanishHolidayParserConfiguration::teacherDay);
+        holidays.put("todoslossantos", SpanishHolidayParserConfiguration::halloweenDay);
+        holidays.put("niño", SpanishHolidayParserConfiguration::childrenDay);
+        holidays.put("mujer", SpanishHolidayParserConfiguration::femaleDay);
+
+        return holidays;
+    }
+
+    private static LocalDateTime newYear(int year) {
+        return DateUtil.safeCreateFromMinValue(year, 1, 1);
+    }
+
+    private static LocalDateTime newYearEve(int year) {
+        return DateUtil.safeCreateFromMinValue(year, 12, 31);
+    }
+
+    private static LocalDateTime christmasDay(int year) {
+        return DateUtil.safeCreateFromMinValue(year, 12, 25);
+    }
+
+    private static LocalDateTime christmasEve(int year) {
+        return DateUtil.safeCreateFromMinValue(year, 12, 24);
+    }
+
+    private static LocalDateTime femaleDay(int year) {
+        return DateUtil.safeCreateFromMinValue(year, 3, 8);
+    }
+
+    private static LocalDateTime childrenDay(int year) {
+        return DateUtil.safeCreateFromMinValue(year, 6, 1);
+    }
+
+    private static LocalDateTime halloweenDay(int year) {
+        return DateUtil.safeCreateFromMinValue(year, 10, 31);
+    }
+
+    private static LocalDateTime teacherDay(int year) {
+        return DateUtil.safeCreateFromMinValue(year, 9, 10);
+    }
+
+    private static LocalDateTime pascuas(int year) {
+        return DateUtil.minValue();
+    }
+}

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/parsers/SpanishSetParserConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/parsers/SpanishSetParserConfiguration.java
@@ -1,0 +1,217 @@
+package com.microsoft.recognizers.text.datetime.spanish.parsers;
+
+import com.google.common.collect.ImmutableMap;
+import com.microsoft.recognizers.text.datetime.config.BaseOptionsConfiguration;
+import com.microsoft.recognizers.text.datetime.extractors.IDateTimeExtractor;
+import com.microsoft.recognizers.text.datetime.parsers.IDateTimeParser;
+import com.microsoft.recognizers.text.datetime.parsers.config.ICommonDateTimeParserConfiguration;
+import com.microsoft.recognizers.text.datetime.parsers.config.ISetParserConfiguration;
+import com.microsoft.recognizers.text.datetime.spanish.extractors.SpanishSetExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.utilities.MatchedTimexResult;
+
+import java.util.Locale;
+import java.util.regex.Pattern;
+
+public class SpanishSetParserConfiguration extends BaseOptionsConfiguration implements ISetParserConfiguration {
+
+    private IDateTimeExtractor durationExtractor;
+
+    public final IDateTimeExtractor getDurationExtractor() {
+        return durationExtractor;
+    }
+
+    private IDateTimeParser durationParser;
+
+    public final IDateTimeParser getDurationParser() {
+        return durationParser;
+    }
+
+    private IDateTimeExtractor timeExtractor;
+
+    public final IDateTimeExtractor getTimeExtractor() {
+        return timeExtractor;
+    }
+
+    private IDateTimeParser timeParser;
+
+    public final IDateTimeParser getTimeParser() {
+        return timeParser;
+    }
+
+    private IDateTimeExtractor dateExtractor;
+
+    public final IDateTimeExtractor getDateExtractor() {
+        return dateExtractor;
+    }
+
+    private IDateTimeParser dateParser;
+
+    public final IDateTimeParser getDateParser() {
+        return dateParser;
+    }
+
+    private IDateTimeExtractor dateTimeExtractor;
+
+    public final IDateTimeExtractor getDateTimeExtractor() {
+        return dateTimeExtractor;
+    }
+
+    private IDateTimeParser dateTimeParser;
+
+    public final IDateTimeParser getDateTimeParser() {
+        return dateTimeParser;
+    }
+
+    private IDateTimeExtractor datePeriodExtractor;
+
+    public final IDateTimeExtractor getDatePeriodExtractor() {
+        return datePeriodExtractor;
+    }
+
+    private IDateTimeParser datePeriodParser;
+
+    public final IDateTimeParser getDatePeriodParser() {
+        return datePeriodParser;
+    }
+
+    private IDateTimeExtractor timePeriodExtractor;
+
+    public final IDateTimeExtractor getTimePeriodExtractor() {
+        return timePeriodExtractor;
+    }
+
+    private IDateTimeParser timePeriodParser;
+
+    public final IDateTimeParser getTimePeriodParser() {
+        return timePeriodParser;
+    }
+
+    private IDateTimeExtractor dateTimePeriodExtractor;
+
+    public final IDateTimeExtractor getDateTimePeriodExtractor() {
+        return dateTimePeriodExtractor;
+    }
+
+    private IDateTimeParser dateTimePeriodParser;
+
+    public final IDateTimeParser getDateTimePeriodParser() {
+        return dateTimePeriodParser;
+    }
+
+    private ImmutableMap<String, String> unitMap;
+
+    public final ImmutableMap<String, String> getUnitMap() {
+        return unitMap;
+    }
+
+    private Pattern eachPrefixRegex;
+
+    public final Pattern getEachPrefixRegex() {
+        return eachPrefixRegex;
+    }
+
+    private Pattern periodicRegex;
+
+    public final Pattern getPeriodicRegex() {
+        return periodicRegex;
+    }
+
+    private Pattern eachUnitRegex;
+
+    public final Pattern getEachUnitRegex() {
+        return eachUnitRegex;
+    }
+
+    private Pattern eachDayRegex;
+
+    public final Pattern getEachDayRegex() {
+        return eachDayRegex;
+    }
+
+    private Pattern setWeekDayRegex;
+
+    public final Pattern getSetWeekDayRegex() {
+        return setWeekDayRegex;
+    }
+
+    private Pattern setEachRegex;
+
+    public final Pattern getSetEachRegex() {
+        return setEachRegex;
+    }
+
+    public SpanishSetParserConfiguration(ICommonDateTimeParserConfiguration config) {
+
+        super(config.getOptions());
+
+        durationExtractor = config.getDurationExtractor();
+        timeExtractor = config.getTimeExtractor();
+        dateExtractor = config.getDateExtractor();
+        dateTimeExtractor = config.getDateTimeExtractor();
+        datePeriodExtractor = config.getDatePeriodExtractor();
+        timePeriodExtractor = config.getTimePeriodExtractor();
+        dateTimePeriodExtractor = config.getDateTimePeriodExtractor();
+
+        durationParser = config.getDurationParser();
+        timeParser = config.getTimeParser();
+        dateParser = config.getDateParser();
+        dateTimeParser = config.getDateTimeParser();
+        datePeriodParser = config.getDatePeriodParser();
+        timePeriodParser = config.getTimePeriodParser();
+        dateTimePeriodParser = config.getDateTimePeriodParser();
+        unitMap = config.getUnitMap();
+
+        eachPrefixRegex = SpanishSetExtractorConfiguration.EachPrefixRegex;
+        periodicRegex = SpanishSetExtractorConfiguration.PeriodicRegex;
+        eachUnitRegex = SpanishSetExtractorConfiguration.EachUnitRegex;
+        eachDayRegex = SpanishSetExtractorConfiguration.EachDayRegex;
+        setWeekDayRegex = SpanishSetExtractorConfiguration.SetWeekDayRegex;
+        setEachRegex = SpanishSetExtractorConfiguration.SetEachRegex;
+    }
+
+    public MatchedTimexResult getMatchedDailyTimex(String text) {
+
+        MatchedTimexResult result = new MatchedTimexResult();
+        String trimmedText = text.trim().toLowerCase(Locale.ROOT);
+
+        if (trimmedText.endsWith("diario") || trimmedText.endsWith("diariamente")) {
+            result.setTimex("P1D");
+        } else if (trimmedText.equals("semanalmente")) {
+            result.setTimex("P1W");
+        } else if (trimmedText.equals("quincenalmente")) {
+            result.setTimex("P2W");
+        } else if (trimmedText.equals("mensualmente")) {
+            result.setTimex("P1M");
+        } else if (trimmedText.equals("anualmente")) {
+            result.setTimex("P1Y");
+        }
+
+        if (result.getTimex() != "") {
+            result.setResult(true);
+        }
+
+        return result;
+    }
+
+    public MatchedTimexResult getMatchedUnitTimex(String text) {
+
+        MatchedTimexResult result = new MatchedTimexResult();
+        String trimmedText = text.trim().toLowerCase(Locale.ROOT);
+
+        if (trimmedText.equals("día") || trimmedText.equals("dia")  || trimmedText.equals("días")  || trimmedText.equals("dias")) {
+            result.setTimex("P1D");
+        } else if (trimmedText.equals("semana") || trimmedText.equals("semanas")) {
+            result.setTimex("P1W");
+        } else if (trimmedText.equals("mes") || trimmedText.equals("meses")) {
+            result.setTimex("P1M");
+        } else if (trimmedText.equals("año") || trimmedText.equals("años")) {
+            result.setTimex("P1Y");
+        }
+
+        if (result.getTimex() != "") {
+            result.setResult(true);
+        }
+
+        return result;
+    }
+}

--- a/Java/tests/src/test/java/com/microsoft/recognizers/text/tests/datetime/DateTimeParserTest.java
+++ b/Java/tests/src/test/java/com/microsoft/recognizers/text/tests/datetime/DateTimeParserTest.java
@@ -35,7 +35,9 @@ import com.microsoft.recognizers.text.datetime.parsers.BaseTimePeriodParser;
 import com.microsoft.recognizers.text.datetime.parsers.BaseTimeZoneParser;
 import com.microsoft.recognizers.text.datetime.parsers.DateTimeParseResult;
 import com.microsoft.recognizers.text.datetime.parsers.IDateTimeParser;
+import com.microsoft.recognizers.text.datetime.spanish.parsers.DateTimePeriodParser;
 import com.microsoft.recognizers.text.datetime.spanish.parsers.SpanishCommonDateTimeParserConfiguration;
+import com.microsoft.recognizers.text.datetime.spanish.parsers.SpanishDateTimePeriodParserConfiguration;
 import com.microsoft.recognizers.text.datetime.spanish.parsers.SpanishDateParserConfiguration;
 import com.microsoft.recognizers.text.datetime.spanish.parsers.SpanishDatePeriodParserConfiguration;
 import com.microsoft.recognizers.text.datetime.spanish.parsers.SpanishDateTimeParserConfiguration;
@@ -226,8 +228,8 @@ public class DateTimeParserTest extends AbstractTest {
             //    return new BaseDateTimeAltParser(new EnglishDateTimeAltParserConfiguration(new EnglishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
             case "DateTimeParser":
                 return new BaseDateTimeParser(new SpanishDateTimeParserConfiguration(new SpanishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
-            //case "DateTimePeriodParser":
-            //    return new BaseDateTimePeriodParser(new SpanishDateTimePeriodParserConfiguration(new SpanishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
+            case "DateTimePeriodParser":
+                return new DateTimePeriodParser(new SpanishDateTimePeriodParserConfiguration(new SpanishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
             case "DurationParser":
                 return new BaseDurationParser(new SpanishDurationParserConfiguration(new SpanishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
             //case "HolidayParser":

--- a/Java/tests/src/test/java/com/microsoft/recognizers/text/tests/datetime/DateTimeParserTest.java
+++ b/Java/tests/src/test/java/com/microsoft/recognizers/text/tests/datetime/DateTimeParserTest.java
@@ -45,6 +45,7 @@ import com.microsoft.recognizers.text.datetime.spanish.parsers.SpanishDateTimePa
 import com.microsoft.recognizers.text.datetime.spanish.parsers.SpanishDurationParserConfiguration;
 import com.microsoft.recognizers.text.datetime.spanish.parsers.SpanishTimePeriodParserConfiguration;
 import com.microsoft.recognizers.text.datetime.spanish.parsers.SpanishDurationParserConfiguration;
+import com.microsoft.recognizers.text.datetime.spanish.parsers.SpanishSetParserConfiguration;
 import com.microsoft.recognizers.text.datetime.spanish.parsers.SpanishTimeParserConfiguration;
 import com.microsoft.recognizers.text.datetime.utilities.DateTimeResolutionResult;
 import com.microsoft.recognizers.text.datetime.utilities.TimeZoneResolutionResult;
@@ -235,8 +236,8 @@ public class DateTimeParserTest extends AbstractTest {
                 return new BaseDurationParser(new SpanishDurationParserConfiguration(new SpanishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
             case "HolidayParser":
                 return new BaseHolidayParser(new SpanishHolidayParserConfiguration());
-            //case "SetParser":
-            //    return new BaseSetParser(new SpanishSetParserConfiguration(new SpanishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
+            case "SetParser":
+                return new BaseSetParser(new SpanishSetParserConfiguration(new SpanishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
             //case "MergedParser":
             //    return new BaseMergedDateTimeParser(new EnglishMergedParserConfiguration(DateTimeOptions.None));
             case "TimeParser":

--- a/Java/tests/src/test/java/com/microsoft/recognizers/text/tests/datetime/DateTimeParserTest.java
+++ b/Java/tests/src/test/java/com/microsoft/recognizers/text/tests/datetime/DateTimeParserTest.java
@@ -37,6 +37,7 @@ import com.microsoft.recognizers.text.datetime.parsers.DateTimeParseResult;
 import com.microsoft.recognizers.text.datetime.parsers.IDateTimeParser;
 import com.microsoft.recognizers.text.datetime.spanish.parsers.SpanishCommonDateTimeParserConfiguration;
 import com.microsoft.recognizers.text.datetime.spanish.parsers.SpanishDateParserConfiguration;
+import com.microsoft.recognizers.text.datetime.spanish.parsers.SpanishDatePeriodParserConfiguration;
 import com.microsoft.recognizers.text.datetime.spanish.parsers.SpanishDurationParserConfiguration;
 import com.microsoft.recognizers.text.datetime.spanish.parsers.SpanishTimePeriodParserConfiguration;
 import com.microsoft.recognizers.text.datetime.spanish.parsers.SpanishDurationParserConfiguration;
@@ -218,8 +219,8 @@ public class DateTimeParserTest extends AbstractTest {
         switch (name) {
             case "DateParser":
                 return new BaseDateParser(new SpanishDateParserConfiguration(new SpanishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
-            //case "DatePeriodParser":
-            //    return new BaseDatePeriodParser(new SpanishDatePeriodParserConfiguration(new SpanishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
+            case "DatePeriodParser":
+                return new BaseDatePeriodParser(new SpanishDatePeriodParserConfiguration(new SpanishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
             //case "DateTimeAltParser":
             //    return new BaseDateTimeAltParser(new EnglishDateTimeAltParserConfiguration(new EnglishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
             //case "DateTimeParser":

--- a/Java/tests/src/test/java/com/microsoft/recognizers/text/tests/datetime/DateTimeParserTest.java
+++ b/Java/tests/src/test/java/com/microsoft/recognizers/text/tests/datetime/DateTimeParserTest.java
@@ -37,6 +37,7 @@ import com.microsoft.recognizers.text.datetime.parsers.DateTimeParseResult;
 import com.microsoft.recognizers.text.datetime.parsers.IDateTimeParser;
 import com.microsoft.recognizers.text.datetime.spanish.parsers.SpanishCommonDateTimeParserConfiguration;
 import com.microsoft.recognizers.text.datetime.spanish.parsers.SpanishDateParserConfiguration;
+import com.microsoft.recognizers.text.datetime.spanish.parsers.SpanishDurationParserConfiguration;
 import com.microsoft.recognizers.text.datetime.spanish.parsers.SpanishTimePeriodParserConfiguration;
 import com.microsoft.recognizers.text.datetime.spanish.parsers.SpanishDurationParserConfiguration;
 import com.microsoft.recognizers.text.datetime.spanish.parsers.SpanishTimeParserConfiguration;
@@ -237,36 +238,6 @@ public class DateTimeParserTest extends AbstractTest {
                 return new TimeParser(new SpanishTimeParserConfiguration(new SpanishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
             case "TimePeriodParser":
                 return new BaseTimePeriodParser(new SpanishTimePeriodParserConfiguration(new SpanishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
-            default:
-                throw new AssumptionViolatedException("Parser Type/Name not supported.");
-        }
-    }
-
-    private static IDateTimeParser getSpanishParser(String name) {
-
-        switch (name) {
-            //case "DateParser":
-            //    return new BaseDateParser(new SpanishDateParserConfiguration(new SpanishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
-            //case "DatePeriodParser":
-            //    return new BaseDatePeriodParser(new SpanishDatePeriodParserConfiguration(new SpanishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
-            //case "DateTimeAltParser":
-            //    return new BaseDateTimeAltParser(new EnglishDateTimeAltParserConfiguration(new EnglishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
-            //case "DateTimeParser":
-            //    return new BaseDateTimeParser(new SpanishDateTimeParserConfiguration(new SpanishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
-            //case "DateTimePeriodParser":
-            //    return new BaseDateTimePeriodParser(new SpanishDateTimePeriodParserConfiguration(new SpanishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
-            //case "DurationParser":
-            //    return new BaseDurationParser(new SpanishDurationParserConfiguration(new SpanishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
-            //case "HolidayParser":
-            //    return new BaseHolidayParser(new SpanishHolidayParserConfiguration());
-            //case "SetParser":
-            //    return new BaseSetParser(new SpanishSetParserConfiguration(new SpanishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
-            //case "MergedParser":
-            //    return new BaseMergedDateTimeParser(new EnglishMergedParserConfiguration(DateTimeOptions.None));
-            //case "TimeParser":
-            //    return new TimeParser(new SpanishTimeParserConfiguration(new SpanishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
-            //case "TimePeriodParser":
-            //    return new BaseTimePeriodParser(new SpanishTimePeriodParserConfiguration(new SpanishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
             default:
                 throw new AssumptionViolatedException("Parser Type/Name not supported.");
         }

--- a/Java/tests/src/test/java/com/microsoft/recognizers/text/tests/datetime/DateTimeParserTest.java
+++ b/Java/tests/src/test/java/com/microsoft/recognizers/text/tests/datetime/DateTimeParserTest.java
@@ -242,6 +242,36 @@ public class DateTimeParserTest extends AbstractTest {
         }
     }
 
+    private static IDateTimeParser getSpanishParser(String name) {
+
+        switch (name) {
+            //case "DateParser":
+            //    return new BaseDateParser(new SpanishDateParserConfiguration(new SpanishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
+            //case "DatePeriodParser":
+            //    return new BaseDatePeriodParser(new SpanishDatePeriodParserConfiguration(new SpanishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
+            //case "DateTimeAltParser":
+            //    return new BaseDateTimeAltParser(new EnglishDateTimeAltParserConfiguration(new EnglishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
+            //case "DateTimeParser":
+            //    return new BaseDateTimeParser(new SpanishDateTimeParserConfiguration(new SpanishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
+            //case "DateTimePeriodParser":
+            //    return new BaseDateTimePeriodParser(new SpanishDateTimePeriodParserConfiguration(new SpanishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
+            //case "DurationParser":
+            //    return new BaseDurationParser(new SpanishDurationParserConfiguration(new SpanishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
+            //case "HolidayParser":
+            //    return new BaseHolidayParser(new SpanishHolidayParserConfiguration());
+            //case "SetParser":
+            //    return new BaseSetParser(new SpanishSetParserConfiguration(new SpanishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
+            //case "MergedParser":
+            //    return new BaseMergedDateTimeParser(new EnglishMergedParserConfiguration(DateTimeOptions.None));
+            //case "TimeParser":
+            //    return new TimeParser(new SpanishTimeParserConfiguration(new SpanishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
+            //case "TimePeriodParser":
+            //    return new BaseTimePeriodParser(new SpanishTimePeriodParserConfiguration(new SpanishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
+            default:
+                throw new AssumptionViolatedException("Parser Type/Name not supported.");
+        }
+    }
+
     private IDateTimeExtractor getExtractor(TestCase currentCase) {
 
         String extractorName = currentCase.modelName.replace("Parser", "Extractor");

--- a/Java/tests/src/test/java/com/microsoft/recognizers/text/tests/datetime/DateTimeParserTest.java
+++ b/Java/tests/src/test/java/com/microsoft/recognizers/text/tests/datetime/DateTimeParserTest.java
@@ -37,6 +37,7 @@ import com.microsoft.recognizers.text.datetime.parsers.DateTimeParseResult;
 import com.microsoft.recognizers.text.datetime.parsers.IDateTimeParser;
 import com.microsoft.recognizers.text.datetime.spanish.parsers.DateTimePeriodParser;
 import com.microsoft.recognizers.text.datetime.spanish.parsers.SpanishCommonDateTimeParserConfiguration;
+import com.microsoft.recognizers.text.datetime.spanish.parsers.SpanishHolidayParserConfiguration;
 import com.microsoft.recognizers.text.datetime.spanish.parsers.SpanishDateTimePeriodParserConfiguration;
 import com.microsoft.recognizers.text.datetime.spanish.parsers.SpanishDateParserConfiguration;
 import com.microsoft.recognizers.text.datetime.spanish.parsers.SpanishDatePeriodParserConfiguration;
@@ -232,8 +233,8 @@ public class DateTimeParserTest extends AbstractTest {
                 return new DateTimePeriodParser(new SpanishDateTimePeriodParserConfiguration(new SpanishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
             case "DurationParser":
                 return new BaseDurationParser(new SpanishDurationParserConfiguration(new SpanishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
-            //case "HolidayParser":
-            //    return new BaseHolidayParser(new SpanishHolidayParserConfiguration());
+            case "HolidayParser":
+                return new BaseHolidayParser(new SpanishHolidayParserConfiguration());
             //case "SetParser":
             //    return new BaseSetParser(new SpanishSetParserConfiguration(new SpanishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
             //case "MergedParser":

--- a/Java/tests/src/test/java/com/microsoft/recognizers/text/tests/datetime/DateTimeParserTest.java
+++ b/Java/tests/src/test/java/com/microsoft/recognizers/text/tests/datetime/DateTimeParserTest.java
@@ -38,6 +38,7 @@ import com.microsoft.recognizers.text.datetime.parsers.IDateTimeParser;
 import com.microsoft.recognizers.text.datetime.spanish.parsers.SpanishCommonDateTimeParserConfiguration;
 import com.microsoft.recognizers.text.datetime.spanish.parsers.SpanishDateParserConfiguration;
 import com.microsoft.recognizers.text.datetime.spanish.parsers.SpanishDatePeriodParserConfiguration;
+import com.microsoft.recognizers.text.datetime.spanish.parsers.SpanishDateTimeParserConfiguration;
 import com.microsoft.recognizers.text.datetime.spanish.parsers.SpanishDurationParserConfiguration;
 import com.microsoft.recognizers.text.datetime.spanish.parsers.SpanishTimePeriodParserConfiguration;
 import com.microsoft.recognizers.text.datetime.spanish.parsers.SpanishDurationParserConfiguration;
@@ -223,8 +224,8 @@ public class DateTimeParserTest extends AbstractTest {
                 return new BaseDatePeriodParser(new SpanishDatePeriodParserConfiguration(new SpanishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
             //case "DateTimeAltParser":
             //    return new BaseDateTimeAltParser(new EnglishDateTimeAltParserConfiguration(new EnglishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
-            //case "DateTimeParser":
-            //    return new BaseDateTimeParser(new SpanishDateTimeParserConfiguration(new SpanishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
+            case "DateTimeParser":
+                return new BaseDateTimeParser(new SpanishDateTimeParserConfiguration(new SpanishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
             //case "DateTimePeriodParser":
             //    return new BaseDateTimePeriodParser(new SpanishDateTimePeriodParserConfiguration(new SpanishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
             case "DurationParser":


### PR DESCRIPTION
**Note:** This branch is based both PRs #1271 and #1273 . We will rebase once it is merged with master. 

---
# Description
- Activate `SetParser` tests
- Port `DateTimeAltParser` to Java
- Port `SpanishSetParserConfiguration.cs` to Java
- Fix `ICommonDateTimeParser` and it's dependencies
- Fix `SpanishDateTimePeriodExtractorConfiguration` using an incorrect regex

# Passing Tests

![image](https://user-images.githubusercontent.com/42191764/51060108-4c0e5f00-15cd-11e9-8169-0e2a8a635ce2.png)
