### PR TITLE
[StyleCop] Fix warnings in Italian, French and German DateParserConfiguration

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchDateParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchDateParserConfiguration.cs
@@ -9,6 +9,50 @@ namespace Microsoft.Recognizers.Text.DateTime.French
 {
     public class FrenchDateParserConfiguration : BaseOptionsConfiguration, IDateParserConfiguration
     {
+        public FrenchDateParserConfiguration(ICommonDateTimeParserConfiguration config)
+            : base(config)
+        {
+            DateTokenPrefix = DateTimeDefinitions.DateTokenPrefix;
+            IntegerExtractor = config.IntegerExtractor;
+            OrdinalExtractor = config.OrdinalExtractor;
+            CardinalExtractor = config.CardinalExtractor;
+            NumberParser = config.NumberParser;
+            DurationExtractor = config.DurationExtractor;
+            DateExtractor = config.DateExtractor;
+            DurationParser = config.DurationParser;
+            DateRegexes = new FrenchDateExtractorConfiguration(this).DateRegexList;
+            OnRegex = FrenchDateExtractorConfiguration.OnRegex;
+            SpecialDayRegex = FrenchDateExtractorConfiguration.SpecialDayRegex;
+            SpecialDayWithNumRegex = FrenchDateExtractorConfiguration.SpecialDayWithNumRegex;
+            NextRegex = FrenchDateExtractorConfiguration.NextRegex;
+            ThisRegex = FrenchDateExtractorConfiguration.ThisRegex;
+            LastRegex = FrenchDateExtractorConfiguration.LastRegex;
+            UnitRegex = FrenchDateExtractorConfiguration.DateUnitRegex;
+            WeekDayRegex = FrenchDateExtractorConfiguration.WeekDayRegex;
+            StrictWeekDay = FrenchDateExtractorConfiguration.StrictWeekDay;
+            MonthRegex = FrenchDateExtractorConfiguration.MonthRegex;
+            WeekDayOfMonthRegex = FrenchDateExtractorConfiguration.WeekDayOfMonthRegex;
+            ForTheRegex = FrenchDateExtractorConfiguration.ForTheRegex;
+            WeekDayAndDayOfMothRegex = FrenchDateExtractorConfiguration.WeekDayAndDayOfMothRegex;
+            RelativeMonthRegex = FrenchDateExtractorConfiguration.RelativeMonthRegex;
+            YearSuffix = FrenchDateExtractorConfiguration.YearSuffix;
+            RelativeWeekDayRegex = FrenchDateExtractorConfiguration.RelativeWeekDayRegex;
+            RelativeDayRegex = new Regex(DateTimeDefinitions.RelativeDayRegex, RegexOptions.Singleline);
+            NextPrefixRegex = new Regex(DateTimeDefinitions.NextPrefixRegex, RegexOptions.Singleline);
+            PastPrefixRegex = new Regex(DateTimeDefinitions.PastPrefixRegex, RegexOptions.Singleline);
+            DayOfMonth = config.DayOfMonth;
+            DayOfWeek = config.DayOfWeek;
+            MonthOfYear = config.MonthOfYear;
+            CardinalMap = config.CardinalMap;
+            UnitMap = config.UnitMap;
+            UtilityConfiguration = config.UtilityConfiguration;
+            SameDayTerms = DateTimeDefinitions.SameDayTerms.ToImmutableList();
+            PlusOneDayTerms = DateTimeDefinitions.PlusOneDayTerms.ToImmutableList();
+            PlusTwoDayTerms = DateTimeDefinitions.PlusTwoDayTerms.ToImmutableList();
+            MinusOneDayTerms = DateTimeDefinitions.MinusOneDayTerms.ToImmutableList();
+            MinusTwoDayTerms = DateTimeDefinitions.MinusTwoDayTerms.ToImmutableList();
+        }
+
         public string DateTokenPrefix { get; }
 
         public IExtractor IntegerExtractor { get; }
@@ -87,64 +131,23 @@ namespace Microsoft.Recognizers.Text.DateTime.French
 
         public IDateTimeUtilityConfiguration UtilityConfiguration { get; }
 
-        public FrenchDateParserConfiguration(ICommonDateTimeParserConfiguration config) : base(config)
-        {
-            DateTokenPrefix = DateTimeDefinitions.DateTokenPrefix;
-            IntegerExtractor = config.IntegerExtractor;
-            OrdinalExtractor = config.OrdinalExtractor;
-            CardinalExtractor = config.CardinalExtractor;
-            NumberParser = config.NumberParser;
-            DurationExtractor = config.DurationExtractor;
-            DateExtractor = config.DateExtractor;
-            DurationParser = config.DurationParser;
-            DateRegexes = new FrenchDateExtractorConfiguration(this).DateRegexList;
-            OnRegex = FrenchDateExtractorConfiguration.OnRegex;
-            SpecialDayRegex = FrenchDateExtractorConfiguration.SpecialDayRegex;
-            SpecialDayWithNumRegex = FrenchDateExtractorConfiguration.SpecialDayWithNumRegex;
-            NextRegex = FrenchDateExtractorConfiguration.NextRegex;
-            ThisRegex = FrenchDateExtractorConfiguration.ThisRegex;
-            LastRegex = FrenchDateExtractorConfiguration.LastRegex;
-            UnitRegex = FrenchDateExtractorConfiguration.DateUnitRegex;
-            WeekDayRegex = FrenchDateExtractorConfiguration.WeekDayRegex;
-            StrictWeekDay = FrenchDateExtractorConfiguration.StrictWeekDay;
-            MonthRegex = FrenchDateExtractorConfiguration.MonthRegex;
-            WeekDayOfMonthRegex = FrenchDateExtractorConfiguration.WeekDayOfMonthRegex;
-            ForTheRegex = FrenchDateExtractorConfiguration.ForTheRegex;
-            WeekDayAndDayOfMothRegex = FrenchDateExtractorConfiguration.WeekDayAndDayOfMothRegex;
-            RelativeMonthRegex = FrenchDateExtractorConfiguration.RelativeMonthRegex;
-            YearSuffix = FrenchDateExtractorConfiguration.YearSuffix;
-            RelativeWeekDayRegex = FrenchDateExtractorConfiguration.RelativeWeekDayRegex;
-            RelativeDayRegex = new Regex(DateTimeDefinitions.RelativeDayRegex, RegexOptions.Singleline);
-            NextPrefixRegex = new Regex(DateTimeDefinitions.NextPrefixRegex, RegexOptions.Singleline);
-            PastPrefixRegex = new Regex(DateTimeDefinitions.PastPrefixRegex, RegexOptions.Singleline);
-            DayOfMonth = config.DayOfMonth;
-            DayOfWeek = config.DayOfWeek;
-            MonthOfYear = config.MonthOfYear;
-            CardinalMap = config.CardinalMap;
-            UnitMap = config.UnitMap;
-            UtilityConfiguration = config.UtilityConfiguration;
-            SameDayTerms = DateTimeDefinitions.SameDayTerms.ToImmutableList();
-            PlusOneDayTerms = DateTimeDefinitions.PlusOneDayTerms.ToImmutableList();
-            PlusTwoDayTerms = DateTimeDefinitions.PlusTwoDayTerms.ToImmutableList();
-            MinusOneDayTerms = DateTimeDefinitions.MinusOneDayTerms.ToImmutableList();
-            MinusTwoDayTerms = DateTimeDefinitions.MinusTwoDayTerms.ToImmutableList();
-        }
-
         public int GetSwiftDay(string text)
         {
             var trimmedText = text.Trim().ToLowerInvariant();
 
             var swift = 0;
-            if (trimmedText.Equals("aujourd'hui") || trimmedText.Equals("auj")) //today
+
+            // today
+            if (trimmedText.Equals("aujourd'hui") || trimmedText.Equals("auj"))
             {
                 swift = 0;
             }
-            else if (trimmedText.Equals("demain") || trimmedText.Equals("a2m1") || 
+            else if (trimmedText.Equals("demain") || trimmedText.Equals("a2m1") ||
                      trimmedText.Equals("lendemain") || trimmedText.Equals("jour suivant"))
             {
                 swift = 1;
-            }
-            else if (trimmedText.Equals("hier")) // yesterday
+            } // yesterday
+            else if (trimmedText.Equals("hier"))
             {
                 swift = -1;
             }
@@ -157,11 +160,12 @@ namespace Microsoft.Recognizers.Text.DateTime.French
                      trimmedText.StartsWith("avant hier"))
             {
                 swift = -2;
-            }
-            else if (trimmedText.EndsWith("dernier")) // dernier
+            } // dernier
+            else if (trimmedText.EndsWith("dernier"))
             {
                 swift = -1;
             }
+
             return swift;
         }
 
@@ -178,14 +182,15 @@ namespace Microsoft.Recognizers.Text.DateTime.French
             {
                 swift = -1;
             }
+
             return swift;
         }
 
         public bool IsCardinalLast(string text)
         {
             var trimmedText = text.Trim().ToLowerInvariant();
-            return (trimmedText.Equals("dernière") || trimmedText.Equals("dernières") ||
-                    trimmedText.Equals("derniere") || trimmedText.Equals("dernieres"));
+            return trimmedText.Equals("dernière") || trimmedText.Equals("dernières") ||
+                    trimmedText.Equals("derniere") || trimmedText.Equals("dernieres");
         }
 
         public string Normalize(string text)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanDateParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanDateParserConfiguration.cs
@@ -1,15 +1,57 @@
 ﻿using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Text.RegularExpressions;
-
-using Microsoft.Recognizers.Text.DateTime.Utilities;
 using Microsoft.Recognizers.Definitions.German;
+using Microsoft.Recognizers.Text.DateTime.Utilities;
 using Microsoft.Recognizers.Text.Number;
 
 namespace Microsoft.Recognizers.Text.DateTime.German
 {
     public class GermanDateParserConfiguration : BaseOptionsConfiguration, IDateParserConfiguration
     {
+        public GermanDateParserConfiguration(ICommonDateTimeParserConfiguration config)
+            : base(config)
+        {
+            DateTokenPrefix = DateTimeDefinitions.DateTokenPrefix;
+            IntegerExtractor = config.IntegerExtractor;
+            OrdinalExtractor = config.OrdinalExtractor;
+            CardinalExtractor = config.CardinalExtractor;
+            NumberParser = config.NumberParser;
+            DurationExtractor = config.DurationExtractor;
+            DateExtractor = config.DateExtractor;
+            DurationParser = config.DurationParser;
+            DateRegexes = new GermanDateExtractorConfiguration(this).DateRegexList;
+            OnRegex = GermanDateExtractorConfiguration.OnRegex;
+            SpecialDayRegex = GermanDateExtractorConfiguration.SpecialDayRegex;
+            SpecialDayWithNumRegex = GermanDateExtractorConfiguration.SpecialDayWithNumRegex;
+            NextRegex = GermanDateExtractorConfiguration.NextDateRegex;
+            ThisRegex = GermanDateExtractorConfiguration.ThisRegex;
+            LastRegex = GermanDateExtractorConfiguration.LastDateRegex;
+            UnitRegex = GermanDateExtractorConfiguration.DateUnitRegex;
+            WeekDayRegex = GermanDateExtractorConfiguration.WeekDayRegex;
+            MonthRegex = GermanDateExtractorConfiguration.MonthRegex;
+            WeekDayOfMonthRegex = GermanDateExtractorConfiguration.WeekDayOfMonthRegex;
+            ForTheRegex = GermanDateExtractorConfiguration.ForTheRegex;
+            WeekDayAndDayOfMothRegex = GermanDateExtractorConfiguration.WeekDayAndDayOfMothRegex;
+            RelativeMonthRegex = GermanDateExtractorConfiguration.RelativeMonthRegex;
+            YearSuffix = GermanDateExtractorConfiguration.YearSuffix;
+            RelativeWeekDayRegex = GermanDateExtractorConfiguration.RelativeWeekDayRegex;
+            RelativeDayRegex = new Regex(DateTimeDefinitions.RelativeDayRegex, RegexOptions.Singleline);
+            NextPrefixRegex = new Regex(DateTimeDefinitions.NextPrefixRegex, RegexOptions.Singleline);
+            PastPrefixRegex = new Regex(DateTimeDefinitions.PastPrefixRegex, RegexOptions.Singleline);
+            DayOfMonth = config.DayOfMonth;
+            DayOfWeek = config.DayOfWeek;
+            MonthOfYear = config.MonthOfYear;
+            CardinalMap = config.CardinalMap;
+            UnitMap = config.UnitMap;
+            UtilityConfiguration = config.UtilityConfiguration;
+            SameDayTerms = DateTimeDefinitions.SameDayTerms.ToImmutableList();
+            PlusOneDayTerms = DateTimeDefinitions.PlusOneDayTerms.ToImmutableList();
+            PlusTwoDayTerms = DateTimeDefinitions.PlusTwoDayTerms.ToImmutableList();
+            MinusOneDayTerms = DateTimeDefinitions.MinusOneDayTerms.ToImmutableList();
+            MinusTwoDayTerms = DateTimeDefinitions.MinusTwoDayTerms.ToImmutableList();
+        }
+
         public string DateTokenPrefix { get; }
 
         public IExtractor IntegerExtractor { get; }
@@ -85,48 +127,6 @@ namespace Microsoft.Recognizers.Text.DateTime.German
         public IImmutableList<string> MinusTwoDayTerms { get; }
 
         public IDateTimeUtilityConfiguration UtilityConfiguration { get; }
-
-        public GermanDateParserConfiguration(ICommonDateTimeParserConfiguration config) : base(config)
-        {
-            DateTokenPrefix = DateTimeDefinitions.DateTokenPrefix;
-            IntegerExtractor = config.IntegerExtractor;
-            OrdinalExtractor = config.OrdinalExtractor;
-            CardinalExtractor = config.CardinalExtractor;
-            NumberParser = config.NumberParser;
-            DurationExtractor = config.DurationExtractor;
-            DateExtractor = config.DateExtractor;
-            DurationParser = config.DurationParser;
-            DateRegexes = new GermanDateExtractorConfiguration(this).DateRegexList;
-            OnRegex = GermanDateExtractorConfiguration.OnRegex;
-            SpecialDayRegex = GermanDateExtractorConfiguration.SpecialDayRegex;
-            SpecialDayWithNumRegex = GermanDateExtractorConfiguration.SpecialDayWithNumRegex;
-            NextRegex = GermanDateExtractorConfiguration.NextDateRegex;
-            ThisRegex = GermanDateExtractorConfiguration.ThisRegex;
-            LastRegex = GermanDateExtractorConfiguration.LastDateRegex;
-            UnitRegex = GermanDateExtractorConfiguration.DateUnitRegex;
-            WeekDayRegex = GermanDateExtractorConfiguration.WeekDayRegex;
-            MonthRegex = GermanDateExtractorConfiguration.MonthRegex;
-            WeekDayOfMonthRegex = GermanDateExtractorConfiguration.WeekDayOfMonthRegex;
-            ForTheRegex = GermanDateExtractorConfiguration.ForTheRegex;
-            WeekDayAndDayOfMothRegex = GermanDateExtractorConfiguration.WeekDayAndDayOfMothRegex;
-            RelativeMonthRegex = GermanDateExtractorConfiguration.RelativeMonthRegex;
-            YearSuffix = GermanDateExtractorConfiguration.YearSuffix;
-            RelativeWeekDayRegex = GermanDateExtractorConfiguration.RelativeWeekDayRegex;
-            RelativeDayRegex = new Regex(DateTimeDefinitions.RelativeDayRegex, RegexOptions.Singleline);
-            NextPrefixRegex = new Regex(DateTimeDefinitions.NextPrefixRegex, RegexOptions.Singleline);
-            PastPrefixRegex = new Regex(DateTimeDefinitions.PastPrefixRegex, RegexOptions.Singleline);
-            DayOfMonth = config.DayOfMonth;
-            DayOfWeek = config.DayOfWeek;
-            MonthOfYear = config.MonthOfYear;
-            CardinalMap = config.CardinalMap;
-            UnitMap = config.UnitMap;
-            UtilityConfiguration = config.UtilityConfiguration;
-            SameDayTerms = DateTimeDefinitions.SameDayTerms.ToImmutableList();
-            PlusOneDayTerms = DateTimeDefinitions.PlusOneDayTerms.ToImmutableList();
-            PlusTwoDayTerms = DateTimeDefinitions.PlusTwoDayTerms.ToImmutableList();
-            MinusOneDayTerms = DateTimeDefinitions.MinusOneDayTerms.ToImmutableList();
-            MinusTwoDayTerms = DateTimeDefinitions.MinusTwoDayTerms.ToImmutableList();
-        }
 
         public int GetSwiftMonth(string text)
         {

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianDateParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianDateParserConfiguration.cs
@@ -9,6 +9,50 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
 {
     public class ItalianDateParserConfiguration : BaseOptionsConfiguration, IDateParserConfiguration
     {
+        public ItalianDateParserConfiguration(ICommonDateTimeParserConfiguration config)
+            : base(config.Options)
+        {
+            DateTokenPrefix = DateTimeDefinitions.DateTokenPrefix;
+            IntegerExtractor = config.IntegerExtractor;
+            OrdinalExtractor = config.OrdinalExtractor;
+            CardinalExtractor = config.CardinalExtractor;
+            NumberParser = config.NumberParser;
+            DurationExtractor = config.DurationExtractor;
+            DateExtractor = config.DateExtractor;
+            DurationParser = config.DurationParser;
+            DateRegexes = new ItalianDateExtractorConfiguration(this).DateRegexList;
+            OnRegex = ItalianDateExtractorConfiguration.OnRegex;
+            SpecialDayRegex = ItalianDateExtractorConfiguration.SpecialDayRegex;
+            SpecialDayWithNumRegex = ItalianDateExtractorConfiguration.SpecialDayWithNumRegex;
+            NextRegex = ItalianDateExtractorConfiguration.NextRegex;
+            ThisRegex = ItalianDateExtractorConfiguration.ThisRegex;
+            LastRegex = ItalianDateExtractorConfiguration.LastRegex;
+            UnitRegex = ItalianDateExtractorConfiguration.DateUnitRegex;
+            WeekDayRegex = ItalianDateExtractorConfiguration.WeekDayRegex;
+            StrictWeekDay = ItalianDateExtractorConfiguration.StrictWeekDay;
+            MonthRegex = ItalianDateExtractorConfiguration.MonthRegex;
+            WeekDayOfMonthRegex = ItalianDateExtractorConfiguration.WeekDayOfMonthRegex;
+            ForTheRegex = ItalianDateExtractorConfiguration.ForTheRegex;
+            WeekDayAndDayOfMothRegex = ItalianDateExtractorConfiguration.WeekDayAndDayOfMothRegex;
+            RelativeMonthRegex = ItalianDateExtractorConfiguration.RelativeMonthRegex;
+            YearSuffix = ItalianDateExtractorConfiguration.YearSuffix;
+            RelativeWeekDayRegex = ItalianDateExtractorConfiguration.RelativeWeekDayRegex;
+            RelativeDayRegex = new Regex(DateTimeDefinitions.RelativeDayRegex, RegexOptions.Singleline);
+            NextPrefixRegex = new Regex(DateTimeDefinitions.NextPrefixRegex, RegexOptions.Singleline);
+            PastPrefixRegex = new Regex(DateTimeDefinitions.PastPrefixRegex, RegexOptions.Singleline);
+            DayOfMonth = config.DayOfMonth;
+            DayOfWeek = config.DayOfWeek;
+            MonthOfYear = config.MonthOfYear;
+            CardinalMap = config.CardinalMap;
+            UnitMap = config.UnitMap;
+            UtilityConfiguration = config.UtilityConfiguration;
+            SameDayTerms = DateTimeDefinitions.SameDayTerms.ToImmutableList();
+            PlusOneDayTerms = DateTimeDefinitions.PlusOneDayTerms.ToImmutableList();
+            PlusTwoDayTerms = DateTimeDefinitions.PlusTwoDayTerms.ToImmutableList();
+            MinusOneDayTerms = DateTimeDefinitions.MinusOneDayTerms.ToImmutableList();
+            MinusTwoDayTerms = DateTimeDefinitions.MinusTwoDayTerms.ToImmutableList();
+        }
+
         public string DateTokenPrefix { get; }
 
         public IExtractor IntegerExtractor { get; }
@@ -87,49 +131,6 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
 
         public IDateTimeUtilityConfiguration UtilityConfiguration { get; }
 
-        public ItalianDateParserConfiguration(ICommonDateTimeParserConfiguration config) : base(config.Options)
-        {
-            DateTokenPrefix = DateTimeDefinitions.DateTokenPrefix;
-            IntegerExtractor = config.IntegerExtractor;
-            OrdinalExtractor = config.OrdinalExtractor;
-            CardinalExtractor = config.CardinalExtractor;
-            NumberParser = config.NumberParser;
-            DurationExtractor = config.DurationExtractor;
-            DateExtractor = config.DateExtractor;
-            DurationParser = config.DurationParser;
-            DateRegexes = new ItalianDateExtractorConfiguration(this).DateRegexList;
-            OnRegex = ItalianDateExtractorConfiguration.OnRegex;
-            SpecialDayRegex = ItalianDateExtractorConfiguration.SpecialDayRegex;
-            SpecialDayWithNumRegex = ItalianDateExtractorConfiguration.SpecialDayWithNumRegex;
-            NextRegex = ItalianDateExtractorConfiguration.NextRegex;
-            ThisRegex = ItalianDateExtractorConfiguration.ThisRegex;
-            LastRegex = ItalianDateExtractorConfiguration.LastRegex;
-            UnitRegex = ItalianDateExtractorConfiguration.DateUnitRegex;
-            WeekDayRegex = ItalianDateExtractorConfiguration.WeekDayRegex;
-            StrictWeekDay = ItalianDateExtractorConfiguration.StrictWeekDay;
-            MonthRegex = ItalianDateExtractorConfiguration.MonthRegex;
-            WeekDayOfMonthRegex = ItalianDateExtractorConfiguration.WeekDayOfMonthRegex;
-            ForTheRegex = ItalianDateExtractorConfiguration.ForTheRegex;
-            WeekDayAndDayOfMothRegex = ItalianDateExtractorConfiguration.WeekDayAndDayOfMothRegex;
-            RelativeMonthRegex = ItalianDateExtractorConfiguration.RelativeMonthRegex;
-            YearSuffix = ItalianDateExtractorConfiguration.YearSuffix;
-            RelativeWeekDayRegex = ItalianDateExtractorConfiguration.RelativeWeekDayRegex;
-            RelativeDayRegex = new Regex(DateTimeDefinitions.RelativeDayRegex, RegexOptions.Singleline);
-            NextPrefixRegex = new Regex(DateTimeDefinitions.NextPrefixRegex, RegexOptions.Singleline);
-            PastPrefixRegex = new Regex(DateTimeDefinitions.PastPrefixRegex, RegexOptions.Singleline);
-            DayOfMonth = config.DayOfMonth;
-            DayOfWeek = config.DayOfWeek;
-            MonthOfYear = config.MonthOfYear;
-            CardinalMap = config.CardinalMap;
-            UnitMap = config.UnitMap;
-            UtilityConfiguration = config.UtilityConfiguration;
-            SameDayTerms = DateTimeDefinitions.SameDayTerms.ToImmutableList();
-            PlusOneDayTerms = DateTimeDefinitions.PlusOneDayTerms.ToImmutableList();
-            PlusTwoDayTerms = DateTimeDefinitions.PlusTwoDayTerms.ToImmutableList();
-            MinusOneDayTerms = DateTimeDefinitions.MinusOneDayTerms.ToImmutableList();
-            MinusTwoDayTerms = DateTimeDefinitions.MinusTwoDayTerms.ToImmutableList();
-        }
-
         public int GetSwiftMonth(string text)
         {
             var trimmedText = text.Trim().ToLowerInvariant();
@@ -143,14 +144,15 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
             {
                 swift = -1;
             }
+
             return swift;
         }
 
         public bool IsCardinalLast(string text)
         {
             var trimmedText = text.Trim().ToLowerInvariant();
-            return (trimmedText.Equals("dernière") || trimmedText.Equals("dernières") ||
-                    trimmedText.Equals("derniere") || trimmedText.Equals("dernieres"));
+            return trimmedText.Equals("dernière") || trimmedText.Equals("dernières") ||
+                    trimmedText.Equals("derniere") || trimmedText.Equals("dernieres");
         }
 
         public string Normalize(string text)


### PR DESCRIPTION
- Move constructor before properties
- Remove extra parenthesis
