### PR TITLE
[StyleCop] Fix all the warnings in NumberWithUnit Parsers

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Parsers/BaseCurrencyParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Parsers/BaseCurrencyParser.cs
@@ -10,11 +10,11 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit
 
         public BaseCurrencyParser(BaseNumberWithUnitParserConfiguration config)
         {
-            this.Config = config;
+            this.config = config;
             numberWithUnitParser = new NumberWithUnitParser(config);
         }
 
-        protected BaseNumberWithUnitParserConfiguration Config { get; }
+        protected BaseNumberWithUnitParserConfiguration config { get; }
 
         public ParseResult Parse(ExtractResult extResult)
         {
@@ -29,7 +29,7 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit
                 pr = numberWithUnitParser.Parse(extResult);
                 var value = pr.Value as UnitValue;
 
-                Config.CurrencyNameToIsoCodeMap.TryGetValue(value?.Unit, out var mainUnitIsoCode);
+                config.CurrencyNameToIsoCodeMap.TryGetValue(value?.Unit, out var mainUnitIsoCode);
                 if (string.IsNullOrEmpty(mainUnitIsoCode) || mainUnitIsoCode.StartsWith(Constants.FAKE_ISO_CODE_PREFIX))
                 {
                     pr.Value = new UnitValue
@@ -65,8 +65,8 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit
 
         private string GetResolutionStr(object value)
         {
-            return Config.CultureInfo != null
-                ? ((double)value).ToString(Config.CultureInfo)
+            return config.CultureInfo != null
+                ? ((double)value).ToString(config.CultureInfo)
                 : value.ToString();
         }
 
@@ -110,7 +110,7 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit
                     numberValue = double.Parse(parseResultValue?.Number);
                     result.ResolutionStr = parseResult.ResolutionStr;
 
-                    Config.CurrencyNameToIsoCodeMap.TryGetValue(unitValue, out mainUnitIsoCode);
+                    config.CurrencyNameToIsoCodeMap.TryGetValue(unitValue, out mainUnitIsoCode);
 
                     // If the main unit can't be recognized, finish process this group.
                     if (string.IsNullOrEmpty(mainUnitIsoCode))
@@ -125,7 +125,7 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit
                         continue;
                     }
 
-                    Config.CurrencyFractionMapping.TryGetValue(mainUnitIsoCode, out fractionUnitsString);
+                    config.CurrencyFractionMapping.TryGetValue(mainUnitIsoCode, out fractionUnitsString);
                 }
                 else
                 {
@@ -139,8 +139,8 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit
                         continue;
                     }
 
-                    Config.CurrencyFractionCodeList.TryGetValue(unitValue, out var fractionUnitCode);
-                    Config.CurrencyFractionNumMap.TryGetValue(parseResultValue?.Unit, out var fractionNumValue);
+                    config.CurrencyFractionCodeList.TryGetValue(unitValue, out var fractionUnitCode);
+                    config.CurrencyFractionNumMap.TryGetValue(parseResultValue?.Unit, out var fractionNumValue);
 
                     if (!string.IsNullOrEmpty(fractionUnitCode) && fractionNumValue != 0 &&
                         CheckUnitsStringContains(fractionUnitCode, fractionUnitsString))

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Parsers/BaseMergedUnitParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Parsers/BaseMergedUnitParser.cs
@@ -1,15 +1,16 @@
 ﻿namespace Microsoft.Recognizers.Text.NumberWithUnit
 {
-    class BaseMergedUnitParser : IParser
+    public class BaseMergedUnitParser : IParser
     {
-        protected readonly BaseNumberWithUnitParserConfiguration config;
         private readonly NumberWithUnitParser numberWithUnitParser;
 
         public BaseMergedUnitParser(BaseNumberWithUnitParserConfiguration config)
         {
-            this.config = config;
+            this.Config = config;
             numberWithUnitParser = new NumberWithUnitParser(config);
         }
+
+        protected BaseNumberWithUnitParserConfiguration Config { get; private set; }
 
         public ParseResult Parse(ExtractResult extResult)
         {
@@ -18,7 +19,7 @@
             // For now only currency model recognizes compound units.
             if (extResult.Type.Equals(Constants.SYS_UNIT_CURRENCY))
             {
-                pr = new BaseCurrencyParser(config).Parse(extResult);
+                pr = new BaseCurrencyParser(Config).Parse(extResult);
             }
             else
             {

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Parsers/BaseMergedUnitParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Parsers/BaseMergedUnitParser.cs
@@ -6,11 +6,11 @@
 
         public BaseMergedUnitParser(BaseNumberWithUnitParserConfiguration config)
         {
-            this.Config = config;
+            this.config = config;
             numberWithUnitParser = new NumberWithUnitParser(config);
         }
 
-        protected BaseNumberWithUnitParserConfiguration Config { get; private set; }
+        protected BaseNumberWithUnitParserConfiguration config { get; private set; }
 
         public ParseResult Parse(ExtractResult extResult)
         {
@@ -19,7 +19,7 @@
             // For now only currency model recognizes compound units.
             if (extResult.Type.Equals(Constants.SYS_UNIT_CURRENCY))
             {
-                pr = new BaseCurrencyParser(Config).Parse(extResult);
+                pr = new BaseCurrencyParser(config).Parse(extResult);
             }
             else
             {

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Parsers/CurrencyUnitValue.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Parsers/CurrencyUnitValue.cs
@@ -1,0 +1,19 @@
+﻿using System.Collections.Generic;
+
+using Microsoft.Recognizers.Text.NumberWithUnit.Utilities;
+
+namespace Microsoft.Recognizers.Text.NumberWithUnit
+{
+    public class CurrencyUnitValue
+    {
+        private string number = string.Empty;
+        private string unit = string.Empty;
+        private string isoCurrency = string.Empty;
+
+        public string Number { get => number; set => number = value; }
+
+        public string Unit { get => unit; set => unit = value; }
+
+        public string IsoCurrency { get => isoCurrency; set => isoCurrency = value; }
+    }
+}

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Parsers/CurrencyUnitValue.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Parsers/CurrencyUnitValue.cs
@@ -9,11 +9,5 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit
         private string number = string.Empty;
         private string unit = string.Empty;
         private string isoCurrency = string.Empty;
-
-        public string Number { get => number; set => number = value; }
-
-        public string Unit { get => unit; set => unit = value; }
-
-        public string IsoCurrency { get => isoCurrency; set => isoCurrency = value; }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Parsers/INumberWithUnitParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Parsers/INumberWithUnitParserConfiguration.cs
@@ -14,8 +14,6 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit
 
         IDictionary<string, long> CurrencyFractionNumMap { get; }
 
-        #region Language settings
-
         CultureInfo CultureInfo { get; }
 
         IParser InternalNumberParser { get; }
@@ -24,13 +22,21 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit
 
         string ConnectorToken { get; }
 
-        #endregion
-
         void BindDictionary(IDictionary<string, string> dictionary);
     }
 
     public abstract class BaseNumberWithUnitParserConfiguration : INumberWithUnitParserConfiguration
     {
+        protected BaseNumberWithUnitParserConfiguration(CultureInfo ci)
+        {
+            this.CultureInfo = ci;
+            this.UnitMap = new Dictionary<string, string>();
+            this.CurrencyFractionNumMap = BaseCurrency.CurrencyFractionalRatios.ToImmutableDictionary();
+            this.CurrencyFractionMapping = BaseCurrency.CurrencyFractionMapping.ToImmutableDictionary();
+            this.CurrencyNameToIsoCodeMap = new Dictionary<string, string>();
+            this.CurrencyFractionCodeList = new Dictionary<string, string>();
+        }
+
         public IDictionary<string, string> UnitMap { get; }
 
         public IDictionary<string, long> CurrencyFractionNumMap { get; }
@@ -49,19 +55,9 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit
 
         public IDictionary<string, string> CurrencyFractionCodeList { get; set; }
 
-        protected BaseNumberWithUnitParserConfiguration(CultureInfo ci)
-        {
-            this.CultureInfo = ci;
-            this.UnitMap = new Dictionary<string, string>();
-            this.CurrencyFractionNumMap = BaseCurrency.CurrencyFractionalRatios.ToImmutableDictionary();
-            this.CurrencyFractionMapping = BaseCurrency.CurrencyFractionMapping.ToImmutableDictionary();
-            this.CurrencyNameToIsoCodeMap = new Dictionary<string, string>();
-            this.CurrencyFractionCodeList = new Dictionary<string, string>();
-        }
-
         public void BindDictionary(IDictionary<string, string> dictionary)
         {
-           DictionaryUtils.BindDictionary(dictionary, UnitMap); 
+           DictionaryUtils.BindDictionary(dictionary, UnitMap);
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Parsers/NumberWithUnitParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Parsers/NumberWithUnitParser.cs
@@ -6,12 +6,12 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit
 {
     public class NumberWithUnitParser : IParser
     {
-        protected readonly INumberWithUnitParserConfiguration config;
-
         public NumberWithUnitParser(INumberWithUnitParserConfiguration config)
         {
-            this.config = config;
+            this.Config = config;
         }
+
+        protected INumberWithUnitParserConfiguration Config { get; private set; }
 
         public ParseResult Parse(ExtractResult extResult)
         {
@@ -24,11 +24,11 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit
             }
             else if (extResult.Type.Equals(Constants.SYS_NUM))
             {
-                ret.Value = config.InternalNumberParser.Parse(extResult).Value;
+                ret.Value = Config.InternalNumberParser.Parse(extResult).Value;
                 return ret;
             }
             else
-            { 
+            {
                 // If there is no unitResult, means there is just unit
                 numberResult = new ExtractResult { Start = -1, Length = 0 };
             }
@@ -47,13 +47,14 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit
                     }
                 }
                 else if (i == numberResult.Start)
-                {   
+                {
                     // numberResult.start is a relative position
                     if (unitKeyBuild.Length != 0)
                     {
                         AddIfNotContained(unitKeys, unitKeyBuild.ToString().Trim());
                         unitKeyBuild.Clear();
                     }
+
                     var o = numberResult.Start + numberResult.Length - 1;
                     if (o != null)
                     {
@@ -69,25 +70,25 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit
             // Unit type depends on last unit in suffix
             var lastUnit = unitKeys.Last();
             var normalizedLastUnit = lastUnit.ToLowerInvariant();
-            if (!string.IsNullOrEmpty(config.ConnectorToken) && normalizedLastUnit.StartsWith(config.ConnectorToken))
+            if (!string.IsNullOrEmpty(Config.ConnectorToken) && normalizedLastUnit.StartsWith(Config.ConnectorToken))
             {
-                normalizedLastUnit = normalizedLastUnit.Substring(config.ConnectorToken.Length).Trim();
-                lastUnit = lastUnit.Substring(config.ConnectorToken.Length).Trim();
+                normalizedLastUnit = normalizedLastUnit.Substring(Config.ConnectorToken.Length).Trim();
+                lastUnit = lastUnit.Substring(Config.ConnectorToken.Length).Trim();
             }
 
-            if (!string.IsNullOrWhiteSpace(key) && config.UnitMap != null)
+            if (!string.IsNullOrWhiteSpace(key) && Config.UnitMap != null)
             {
-                if (config.UnitMap.TryGetValue(lastUnit, out var unitValue) ||
-                    config.UnitMap.TryGetValue(normalizedLastUnit, out unitValue))
+                if (Config.UnitMap.TryGetValue(lastUnit, out var unitValue) ||
+                    Config.UnitMap.TryGetValue(normalizedLastUnit, out unitValue))
                 {
                     var numValue = string.IsNullOrEmpty(numberResult.Text) ?
                         null :
-                        this.config.InternalNumberParser.Parse(numberResult);
+                        this.Config.InternalNumberParser.Parse(numberResult);
 
                     ret.Value = new UnitValue
                     {
                         Number = numValue?.ResolutionStr,
-                        Unit = unitValue
+                        Unit = unitValue,
                     };
                     ret.ResolutionStr = $"{numValue?.ResolutionStr} {unitValue}".Trim();
                 }
@@ -115,11 +116,5 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit
                 unitKeys.Add(unit);
             }
         }
-    }
-
-    public class UnitValue
-    {
-        public string Number = "";
-        public string Unit = "";
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Parsers/NumberWithUnitParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Parsers/NumberWithUnitParser.cs
@@ -8,10 +8,10 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit
     {
         public NumberWithUnitParser(INumberWithUnitParserConfiguration config)
         {
-            this.Config = config;
+            this.config = config;
         }
 
-        protected INumberWithUnitParserConfiguration Config { get; private set; }
+        protected INumberWithUnitParserConfiguration config { get; private set; }
 
         public ParseResult Parse(ExtractResult extResult)
         {
@@ -24,7 +24,7 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit
             }
             else if (extResult.Type.Equals(Constants.SYS_NUM))
             {
-                ret.Value = Config.InternalNumberParser.Parse(extResult).Value;
+                ret.Value = config.InternalNumberParser.Parse(extResult).Value;
                 return ret;
             }
             else
@@ -70,20 +70,20 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit
             // Unit type depends on last unit in suffix
             var lastUnit = unitKeys.Last();
             var normalizedLastUnit = lastUnit.ToLowerInvariant();
-            if (!string.IsNullOrEmpty(Config.ConnectorToken) && normalizedLastUnit.StartsWith(Config.ConnectorToken))
+            if (!string.IsNullOrEmpty(config.ConnectorToken) && normalizedLastUnit.StartsWith(config.ConnectorToken))
             {
-                normalizedLastUnit = normalizedLastUnit.Substring(Config.ConnectorToken.Length).Trim();
-                lastUnit = lastUnit.Substring(Config.ConnectorToken.Length).Trim();
+                normalizedLastUnit = normalizedLastUnit.Substring(config.ConnectorToken.Length).Trim();
+                lastUnit = lastUnit.Substring(config.ConnectorToken.Length).Trim();
             }
 
-            if (!string.IsNullOrWhiteSpace(key) && Config.UnitMap != null)
+            if (!string.IsNullOrWhiteSpace(key) && config.UnitMap != null)
             {
-                if (Config.UnitMap.TryGetValue(lastUnit, out var unitValue) ||
-                    Config.UnitMap.TryGetValue(normalizedLastUnit, out unitValue))
+                if (config.UnitMap.TryGetValue(lastUnit, out var unitValue) ||
+                    config.UnitMap.TryGetValue(normalizedLastUnit, out unitValue))
                 {
                     var numValue = string.IsNullOrEmpty(numberResult.Text) ?
                         null :
-                        this.Config.InternalNumberParser.Parse(numberResult);
+                        this.config.InternalNumberParser.Parse(numberResult);
 
                     ret.Value = new UnitValue
                     {

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Parsers/UnitValue.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Parsers/UnitValue.cs
@@ -1,0 +1,13 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Microsoft.Recognizers.Text.NumberWithUnit
+{
+    public class UnitValue
+    {
+        public string Number { get; set; } = string.Empty;
+
+        public string Unit { get; set; } = string.Empty;
+    }
+}


### PR DESCRIPTION
- SA1122: Use string.Empty for empty strings
- SA1124: Do not use regions
- SA1400: Class should declare an access modifier
- SA1401: Field should be private
- SA1122: Use string.Empty for empty strings
- SA1028: Code should not contain trailing whitespace
- SA1413: Use trailing comma in multi-line initializers
- Reorder fields, properties and constructor.
- Add spaces before comments
- Add file with the class UnitValue
- Add file with the class CurrencyUnitValue