### PR TITLE
[StyleCop] Fix warning Spanish and German Configuration files

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanHolidayParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanHolidayParserConfiguration.cs
@@ -1,15 +1,15 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using DateObject = System.DateTime;
-
 using Microsoft.Recognizers.Definitions.German;
+using DateObject = System.DateTime;
 
 namespace Microsoft.Recognizers.Text.DateTime.German
 {
     public class GermanHolidayParserConfiguration : BaseHolidayParserConfiguration
     {
-        public GermanHolidayParserConfiguration(IOptionsConfiguration config) : base(config)
+        public GermanHolidayParserConfiguration(IOptionsConfiguration config)
+            : base(config)
         {
             this.HolidayRegexList = GermanHolidayExtractorConfiguration.HolidayRegexList;
             this.HolidayNames = DateTimeDefinitions.HolidayNames.ToImmutableDictionary();
@@ -31,14 +31,15 @@ namespace Microsoft.Recognizers.Text.DateTime.German
             {
                 swift = 0;
             }
+
             return swift;
         }
 
         public override string SanitizeHolidayToken(string holiday)
         {
             return holiday
-                .Replace(" ", "")
-                .Replace("'", "");
+                .Replace(" ", string.Empty)
+                .Replace("'", string.Empty);
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanTimePeriodParserConfiguration.cs
@@ -9,6 +9,24 @@ namespace Microsoft.Recognizers.Text.DateTime.German
 {
     public class GermanTimePeriodParserConfiguration : BaseOptionsConfiguration, ITimePeriodParserConfiguration
     {
+        public GermanTimePeriodParserConfiguration(ICommonDateTimeParserConfiguration config)
+            : base(config)
+        {
+            TimeExtractor = config.TimeExtractor;
+            IntegerExtractor = config.IntegerExtractor;
+            TimeParser = config.TimeParser;
+            TimeZoneParser = config.TimeZoneParser;
+            PureNumberFromToRegex = GermanTimePeriodExtractorConfiguration.PureNumFromTo;
+            PureNumberBetweenAndRegex = GermanTimePeriodExtractorConfiguration.PureNumBetweenAnd;
+            SpecificTimeFromToRegex = GermanTimePeriodExtractorConfiguration.SpecificTimeFromTo;
+            SpecificTimeBetweenAndRegex = GermanTimePeriodExtractorConfiguration.SpecificTimeBetweenAnd;
+            TimeOfDayRegex = GermanTimePeriodExtractorConfiguration.TimeOfDayRegex;
+            GeneralEndingRegex = GermanTimePeriodExtractorConfiguration.GeneralEndingRegex;
+            TillRegex = GermanTimePeriodExtractorConfiguration.TillRegex;
+            Numbers = config.Numbers;
+            UtilityConfiguration = config.UtilityConfiguration;
+        }
+
         public IDateTimeExtractor TimeExtractor { get; }
 
         public IDateTimeParser TimeParser { get; }
@@ -35,23 +53,6 @@ namespace Microsoft.Recognizers.Text.DateTime.German
 
         public IDateTimeUtilityConfiguration UtilityConfiguration { get; }
 
-        public GermanTimePeriodParserConfiguration(ICommonDateTimeParserConfiguration config) : base(config)
-        {
-            TimeExtractor = config.TimeExtractor;
-            IntegerExtractor = config.IntegerExtractor;
-            TimeParser = config.TimeParser;
-            TimeZoneParser = config.TimeZoneParser;
-            PureNumberFromToRegex = GermanTimePeriodExtractorConfiguration.PureNumFromTo;
-            PureNumberBetweenAndRegex = GermanTimePeriodExtractorConfiguration.PureNumBetweenAnd;
-            SpecificTimeFromToRegex = GermanTimePeriodExtractorConfiguration.SpecificTimeFromTo;
-            SpecificTimeBetweenAndRegex = GermanTimePeriodExtractorConfiguration.SpecificTimeBetweenAnd;
-            TimeOfDayRegex = GermanTimePeriodExtractorConfiguration.TimeOfDayRegex;
-            GeneralEndingRegex = GermanTimePeriodExtractorConfiguration.GeneralEndingRegex;
-            TillRegex = GermanTimePeriodExtractorConfiguration.TillRegex;
-            Numbers = config.Numbers;
-            UtilityConfiguration = config.UtilityConfiguration;
-        }
-
         public bool GetMatchedTimexRange(string text, out string timex, out int beginHour, out int endHour, out int endMin)
         {
             var trimmedText = text.Trim().ToLowerInvariant();
@@ -64,7 +65,7 @@ namespace Microsoft.Recognizers.Text.DateTime.German
             endHour = 0;
             endMin = 0;
 
-            var timeOfDay = "";
+            var timeOfDay = string.Empty;
             if (DateTimeDefinitions.MorningTermList.Any(o => trimmedText.EndsWith(o)))
             {
                 timeOfDay = Constants.Morning;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Utilities/GermanDatetimeUtilityConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Utilities/GermanDatetimeUtilityConfiguration.cs
@@ -6,34 +6,25 @@ namespace Microsoft.Recognizers.Text.DateTime.German.Utilities
 {
     public class GermanDatetimeUtilityConfiguration : IDateTimeUtilityConfiguration
     {
-        public static readonly Regex AgoRegex = new Regex(DateTimeDefinitions.AgoRegex,
-            RegexOptions.Singleline);
+        public static readonly Regex AgoRegex = new Regex(DateTimeDefinitions.AgoRegex, RegexOptions.Singleline);
 
-        public static readonly Regex LaterRegex = new Regex(DateTimeDefinitions.LaterRegex,
-            RegexOptions.Singleline);
+        public static readonly Regex LaterRegex = new Regex(DateTimeDefinitions.LaterRegex, RegexOptions.Singleline);
 
-        public static readonly Regex InConnectorRegex = new Regex(DateTimeDefinitions.InConnectorRegex,
-            RegexOptions.Singleline);
+        public static readonly Regex InConnectorRegex = new Regex(DateTimeDefinitions.InConnectorRegex, RegexOptions.Singleline);
 
         public static readonly Regex WithinNextPrefixRegex = new Regex(DateTimeDefinitions.WithinNextPrefixRegex, RegexOptions.Singleline);
 
-        public static readonly Regex AmDescRegex = new Regex(DateTimeDefinitions.AmDescRegex,
-            RegexOptions.Singleline);
+        public static readonly Regex AmDescRegex = new Regex(DateTimeDefinitions.AmDescRegex, RegexOptions.Singleline);
 
-        public static readonly Regex PmDescRegex = new Regex(DateTimeDefinitions.PmDescRegex,
-            RegexOptions.Singleline);
+        public static readonly Regex PmDescRegex = new Regex(DateTimeDefinitions.PmDescRegex, RegexOptions.Singleline);
 
-        public static readonly Regex AmPmDescRegex = new Regex(DateTimeDefinitions.AmPmDescRegex,
-            RegexOptions.Singleline);
+        public static readonly Regex AmPmDescRegex = new Regex(DateTimeDefinitions.AmPmDescRegex, RegexOptions.Singleline);
 
-        public static readonly Regex RangeUnitRegex = new Regex(DateTimeDefinitions.RangeUnitRegex,
-            RegexOptions.Singleline);
+        public static readonly Regex RangeUnitRegex = new Regex(DateTimeDefinitions.RangeUnitRegex, RegexOptions.Singleline);
 
-        public static readonly Regex TimeUnitRegex = new Regex(DateTimeDefinitions.TimeUnitRegex,
-            RegexOptions.Singleline);
+        public static readonly Regex TimeUnitRegex = new Regex(DateTimeDefinitions.TimeUnitRegex, RegexOptions.Singleline);
 
-        public static readonly Regex DateUnitRegex = new Regex(DateTimeDefinitions.DateUnitRegex,
-            RegexOptions.Singleline);
+        public static readonly Regex DateUnitRegex = new Regex(DateTimeDefinitions.DateUnitRegex, RegexOptions.Singleline);
 
         public static readonly Regex CommonDatePrefixRegex =
             new Regex(DateTimeDefinitions.CommonDatePrefixRegex, RegexOptions.Singleline);

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishSetParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishSetParserConfiguration.cs
@@ -5,6 +5,34 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
 {
     public class SpanishSetParserConfiguration : BaseOptionsConfiguration, ISetParserConfiguration
     {
+        public SpanishSetParserConfiguration(ICommonDateTimeParserConfiguration config)
+            : base(config)
+        {
+            DurationExtractor = config.DurationExtractor;
+            TimeExtractor = config.TimeExtractor;
+            DateExtractor = config.DateExtractor;
+            DateTimeExtractor = config.DateTimeExtractor;
+            DatePeriodExtractor = config.DatePeriodExtractor;
+            TimePeriodExtractor = config.TimePeriodExtractor;
+            DateTimePeriodExtractor = config.DateTimePeriodExtractor;
+
+            DurationParser = config.DurationParser;
+            TimeParser = config.TimeParser;
+            DateParser = config.DateParser;
+            DateTimeParser = config.DateTimeParser;
+            DatePeriodParser = config.DatePeriodParser;
+            TimePeriodParser = config.TimePeriodParser;
+            DateTimePeriodParser = config.DateTimePeriodParser;
+            UnitMap = config.UnitMap;
+
+            EachPrefixRegex = SpanishSetExtractorConfiguration.EachPrefixRegex;
+            PeriodicRegex = SpanishSetExtractorConfiguration.PeriodicRegex;
+            EachUnitRegex = SpanishSetExtractorConfiguration.EachUnitRegex;
+            EachDayRegex = SpanishSetExtractorConfiguration.EachDayRegex;
+            SetWeekDayRegex = SpanishSetExtractorConfiguration.SetWeekDayRegex;
+            SetEachRegex = SpanishSetExtractorConfiguration.SetEachRegex;
+        }
+
         public IDateTimeExtractor DurationExtractor { get; }
 
         public IDateTimeParser DurationParser { get; }
@@ -46,33 +74,6 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
         public Regex SetWeekDayRegex { get; }
 
         public Regex SetEachRegex { get; }
-
-        public SpanishSetParserConfiguration(ICommonDateTimeParserConfiguration config) : base(config)
-        {
-            DurationExtractor = config.DurationExtractor;
-            TimeExtractor = config.TimeExtractor;
-            DateExtractor = config.DateExtractor;
-            DateTimeExtractor = config.DateTimeExtractor;
-            DatePeriodExtractor = config.DatePeriodExtractor;
-            TimePeriodExtractor = config.TimePeriodExtractor;
-            DateTimePeriodExtractor = config.DateTimePeriodExtractor;
-
-            DurationParser = config.DurationParser;
-            TimeParser = config.TimeParser;
-            DateParser = config.DateParser;
-            DateTimeParser = config.DateTimeParser;
-            DatePeriodParser = config.DatePeriodParser;
-            TimePeriodParser = config.TimePeriodParser;
-            DateTimePeriodParser = config.DateTimePeriodParser;
-            UnitMap = config.UnitMap;
-
-            EachPrefixRegex = SpanishSetExtractorConfiguration.EachPrefixRegex;
-            PeriodicRegex = SpanishSetExtractorConfiguration.PeriodicRegex;
-            EachUnitRegex = SpanishSetExtractorConfiguration.EachUnitRegex;
-            EachDayRegex = SpanishSetExtractorConfiguration.EachDayRegex;
-            SetWeekDayRegex = SpanishSetExtractorConfiguration.SetWeekDayRegex;
-            SetEachRegex = SpanishSetExtractorConfiguration.SetEachRegex;
-        }
 
         public bool GetMatchedDailyTimex(string text, out string timex)
         {


### PR DESCRIPTION
- Move constructor before properties
- Use String.Empty instead empty strings
- move constructor initializers on their own line
- move parameters to begin on the same line of the declaration