### PR TITLE
[StyleCop] Fix warnings in English and German TimeParser

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/TimeParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/TimeParser.cs
@@ -4,7 +4,10 @@ namespace Microsoft.Recognizers.Text.DateTime.English
 {
     public class TimeParser : BaseTimeParser
     {
-        public TimeParser(ITimeParserConfiguration configuration) : base(configuration) { }
+        public TimeParser(ITimeParserConfiguration configuration)
+            : base(configuration)
+        {
+        }
 
         protected override DateTimeResolutionResult InternalParse(string text, DateObject referenceTime)
         {
@@ -13,6 +16,7 @@ namespace Microsoft.Recognizers.Text.DateTime.English
             {
                 innerResult = ParseIsh(text, referenceTime);
             }
+
             return innerResult;
         }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/TimeParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/TimeParser.cs
@@ -4,7 +4,10 @@ namespace Microsoft.Recognizers.Text.DateTime.German
 {
     public class TimeParser : BaseTimeParser
     {
-        public TimeParser(ITimeParserConfiguration configuration) : base(configuration) { }
+        public TimeParser(ITimeParserConfiguration configuration)
+            : base(configuration)
+        {
+        }
 
         protected override DateTimeResolutionResult InternalParse(string text, DateObject referenceTime)
         {
@@ -13,6 +16,7 @@ namespace Microsoft.Recognizers.Text.DateTime.German
             {
                 innerResult = ParseIsh(text, referenceTime);
             }
+
             return innerResult;
         }
 


### PR DESCRIPTION
- move constructor initializers on their own line