### PR TITLE
[DateTime] Fix DateTimePeriodExtractor test

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/BaseDateTimePeriodExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/BaseDateTimePeriodExtractor.cs
@@ -181,7 +181,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                             var begin = er.Start ?? 0;
 
                             var middleStr = beforeStr.Substring(begin + (er.Length ?? 0)).Trim().ToLower();
-                            if (string.IsNullOrEmpty(middleStr) || this.config.PrepositionRegex.IsMatch(middleStr))
+                            if (string.IsNullOrEmpty(middleStr) || this.config.PrepositionRegex.IsExactMatch(middleStr, true))
                             {
                                 ret.Add(new Token(begin, match.Index + match.Length));
                                 hasBeforeDate = true;
@@ -199,7 +199,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                             var begin = er[0].Start ?? 0;
                             var end = (er[0].Start ?? 0) + (er[0].Length ?? 0);
                             var middleStr = followedStr.Substring(0, begin).Trim().ToLower();
-                            if (string.IsNullOrEmpty(middleStr) || this.config.PrepositionRegex.IsMatch(middleStr))
+                            if (string.IsNullOrEmpty(middleStr) || this.config.PrepositionRegex.IsExactMatch(middleStr, true))
                             {
                                 ret.Add(new Token(match.Index, match.Index + match.Length + end));
                             }

--- a/Specs/DateTime/Spanish/DateTimePeriodExtractor.json
+++ b/Specs/DateTime/Spanish/DateTimePeriodExtractor.json
@@ -12,16 +12,8 @@
   },
   {
     "Input": "Hoy estaré fuera de cinco a siete",
-    "NotSupported": "javascript, python, java, dotnet",
-	"Comment": "There is no datetime period in this sentence, only a time period.",
-    "Results": [
-      {
-        "Text": "de cinco a siete",
-        "Type": "datetimerange",
-        "Start": 17,
-        "Length": 33
-      }
-    ]
+    "NotSupported": "javascript, python",
+    "Results": []
   },
   {
     "Input": "Estaré fuera hoy de cinco a siete",


### PR DESCRIPTION
# Description
We applied the feedback of the PR #1351
- Fix test result
- Enable the test in Java and .Net
- Fix .Net BaseDateTimePeriodExtractor

# Passing Tests
**Before**
![image](https://user-images.githubusercontent.com/42191764/51343086-46ed5c00-1a74-11e9-964e-e0d7eee98a31.png)

**After**
![image](https://user-images.githubusercontent.com/42191764/51343099-4fde2d80-1a74-11e9-96e6-bfede1b88161.png)
