### PR TITLE
[StyleCop] Fix all the warnings in DateTime files

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDurationParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDurationParser.cs
@@ -16,6 +16,11 @@ namespace Microsoft.Recognizers.Text.DateTime
             config = configuration;
         }
 
+        public static bool IsLessThanDay(string unit)
+        {
+            return unit.Equals("S") || unit.Equals("M") || unit.Equals("H");
+        }
+
         public ParseResult Parse(ExtractResult result)
         {
             return this.Parse(result, DateObject.Now);
@@ -43,12 +48,12 @@ namespace Microsoft.Recognizers.Text.DateTime
                 {
                     innerResult.FutureResolution = new Dictionary<string, string>
                     {
-                        {TimeTypeConstants.DURATION, innerResult.FutureValue.ToString()}
+                        { TimeTypeConstants.DURATION, innerResult.FutureValue.ToString() },
                     };
 
                     innerResult.PastResolution = new Dictionary<string, string>
                     {
-                        {TimeTypeConstants.DURATION, innerResult.PastValue.ToString()}
+                        { TimeTypeConstants.DURATION, innerResult.PastValue.ToString() },
                     };
                     value = innerResult;
                 }
@@ -75,10 +80,15 @@ namespace Microsoft.Recognizers.Text.DateTime
                 Type = er.Type,
                 Data = er.Data,
                 Value = value,
-                TimexStr = value == null ? "" : ((DateTimeResolutionResult)value).Timex,
-                ResolutionStr = ""
+                TimexStr = value == null ? string.Empty : ((DateTimeResolutionResult)value).Timex,
+                ResolutionStr = string.Empty,
             };
             return ret;
+        }
+
+        public List<DateTimeParseResult> FilterResults(string query, List<DateTimeParseResult> candidateResults)
+        {
+            return candidateResults;
         }
 
         // check {and} suffix after a {number} {unit}
@@ -87,7 +97,8 @@ namespace Microsoft.Recognizers.Text.DateTime
             double numVal = 0;
 
             var match = this.config.SuffixAndRegex.Match(text);
-            if (match.Success) {
+            if (match.Success)
+            {
                 var numStr = match.Groups["suffix_num"].Value.ToLower();
                 if (this.config.DoubleNumbers.ContainsKey(numStr))
                 {
@@ -101,7 +112,6 @@ namespace Microsoft.Recognizers.Text.DateTime
         // simple cases made by a number followed an unit
         private DateTimeResolutionResult ParseNumberWithUnit(string text, DateObject referenceTime)
         {
-
             DateTimeResolutionResult ret;
 
             if ((ret = ParseNumberSpaceUnit(text)).Success)
@@ -169,6 +179,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                     return ret;
                 }
             }
+
             return ret;
         }
 
@@ -202,6 +213,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                     return ret;
                 }
             }
+
             return ret;
         }
 
@@ -276,6 +288,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                     ret.Success = true;
                 }
             }
+
             return ret;
         }
 
@@ -333,10 +346,6 @@ namespace Microsoft.Recognizers.Text.DateTime
             return match.Success;
         }
 
-        public static bool IsLessThanDay(string unit) {
-            return unit.Equals("S") || unit.Equals("M") || unit.Equals("H");
-        }
-
         private DateTimeResolutionResult ParseMergedDuration(string text, DateObject referenceTime)
         {
             var ret = new DateTimeResolutionResult();
@@ -362,7 +371,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                 }
             }
 
-            var end = ers[ers.Count - 1].Start + ers[ers.Count - 1].Length?? 0;
+            var end = ers[ers.Count - 1].Start + ers[ers.Count - 1].Length ?? 0;
             if (end != text.Length)
             {
                 var afterStr = text.Substring(end);
@@ -374,6 +383,7 @@ namespace Microsoft.Recognizers.Text.DateTime
 
             var prs = new List<DateTimeParseResult>();
             var timexDict = new Dictionary<string, string>();
+
             // insert timex into a dictionary
             foreach (var er in ers)
             {
@@ -406,11 +416,6 @@ namespace Microsoft.Recognizers.Text.DateTime
 
             ret.Success = true;
             return ret;
-        }
-
-        public List<DateTimeParseResult> FilterResults(string query, List<DateTimeParseResult> candidateResults)
-        {
-            return candidateResults;
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseHolidayParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseHolidayParser.cs
@@ -8,8 +8,8 @@ namespace Microsoft.Recognizers.Text.DateTime
 {
     public class BaseHolidayParser : IDateTimeParser
     {
-        public static readonly string ParserName = Constants.SYS_DATETIME_DATE; //"Date";
-        
+        public static readonly string ParserName = Constants.SYS_DATETIME_DATE; // "Date"
+
         private readonly IHolidayParserConfiguration config;
 
         public BaseHolidayParser(IHolidayParserConfiguration config)
@@ -35,11 +35,11 @@ namespace Microsoft.Recognizers.Text.DateTime
                 {
                     innerResult.FutureResolution = new Dictionary<string, string>
                     {
-                        {TimeTypeConstants.DATE, DateTimeFormatUtil.FormatDate((DateObject) innerResult.FutureValue)}
+                        { TimeTypeConstants.DATE, DateTimeFormatUtil.FormatDate((DateObject)innerResult.FutureValue) },
                     };
                     innerResult.PastResolution = new Dictionary<string, string>
                     {
-                        {TimeTypeConstants.DATE, DateTimeFormatUtil.FormatDate((DateObject) innerResult.PastValue)}
+                        { TimeTypeConstants.DATE, DateTimeFormatUtil.FormatDate((DateObject)innerResult.PastValue) },
                     };
                     value = innerResult;
                 }
@@ -53,10 +53,16 @@ namespace Microsoft.Recognizers.Text.DateTime
                 Type = er.Type,
                 Data = er.Data,
                 Value = value,
-                TimexStr = value == null ? "" : ((DateTimeResolutionResult) value).Timex,
-                ResolutionStr = ""
+                TimexStr = value == null ? string.Empty : ((DateTimeResolutionResult)value).Timex,
+                ResolutionStr = string.Empty,
             };
+
             return ret;
+        }
+
+        public List<DateTimeParseResult> FilterResults(string query, List<DateTimeParseResult> candidateResults)
+        {
+            return candidateResults;
         }
 
         private DateTimeResolutionResult ParseHolidayRegexMatch(string text, DateObject referenceDate)
@@ -72,6 +78,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                     return ret;
                 }
             }
+
             return new DateTimeResolutionResult();
         }
 
@@ -98,6 +105,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                 {
                     return ret;
                 }
+
                 year = referenceDate.Year + swift;
                 hasYear = true;
             }
@@ -115,7 +123,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                     break;
                 }
             }
-            
+
             var timexStr = string.Empty;
             if (!string.IsNullOrEmpty(holidayKey))
             {
@@ -137,7 +145,7 @@ namespace Microsoft.Recognizers.Text.DateTime
 
                 if (value.Equals(DateObject.MinValue))
                 {
-                    ret.Timex = "";
+                    ret.Timex = string.Empty;
                     ret.FutureValue = ret.PastValue = DateObject.MinValue;
                     ret.Success = true;
                     return ret;
@@ -186,11 +194,6 @@ namespace Microsoft.Recognizers.Text.DateTime
             }
 
             return value;
-        }
-
-        public List<DateTimeParseResult> FilterResults(string query, List<DateTimeParseResult> candidateResults)
-        {
-            return candidateResults;
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseHolidayParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseHolidayParserConfiguration.cs
@@ -3,14 +3,20 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Text.RegularExpressions;
-using DateObject = System.DateTime;
-
 using Microsoft.Recognizers.Definitions;
+using DateObject = System.DateTime;
 
 namespace Microsoft.Recognizers.Text.DateTime
 {
     public abstract class BaseHolidayParserConfiguration : BaseOptionsConfiguration, IHolidayParserConfiguration
     {
+        protected BaseHolidayParserConfiguration(IOptionsConfiguration config)
+                : base(config)
+        {
+            this.VariableHolidaysTimexDictionary = BaseDateTime.VariableHolidaysTimexDictionary.ToImmutableDictionary();
+            this.HolidayFuncDictionary = InitHolidayFuncs().ToImmutableDictionary();
+        }
+
         public IImmutableDictionary<string, string> VariableHolidaysTimexDictionary { get; protected set; }
 
         public IImmutableDictionary<string, Func<int, DateObject>> HolidayFuncDictionary { get; protected set; }
@@ -19,29 +25,6 @@ namespace Microsoft.Recognizers.Text.DateTime
 
         public IEnumerable<Regex> HolidayRegexList { get; protected set; }
 
-        protected BaseHolidayParserConfiguration(IOptionsConfiguration config) : base(config)
-        {
-            this.VariableHolidaysTimexDictionary = BaseDateTime.VariableHolidaysTimexDictionary.ToImmutableDictionary();
-            this.HolidayFuncDictionary = InitHolidayFuncs().ToImmutableDictionary();
-        }
-
-        protected virtual IDictionary<string, Func<int, DateObject>> InitHolidayFuncs()
-        {
-            return new Dictionary<string, Func<int, DateObject>>
-            {
-                {"fathers", FathersDay},
-                {"mothers", MothersDay},
-                {"thanksgivingday", ThanksgivingDay},
-                {"thanksgiving", ThanksgivingDay},
-                {"martinlutherking", MartinLutherKingDay},
-                {"washingtonsbirthday", WashingtonsBirthday},
-                {"canberra", CanberraDay},
-                {"labour", LabourDay},
-                {"columbus", ColumbusDay},
-                {"memorial", MemorialDay}
-            };
-        }
-
         public abstract int GetSwiftYear(string text);
 
         public abstract string SanitizeHolidayToken(string holiday);
@@ -49,12 +32,6 @@ namespace Microsoft.Recognizers.Text.DateTime
         protected static DateObject MothersDay(int year) => DateObject.MinValue.SafeCreateFromValue(year, 5, GetDay(year, 5, 1, DayOfWeek.Sunday));
 
         protected static DateObject FathersDay(int year) => DateObject.MinValue.SafeCreateFromValue(year, 6, GetDay(year, 6, 2, DayOfWeek.Sunday));
-
-        private static DateObject MartinLutherKingDay(int year) => DateObject.MinValue.SafeCreateFromValue(year, 1, GetDay(year, 1, 2, DayOfWeek.Monday));
-
-        private static DateObject WashingtonsBirthday(int year) => DateObject.MinValue.SafeCreateFromValue(year, 2, GetDay(year, 2, 2, DayOfWeek.Monday));
-
-        private static DateObject CanberraDay(int year) => DateObject.MinValue.SafeCreateFromValue(year, 3, GetDay(year, 3, 0, DayOfWeek.Monday));
 
         protected static DateObject MemorialDay(int year) => DateObject.MinValue.SafeCreateFromValue(year, 5, GetLastDay(year, 5, DayOfWeek.Monday));
 
@@ -73,5 +50,28 @@ namespace Microsoft.Recognizers.Text.DateTime
             (from day in Enumerable.Range(1, DateObject.DaysInMonth(year, month))
              where DateObject.MinValue.SafeCreateFromValue(year, month, day).DayOfWeek == dayOfWeek
              select day).Last();
+
+        protected virtual IDictionary<string, Func<int, DateObject>> InitHolidayFuncs()
+        {
+            return new Dictionary<string, Func<int, DateObject>>
+            {
+                { "fathers", FathersDay },
+                { "mothers", MothersDay },
+                { "thanksgivingday", ThanksgivingDay },
+                { "thanksgiving", ThanksgivingDay },
+                { "martinlutherking", MartinLutherKingDay },
+                { "washingtonsbirthday", WashingtonsBirthday },
+                { "canberra", CanberraDay },
+                { "labour", LabourDay },
+                { "columbus", ColumbusDay },
+                { "memorial", MemorialDay },
+            };
+        }
+
+        private static DateObject MartinLutherKingDay(int year) => DateObject.MinValue.SafeCreateFromValue(year, 1, GetDay(year, 1, 2, DayOfWeek.Monday));
+
+        private static DateObject WashingtonsBirthday(int year) => DateObject.MinValue.SafeCreateFromValue(year, 2, GetDay(year, 2, 2, DayOfWeek.Monday));
+
+        private static DateObject CanberraDay(int year) => DateObject.MinValue.SafeCreateFromValue(year, 3, GetDay(year, 3, 0, DayOfWeek.Monday));
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/DateTimePeriodParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/DateTimePeriodParser.cs
@@ -1,13 +1,13 @@
 ﻿using System;
-using DateObject = System.DateTime;
-
 using Microsoft.Recognizers.Definitions.Spanish;
+using DateObject = System.DateTime;
 
 namespace Microsoft.Recognizers.Text.DateTime.Spanish
 {
     public class DateTimePeriodParser : BaseDateTimePeriodParser
     {
-        public DateTimePeriodParser(IDateTimePeriodParserConfiguration configuration) : base(configuration)
+        public DateTimePeriodParser(IDateTimePeriodParserConfiguration configuration)
+            : base(configuration)
         {
         }
 
@@ -34,7 +34,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
                 ret.Timex = DateTimeFormatUtil.FormatDate(date) + timeStr;
                 ret.FutureValue =
                     ret.PastValue =
-                        new Tuple<DateObject, DateObject>(DateObject.MinValue.SafeCreateFromValue(year, month, day, beginHour, 0, 0),
+                        new Tuple<DateObject, DateObject>(
+                            DateObject.MinValue.SafeCreateFromValue(year, month, day, beginHour, 0, 0),
                             DateObject.MinValue.SafeCreateFromValue(year, month, day, endHour, endMin, endMin));
                 ret.Success = true;
                 return ret;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/DateTimePeriodParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/DateTimePeriodParser.cs
@@ -1,13 +1,13 @@
 ﻿using System;
-using Microsoft.Recognizers.Definitions.Spanish;
 using DateObject = System.DateTime;
+
+using Microsoft.Recognizers.Definitions.Spanish;
 
 namespace Microsoft.Recognizers.Text.DateTime.Spanish
 {
     public class DateTimePeriodParser : BaseDateTimePeriodParser
     {
-        public DateTimePeriodParser(IDateTimePeriodParserConfiguration configuration)
-            : base(configuration)
+        public DateTimePeriodParser(IDateTimePeriodParserConfiguration configuration) : base(configuration)
         {
         }
 
@@ -34,8 +34,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
                 ret.Timex = DateTimeFormatUtil.FormatDate(date) + timeStr;
                 ret.FutureValue =
                     ret.PastValue =
-                        new Tuple<DateObject, DateObject>(
-                            DateObject.MinValue.SafeCreateFromValue(year, month, day, beginHour, 0, 0),
+                        new Tuple<DateObject, DateObject>(DateObject.MinValue.SafeCreateFromValue(year, month, day, beginHour, 0, 0),
                             DateObject.MinValue.SafeCreateFromValue(year, month, day, endHour, endMin, endMin));
                 ret.Success = true;
                 return ret;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/AgoLaterUtil.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/AgoLaterUtil.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Text.RegularExpressions;
 
@@ -8,12 +8,24 @@ using DateObject = System.DateTime;
 
 namespace Microsoft.Recognizers.Text.DateTime
 {
+    public enum AgoLaterMode
+    {
+        /// <summary>
+        /// Date
+        /// </summary>
+        Date = 0,
+
+        /// <summary>
+        /// Datetime
+        /// </summary>
+        DateTime,
+    }
+
     public class AgoLaterUtil
     {
         public delegate int SwiftDayDelegate(string text);
 
-        public static List<Token> ExtractorDurationWithBeforeAndAfter(string text, ExtractResult er, List<Token> ret,
-            IDateTimeUtilityConfiguration utilityConfiguration)
+        public static List<Token> ExtractorDurationWithBeforeAndAfter(string text, ExtractResult er, List<Token> ret, IDateTimeUtilityConfiguration utilityConfiguration)
         {
             var pos = (int)er.Start + (int)er.Length;
 
@@ -66,22 +78,22 @@ namespace Microsoft.Recognizers.Text.DateTime
                             ret.Add(new Token((int)er.Start - index, (int)er.Start + (int)er.Length));
                         }
                     }
-                }                
+                }
             }
 
             return ret;
         }
 
-        public static DateTimeResolutionResult ParseDurationWithAgoAndLater(string text, 
+        public static DateTimeResolutionResult ParseDurationWithAgoAndLater(
+            string text,
             DateObject referenceTime,
             IDateTimeExtractor durationExtractor,
-            IDateTimeParser durationParser, 
+            IDateTimeParser durationParser,
             IImmutableDictionary<string, string> unitMap,
             Regex unitRegex,
             IDateTimeUtilityConfiguration utilityConfiguration,
             SwiftDayDelegate swiftDay)
         {
-
             var ret = new DateTimeResolutionResult();
             var durationRes = durationExtractor.Extract(text, referenceTime);
             if (durationRes.Count > 0)
@@ -90,7 +102,6 @@ namespace Microsoft.Recognizers.Text.DateTime
                 var matches = unitRegex.Matches(text);
                 if (matches.Count > 0)
                 {
-
                     var afterStr =
                             text.Substring((int)durationRes[0].Start + (int)durationRes[0].Length)
                                 .Trim().ToLowerInvariant();
@@ -107,14 +118,14 @@ namespace Microsoft.Recognizers.Text.DateTime
 
                     if (pr.Value != null)
                     {
-                        return GetAgoLaterResult(pr, afterStr, beforeStr, referenceTime,
-                                                 utilityConfiguration, mode, swiftDay);
+                        return GetAgoLaterResult(pr, afterStr, beforeStr, referenceTime, utilityConfiguration, mode, swiftDay);
                     }
                 }
             }
+
             return ret;
         }
-        
+
         private static DateTimeResolutionResult GetAgoLaterResult(
             DateTimeParseResult durationParseResult,
             string afterStr,
@@ -124,7 +135,6 @@ namespace Microsoft.Recognizers.Text.DateTime
             AgoLaterMode mode,
             SwiftDayDelegate swiftDay)
         {
-
             var ret = new DateTimeResolutionResult();
             var resultDateTime = referenceTime;
             var timex = durationParseResult.TimexStr;
@@ -148,9 +158,9 @@ namespace Microsoft.Recognizers.Text.DateTime
                 {
                     swift = swiftDay(match.Groups["day"].Value);
                 }
-                
+
                 resultDateTime = DurationParsingUtil.ShiftDateTime(timex, referenceTime.AddDays(swift), false);
-                
+
                 ((DateTimeResolutionResult)durationParseResult.Value).Mod = Constants.BEFORE_MOD;
             }
             else if (MatchingUtil.ContainsAgoLaterIndex(afterStr, utilityConfiguration.LaterRegex) ||
@@ -185,14 +195,8 @@ namespace Microsoft.Recognizers.Text.DateTime
                 ret.SubDateTimeEntities = new List<object> { durationParseResult };
                 ret.Success = true;
             }
-            
-            return ret;
-        }
 
-        public enum AgoLaterMode
-        {
-            Date = 0,
-            DateTime
+            return ret;
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/ConditionalMatch.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/ConditionalMatch.cs
@@ -7,15 +7,15 @@ namespace Microsoft.Recognizers.Text.DateTime
 {
     public class ConditionalMatch
     {
-        public Match Match { get; }
-
-        public bool Success { get; }
-
         public ConditionalMatch(Match match, bool success)
         {
             Match = match;
             Success = success;
         }
+
+        public Match Match { get; }
+
+        public bool Success { get; }
 
         public int Index
         {

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/MatchingUtil.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/MatchingUtil.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -49,10 +49,8 @@ namespace Microsoft.Recognizers.Text.DateTime
         }
 
         // Temporary solution for remove superfluous words only under the Preview mode
-        public static string PreProcessTextRemoveSuperfluousWords(string text, StringMatcher matcher, 
-                                                                  out List<MatchResult<string>> superfluousWordMatches)
+        public static string PreProcessTextRemoveSuperfluousWords(string text, StringMatcher matcher, out List<MatchResult<string>> superfluousWordMatches)
         {
-
             superfluousWordMatches = RemoveSubMatches(matcher.Find(text));
 
             var bias = 0;
@@ -67,11 +65,8 @@ namespace Microsoft.Recognizers.Text.DateTime
         }
 
         // Temporary solution for recover superfluous words only under the Preview mode
-        public static List<ExtractResult> PosProcessExtractionRecoverSuperfluousWords(List<ExtractResult> extractResults,
-                                                                                      List<MatchResult<string>> superfluousWordMatches, 
-                                                                                      string originText)
+        public static List<ExtractResult> PosProcessExtractionRecoverSuperfluousWords(List<ExtractResult> extractResults, List<MatchResult<string>> superfluousWordMatches, string originText)
         {
-
             foreach (var match in superfluousWordMatches)
             {
                 foreach (var extractResult in extractResults)
@@ -104,9 +99,7 @@ namespace Microsoft.Recognizers.Text.DateTime
             return matchList.Where(item =>
                 !matchList.Any(
                     ritem => (ritem.Start < item.Start && ritem.End >= item.End) ||
-                             (ritem.Start <= item.Start && ritem.End > item.End)
-                    )
-                ).ToList();
+                             (ritem.Start <= item.Start && ritem.End > item.End))).ToList();
         }
     }
 }


### PR DESCRIPTION
- Add whitespaces
- Replace "" with string.Empty
- Add spacing
- Reorder methods
- Document enums