### PR TITLE
[DateTime] Fix typo in variables containing the word 'trimed'

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishTimeParserConfiguration.cs
@@ -46,23 +46,23 @@ namespace Microsoft.Recognizers.Text.DateTime.English
         {
             int deltaMin;
 
-            var trimedPrefix = prefix.Trim().ToLowerInvariant();
+            var trimmedPrefix = prefix.Trim().ToLowerInvariant();
 
-            if (trimedPrefix.StartsWith("half"))
+            if (trimmedPrefix.StartsWith("half"))
             {
                 deltaMin = 30;
             }
-            else if (trimedPrefix.StartsWith("a quarter") || trimedPrefix.StartsWith("quarter"))
+            else if (trimmedPrefix.StartsWith("a quarter") || trimmedPrefix.StartsWith("quarter"))
             {
                 deltaMin = 15;
             }
-            else if (trimedPrefix.StartsWith("three quarter"))
+            else if (trimmedPrefix.StartsWith("three quarter"))
             {
                 deltaMin = 45;
             }
             else
             {
-                var match = EnglishTimeExtractorConfiguration.LessThanOneHour.Match(trimedPrefix);
+                var match = EnglishTimeExtractorConfiguration.LessThanOneHour.Match(trimmedPrefix);
                 var minStr = match.Groups["deltamin"].Value;
                 if (!string.IsNullOrWhiteSpace(minStr))
                 {
@@ -75,7 +75,7 @@ namespace Microsoft.Recognizers.Text.DateTime.English
                 }
             }
 
-            if (trimedPrefix.EndsWith("to"))
+            if (trimmedPrefix.EndsWith("to"))
             {
                 deltaMin = -deltaMin;
             }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchTimeParserConfiguration.cs
@@ -35,24 +35,24 @@ namespace Microsoft.Recognizers.Text.DateTime.French
         public void AdjustByPrefix(string prefix, ref int hour, ref int min, ref bool hasMin)
         {
             var deltaMin = 0;
-            var trimedPrefix = prefix.Trim().ToLowerInvariant();
+            var trimmedPrefix = prefix.Trim().ToLowerInvariant();
 
             // c'este 8 heures et demie, - "it's half past 8"
-            if (trimedPrefix.EndsWith("demie"))
+            if (trimmedPrefix.EndsWith("demie"))
             {
                 deltaMin = 30;
             }
-            else if (trimedPrefix.EndsWith("un quart") || trimedPrefix.EndsWith("quart"))
+            else if (trimmedPrefix.EndsWith("un quart") || trimmedPrefix.EndsWith("quart"))
             {
                 deltaMin = 15;
             }
-            else if (trimedPrefix.EndsWith("trois quarts"))
+            else if (trimmedPrefix.EndsWith("trois quarts"))
             {
                 deltaMin = 45;
             }
             else
             {
-                var match = FrenchTimeExtractorConfiguration.LessThanOneHour.Match(trimedPrefix);
+                var match = FrenchTimeExtractorConfiguration.LessThanOneHour.Match(trimmedPrefix);
                 var minStr = match.Groups["deltamin"].Value;
                 if (!string.IsNullOrWhiteSpace(minStr))
                 {
@@ -66,7 +66,7 @@ namespace Microsoft.Recognizers.Text.DateTime.French
             }
 
             // 'to' i.e 'one to five' = 'un à cinq'
-            if (trimedPrefix.EndsWith("à"))
+            if (trimmedPrefix.EndsWith("à"))
             {
                 deltaMin = -deltaMin;
             }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanTimeParserConfiguration.cs
@@ -52,23 +52,23 @@ namespace Microsoft.Recognizers.Text.DateTime.German
         public void AdjustByPrefix(string prefix, ref int hour, ref int min, ref bool hasMin)
         {
             var deltaMin = 0;
-            var trimedPrefix = prefix.Trim().ToLowerInvariant();
+            var trimmedPrefix = prefix.Trim().ToLowerInvariant();
 
-            if (trimedPrefix.StartsWith("halb"))
+            if (trimmedPrefix.StartsWith("halb"))
             {
                 deltaMin = -30;
             }
-            else if (trimedPrefix.StartsWith("viertel nach"))
+            else if (trimmedPrefix.StartsWith("viertel nach"))
             {
                 deltaMin = 15;
             }
-            else if (trimedPrefix.StartsWith("viertel vor"))
+            else if (trimmedPrefix.StartsWith("viertel vor"))
             {
                 deltaMin = -15;
             }
             else
             {
-                var match = GermanTimeExtractorConfiguration.LessThanOneHour.Match(trimedPrefix);
+                var match = GermanTimeExtractorConfiguration.LessThanOneHour.Match(trimmedPrefix);
                 var minStr = match.Groups["deltamin"].Value;
                 if (!string.IsNullOrWhiteSpace(minStr))
                 {
@@ -81,7 +81,7 @@ namespace Microsoft.Recognizers.Text.DateTime.German
                 }
             }
 
-            if (trimedPrefix.EndsWith("zum"))
+            if (trimmedPrefix.EndsWith("zum"))
             {
                 deltaMin = -deltaMin;
             }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianTimeParserConfiguration.cs
@@ -34,24 +34,24 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
         public void AdjustByPrefix(string prefix, ref int hour, ref int min, ref bool hasMin)
         {
             var deltaMin = 0;
-            var trimedPrefix = prefix.Trim().ToLowerInvariant();
+            var trimmedPrefix = prefix.Trim().ToLowerInvariant();
 
             // c'este 8 heures et demie, - "it's half past 8"
-            if (trimedPrefix.EndsWith("demie"))
+            if (trimmedPrefix.EndsWith("demie"))
             {
                 deltaMin = 30;
             }
-            else if (trimedPrefix.EndsWith("un quart") || trimedPrefix.EndsWith("quart"))
+            else if (trimmedPrefix.EndsWith("un quart") || trimmedPrefix.EndsWith("quart"))
             {
                 deltaMin = 15;
             }
-            else if (trimedPrefix.EndsWith("trois quarts"))
+            else if (trimmedPrefix.EndsWith("trois quarts"))
             {
                 deltaMin = 45;
             }
             else
             {
-                var match = ItalianTimeExtractorConfiguration.LessThanOneHour.Match(trimedPrefix);
+                var match = ItalianTimeExtractorConfiguration.LessThanOneHour.Match(trimmedPrefix);
                 var minStr = match.Groups["deltamin"].Value;
                 if (!string.IsNullOrWhiteSpace(minStr))
                 {
@@ -65,7 +65,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
             }
 
             // 'to' i.e 'one to five' = 'un à cinq'
-            if (trimedPrefix.EndsWith("à"))
+            if (trimmedPrefix.EndsWith("à"))
             {
                 deltaMin = -deltaMin;
             }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseTimeParserConfiguration.cs
@@ -37,24 +37,24 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
         public void AdjustByPrefix(string prefix, ref int hour, ref int min, ref bool hasMin)
         {
             var deltaMin = 0;
-            var trimedPrefix = prefix.Trim().ToLowerInvariant();
+            var trimmedPrefix = prefix.Trim().ToLowerInvariant();
 
-            if (trimedPrefix.StartsWith("quarto") || trimedPrefix.StartsWith("e um quarto") ||
-                trimedPrefix.StartsWith("quinze") || trimedPrefix.StartsWith("e quinze"))
+            if (trimmedPrefix.StartsWith("quarto") || trimmedPrefix.StartsWith("e um quarto") ||
+                trimmedPrefix.StartsWith("quinze") || trimmedPrefix.StartsWith("e quinze"))
             {
                 deltaMin = 15;
             }
-            else if (trimedPrefix.StartsWith("menos um quarto"))
+            else if (trimmedPrefix.StartsWith("menos um quarto"))
             {
                 deltaMin = -15;
             }
-            else if (trimedPrefix.StartsWith("meia") || trimedPrefix.StartsWith("e meia"))
+            else if (trimmedPrefix.StartsWith("meia") || trimmedPrefix.StartsWith("e meia"))
             {
                 deltaMin = 30;
             }
             else
             {
-                var match = PortugueseTimeExtractorConfiguration.LessThanOneHour.Match(trimedPrefix);
+                var match = PortugueseTimeExtractorConfiguration.LessThanOneHour.Match(trimmedPrefix);
                 var minStr = match.Groups["deltamin"].Value;
                 if (!string.IsNullOrWhiteSpace(minStr))
                 {
@@ -67,15 +67,15 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
                 }
             }
 
-            if (trimedPrefix.EndsWith("passadas") || trimedPrefix.EndsWith("pasados") ||
-                trimedPrefix.EndsWith("depois das") || trimedPrefix.EndsWith("depois da") || trimedPrefix.EndsWith("depois do") ||
-                trimedPrefix.EndsWith("passadas as") || trimedPrefix.EndsWith("passadas das"))
+            if (trimmedPrefix.EndsWith("passadas") || trimmedPrefix.EndsWith("pasados") ||
+                trimmedPrefix.EndsWith("depois das") || trimmedPrefix.EndsWith("depois da") || trimmedPrefix.EndsWith("depois do") ||
+                trimmedPrefix.EndsWith("passadas as") || trimmedPrefix.EndsWith("passadas das"))
             {
             // deltaMin it's positive
             }
-            else if (trimedPrefix.EndsWith("para a") || trimedPrefix.EndsWith("para as") ||
-                     trimedPrefix.EndsWith("pra") || trimedPrefix.EndsWith("pras") ||
-                     trimedPrefix.EndsWith("antes da") || trimedPrefix.EndsWith("antes das"))
+            else if (trimmedPrefix.EndsWith("para a") || trimmedPrefix.EndsWith("para as") ||
+                     trimmedPrefix.EndsWith("pra") || trimmedPrefix.EndsWith("pras") ||
+                     trimmedPrefix.EndsWith("antes da") || trimmedPrefix.EndsWith("antes das"))
             {
                 deltaMin = -deltaMin;
             }
@@ -92,11 +92,11 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
 
         public void AdjustBySuffix(string suffix, ref int hour, ref int min, ref bool hasMin, ref bool hasAm, ref bool hasPm)
         {
-            var trimedSuffix = suffix.Trim().ToLowerInvariant();
-            AdjustByPrefix(trimedSuffix, ref hour, ref min, ref hasMin);
+            var trimmedSuffix = suffix.Trim().ToLowerInvariant();
+            AdjustByPrefix(trimmedSuffix, ref hour, ref min, ref hasMin);
 
             var deltaHour = 0;
-            var match = PortugueseTimeExtractorConfiguration.TimeSuffix.MatchExact(trimedSuffix, trim: true);
+            var match = PortugueseTimeExtractorConfiguration.TimeSuffix.MatchExact(trimmedSuffix, trim: true);
 
             if (match.Success)
             {

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishTimeParserConfiguration.cs
@@ -37,23 +37,23 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
         public void AdjustByPrefix(string prefix, ref int hour, ref int min, ref bool hasMin)
         {
             var deltaMin = 0;
-            var trimedPrefix = prefix.Trim().ToLowerInvariant();
+            var trimmedPrefix = prefix.Trim().ToLowerInvariant();
 
-            if (trimedPrefix.StartsWith("cuarto") || trimedPrefix.StartsWith("y cuarto"))
+            if (trimmedPrefix.StartsWith("cuarto") || trimmedPrefix.StartsWith("y cuarto"))
             {
                 deltaMin = 15;
             }
-            else if (trimedPrefix.StartsWith("menos cuarto"))
+            else if (trimmedPrefix.StartsWith("menos cuarto"))
             {
                 deltaMin = -15;
             }
-            else if (trimedPrefix.StartsWith("media") || trimedPrefix.StartsWith("y media"))
+            else if (trimmedPrefix.StartsWith("media") || trimmedPrefix.StartsWith("y media"))
             {
                 deltaMin = 30;
             }
             else
             {
-                var match = SpanishTimeExtractorConfiguration.LessThanOneHour.Match(trimedPrefix);
+                var match = SpanishTimeExtractorConfiguration.LessThanOneHour.Match(trimmedPrefix);
                 var minStr = match.Groups["deltamin"].Value;
                 if (!string.IsNullOrWhiteSpace(minStr))
                 {
@@ -66,14 +66,14 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
                 }
             }
 
-            if (trimedPrefix.EndsWith("pasadas") || trimedPrefix.EndsWith("pasados") ||
-                trimedPrefix.EndsWith("pasadas las") || trimedPrefix.EndsWith("pasados las") ||
-                trimedPrefix.EndsWith("pasadas de las") || trimedPrefix.EndsWith("pasados de las"))
+            if (trimmedPrefix.EndsWith("pasadas") || trimmedPrefix.EndsWith("pasados") ||
+                trimmedPrefix.EndsWith("pasadas las") || trimmedPrefix.EndsWith("pasados las") ||
+                trimmedPrefix.EndsWith("pasadas de las") || trimmedPrefix.EndsWith("pasados de las"))
             {
             // deltaMin it's positive
             }
-            else if (trimedPrefix.EndsWith("para la") || trimedPrefix.EndsWith("para las") ||
-                     trimedPrefix.EndsWith("antes de la") || trimedPrefix.EndsWith("antes de las"))
+            else if (trimmedPrefix.EndsWith("para la") || trimmedPrefix.EndsWith("para las") ||
+                     trimmedPrefix.EndsWith("antes de la") || trimmedPrefix.EndsWith("antes de las"))
             {
                 deltaMin = -deltaMin;
             }
@@ -90,11 +90,11 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
 
         public void AdjustBySuffix(string suffix, ref int hour, ref int min, ref bool hasMin, ref bool hasAm, ref bool hasPm)
         {
-            var trimedSuffix = suffix.Trim().ToLowerInvariant();
-            AdjustByPrefix(trimedSuffix, ref hour, ref min, ref hasMin);
+            var trimmedSuffix = suffix.Trim().ToLowerInvariant();
+            AdjustByPrefix(trimmedSuffix, ref hour, ref min, ref hasMin);
 
             var deltaHour = 0;
-            var match = SpanishTimeExtractorConfiguration.TimeSuffix.MatchExact(trimedSuffix, trim: true);
+            var match = SpanishTimeExtractorConfiguration.TimeSuffix.MatchExact(trimmedSuffix, trim: true);
 
             if (match.Success)
             {

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/extractors/BaseSetExtractor.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/extractors/BaseSetExtractor.java
@@ -138,11 +138,11 @@ public class BaseSetExtractor implements IDateTimeExtractor {
         matches = RegExpUtility.getMatches(setWeekDayRegex, input);
         for (Match match : matches) {
             if (match != null) {
-                String trimedText = sb.delete(match.index, match.index + match.length).toString();
-                sb = new StringBuilder(trimedText);
-                trimedText = sb.insert(match.index, match.getGroup("weekday").value).toString();
+                String trimmedText = sb.delete(match.index, match.index + match.length).toString();
+                sb = new StringBuilder(trimmedText);
+                trimmedText = sb.insert(match.index, match.getGroup("weekday").value).toString();
 
-                List<ExtractResult> ers = extractor.extract(trimedText, reference);
+                List<ExtractResult> ers = extractor.extract(trimmedText, reference);
                 for (ExtractResult er : ers) {
                     if (er.getStart() <= match.index && er.getText().contains(match.getGroup("weekday").value)) {
                         int len = er.getLength() + 1;

--- a/JavaScript/packages/recognizers-date-time/src/dateTime/baseDatePeriod.ts
+++ b/JavaScript/packages/recognizers-date-time/src/dateTime/baseDatePeriod.ts
@@ -510,50 +510,50 @@ export class BaseDatePeriodParser implements IDateTimeParser {
 
         let futureYear = year;
         let pastYear = year;
-        let trimedText = source.trim().toLowerCase();
-        let match = RegExpUtility.getMatches(this.config.oneWordPeriodRegex, trimedText).pop();
+        let trimmedText = source.trim().toLowerCase();
+        let match = RegExpUtility.getMatches(this.config.oneWordPeriodRegex, trimmedText).pop();
 
-        if (!(match && match.index === 0 && match.length === trimedText.length))
+        if (!(match && match.index === 0 && match.length === trimmedText.length))
         {
-            match = RegExpUtility.getMatches(this.config.laterEarlyPeriodRegex, trimedText).pop();
+            match = RegExpUtility.getMatches(this.config.laterEarlyPeriodRegex, trimmedText).pop();
         }
 
-        if (!match || match.index !== 0 || match.length !== trimedText.length) return result;
+        if (!match || match.index !== 0 || match.length !== trimmedText.length) return result;
 
         if (match.groups("EarlyPrefix").value)
         {
             earlyPrefix = true;
-            trimedText = match.groups("suffix").value;
+            trimmedText = match.groups("suffix").value;
             result.mod = Constants.EARLY_MOD;
         }
 
         if (match.groups("LatePrefix").value)
         {
             latePrefix = true;
-            trimedText = match.groups("suffix").value;
+            trimmedText = match.groups("suffix").value;
             result.mod = Constants.LATE_MOD;
         }
 
         if (match.groups("MidPrefix").value)
         {
             latePrefix = true;
-            trimedText = match.groups("suffix").value;
+            trimmedText = match.groups("suffix").value;
             result.mod = Constants.MID_MOD;
         }
 
         let monthStr = match.groups('month').value;
         let swift = 0;
         if (!StringUtility.isNullOrEmpty(monthStr)){
-            swift = this.config.getSwiftYear(trimedText);
+            swift = this.config.getSwiftYear(trimmedText);
         }
         else{
-            swift = this.config.getSwiftDayOrMonth(trimedText);
+            swift = this.config.getSwiftDayOrMonth(trimmedText);
         }
 
         if (RegExpUtility.isMatch(this.config.unspecificEndOfRangeRegex, match.value))
         {
             latePrefix = true;
-            trimedText = match.value;
+            trimmedText = match.value;
             result.mod = Constants.LATE_MOD;
         }
 
@@ -572,7 +572,7 @@ export class BaseDatePeriodParser implements IDateTimeParser {
         }
 
         if (!StringUtility.isNullOrEmpty(monthStr)) {
-            swift = this.config.getSwiftYear(trimedText);
+            swift = this.config.getSwiftYear(trimmedText);
             month = this.config.monthOfYear.get(monthStr) - 1;
             if (swift >= -1) {
                 result.timex = `${DateTimeFormatUtil.toString(year + swift, 4)}-${DateTimeFormatUtil.toString(month + 1, 2)}`;
@@ -585,8 +585,8 @@ export class BaseDatePeriodParser implements IDateTimeParser {
                 if (month >= referenceDate.getMonth()) pastYear--;
             }
         } else {
-            swift = this.config.getSwiftDayOrMonth(trimedText);
-            if (this.config.isWeekOnly(trimedText)) {
+            swift = this.config.getSwiftDayOrMonth(trimmedText);
+            if (this.config.isWeekOnly(trimmedText)) {
                 let monday = DateUtils.addDays(DateUtils.this(referenceDate, DayOfWeek.Monday), 7 * swift);
 
                 result.timex = `${DateTimeFormatUtil.toString(monday.getFullYear(), 4)}-W${DateTimeFormatUtil.toString(DateUtils.getWeekNumber(monday).weekNo, 2)}`;
@@ -623,7 +623,7 @@ export class BaseDatePeriodParser implements IDateTimeParser {
                 result.success = true;
                 return result;
             }
-            if (this.config.isWeekend(trimedText)) {
+            if (this.config.isWeekend(trimmedText)) {
                 let beginDate = DateUtils.addDays(DateUtils.this(referenceDate, DayOfWeek.Saturday), 7 * swift);
                 let endDate = DateUtils.addDays(DateUtils.this(referenceDate, DayOfWeek.Sunday), (7 * swift) + (this.inclusiveEndPeriod ? 0 : 1));
 
@@ -633,7 +633,7 @@ export class BaseDatePeriodParser implements IDateTimeParser {
                 result.success = true;
                 return result;
             }
-            if (this.config.isMonthOnly(trimedText)) {
+            if (this.config.isMonthOnly(trimmedText)) {
                 let tempDate = new Date(referenceDate);
                 tempDate.setMonth(referenceDate.getMonth() + swift);
                 month = tempDate.getMonth();
@@ -641,7 +641,7 @@ export class BaseDatePeriodParser implements IDateTimeParser {
                 result.timex = `${DateTimeFormatUtil.toString(year, 4)}-${DateTimeFormatUtil.toString(month + 1, 2)}`;
                 futureYear = year;
                 pastYear = year;
-            } else if (this.config.isYearOnly(trimedText)) {
+            } else if (this.config.isYearOnly(trimmedText)) {
                 let tempDate = new Date(referenceDate);
                 tempDate.setFullYear(referenceDate.getFullYear() + swift);
                 year = tempDate.getFullYear();

--- a/JavaScript/packages/recognizers-date-time/src/dateTime/baseDateTimePeriod.ts
+++ b/JavaScript/packages/recognizers-date-time/src/dateTime/baseDateTimePeriod.ts
@@ -358,9 +358,9 @@ export class BaseDateTimePeriodParser implements IDateTimeParser {
     protected mergeDateAndTimePeriods( text:string, referenceTime:Date):DateTimeResolutionResult
     {
         let ret = new DateTimeResolutionResult();
-        let trimedText = text.trim().toLowerCase();
+        let trimmedText = text.trim().toLowerCase();
 
-        let er = this.config.timePeriodExtractor.extract(trimedText, referenceTime);
+        let er = this.config.timePeriodExtractor.extract(trimmedText, referenceTime);
         if (er.length !== 1)
         {
             return this.parseSimpleCases(text, referenceTime);
@@ -379,11 +379,11 @@ export class BaseDateTimePeriodParser implements IDateTimeParser {
         if (!StringUtility.isNullOrEmpty(timePeriodTimex)
             && timePeriodTimex.startsWith("("))
         {
-            let dateResult = this.config.dateExtractor.extract(trimedText.replace(er[0].text, ""), referenceTime);
+            let dateResult = this.config.dateExtractor.extract(trimmedText.replace(er[0].text, ""), referenceTime);
             let dateStr = "";
             let futureTime:Date;
             let pastTime: Date;
-            if (dateResult.length === 1 && trimedText.replace(er[0].text, "").trim() === dateResult[0].text) {
+            if (dateResult.length === 1 && trimmedText.replace(er[0].text, "").trim() === dateResult[0].text) {
                 let pr = this.config.dateParser.parse(dateResult[0], referenceTime);
                 if (pr.value) {
                     futureTime = pr.value.futureValue;

--- a/JavaScript/packages/recognizers-date-time/src/dateTime/french/dateConfiguration.ts
+++ b/JavaScript/packages/recognizers-date-time/src/dateTime/french/dateConfiguration.ts
@@ -141,26 +141,26 @@ export class FrenchDateParserConfiguration implements IDateParserConfiguration {
 
     getSwiftDay(source: string): number {
 
-        let trimedText = source.trim().toLowerCase();
+        let trimmedText = source.trim().toLowerCase();
         let swift = 0;
 
-        if (trimedText === "aujourd'hui" || trimedText === "auj") {
+        if (trimmedText === "aujourd'hui" || trimmedText === "auj") {
             swift = 0;
-        } else if (trimedText === "demain" ||
-            trimedText.endsWith("a2m1") ||
-            trimedText.endsWith("lendemain") ||
-            trimedText.endsWith("jour suivant")) {
+        } else if (trimmedText === "demain" ||
+            trimmedText.endsWith("a2m1") ||
+            trimmedText.endsWith("lendemain") ||
+            trimmedText.endsWith("jour suivant")) {
             swift = 1;
-        } else if (trimedText === "hier") {
+        } else if (trimmedText === "hier") {
             swift = -1;
-        } else if (trimedText.endsWith("après demain") ||
-            trimedText.endsWith("après-demain") ||
-            trimedText.endsWith("apres-demain")) {
+        } else if (trimmedText.endsWith("après demain") ||
+            trimmedText.endsWith("après-demain") ||
+            trimmedText.endsWith("apres-demain")) {
             swift = 2;
-        } else if (trimedText.endsWith("avant-hier") ||
-            trimedText.endsWith("avant hier")) {
+        } else if (trimmedText.endsWith("avant-hier") ||
+            trimmedText.endsWith("avant hier")) {
             swift = -2;
-        } else if (trimedText.endsWith("dernier")) {
+        } else if (trimmedText.endsWith("dernier")) {
             swift = -1;
         }
 
@@ -168,14 +168,14 @@ export class FrenchDateParserConfiguration implements IDateParserConfiguration {
     }
 
     getSwiftMonth(source: string): number {
-        let trimedText = source.trim().toLowerCase();
+        let trimmedText = source.trim().toLowerCase();
         let swift = 0;
-        if (trimedText.endsWith("prochaine") || trimedText.endsWith("prochain")) {
+        if (trimmedText.endsWith("prochaine") || trimmedText.endsWith("prochain")) {
             swift = 1;
-        } else if (trimedText === "dernière" ||
-            trimedText.endsWith("dernières") ||
-            trimedText.endsWith("derniere") ||
-            trimedText.endsWith("dernieres")) {
+        } else if (trimmedText === "dernière" ||
+            trimmedText.endsWith("dernières") ||
+            trimmedText.endsWith("derniere") ||
+            trimmedText.endsWith("dernieres")) {
             swift = -1;
         }
 
@@ -183,10 +183,10 @@ export class FrenchDateParserConfiguration implements IDateParserConfiguration {
     }
 
     isCardinalLast(source: string): boolean {
-        let trimedText = source.trim().toLowerCase();
-        return (trimedText.endsWith("dernière") || 
-            trimedText.endsWith("dernières") || 
-            trimedText.endsWith("derniere") || 
-            trimedText.endsWith("dernieres"));
+        let trimmedText = source.trim().toLowerCase();
+        return (trimmedText.endsWith("dernière") || 
+            trimmedText.endsWith("dernières") || 
+            trimmedText.endsWith("derniere") || 
+            trimmedText.endsWith("dernieres"));
     }
 }

--- a/JavaScript/packages/recognizers-date-time/src/dateTime/french/datePeriodConfiguration.ts
+++ b/JavaScript/packages/recognizers-date-time/src/dateTime/french/datePeriodConfiguration.ts
@@ -183,17 +183,17 @@ export class FrenchDatePeriodParserConfiguration implements IDatePeriodParserCon
     }
 
     getSwiftDayOrMonth(source: string): number {
-        let trimedText = source.trim().toLowerCase();
+        let trimmedText = source.trim().toLowerCase();
         let swift = 0;
 
-        if (trimedText.endsWith("prochain") || trimedText.endsWith("prochaine")) {
+        if (trimmedText.endsWith("prochain") || trimmedText.endsWith("prochaine")) {
             swift = 1;
         }
 
-        if (trimedText.endsWith("dernière") || 
-            trimedText.endsWith("dernières") ||
-            trimedText.endsWith("derniere") || 
-            trimedText.endsWith("dernieres")) {
+        if (trimmedText.endsWith("dernière") || 
+            trimmedText.endsWith("dernières") ||
+            trimmedText.endsWith("derniere") || 
+            trimmedText.endsWith("dernieres")) {
             swift = -1;
         }
 
@@ -201,19 +201,19 @@ export class FrenchDatePeriodParserConfiguration implements IDatePeriodParserCon
     }
 
     getSwiftYear(source: string): number {
-        let trimedText = source.trim().toLowerCase();
+        let trimmedText = source.trim().toLowerCase();
         let swift = -10;
-        if (trimedText.endsWith("prochain") || trimedText.endsWith("prochaine")){
+        if (trimmedText.endsWith("prochain") || trimmedText.endsWith("prochaine")){
             swift = 1;
         }
 
-        if (trimedText.endsWith("dernières") || 
-            trimedText.endsWith("dernière") ||
-            trimedText.endsWith("dernieres") || 
-            trimedText.endsWith("derniere") || 
-            trimedText.endsWith("dernier")) {
+        if (trimmedText.endsWith("dernières") || 
+            trimmedText.endsWith("dernière") ||
+            trimmedText.endsWith("dernieres") || 
+            trimmedText.endsWith("derniere") || 
+            trimmedText.endsWith("dernier")) {
             swift = -1;
-        } else if (trimedText.startsWith("cette"))
+        } else if (trimmedText.startsWith("cette"))
         {
             swift = 0;
         }
@@ -222,44 +222,44 @@ export class FrenchDatePeriodParserConfiguration implements IDatePeriodParserCon
     }
 
     isFuture(source: string): boolean {
-        let trimedText = source.trim().toLowerCase();
-        return FrenchDateTime.FutureStartTerms.some(o => trimedText.startsWith(o)) ||
-            FrenchDateTime.FutureEndTerms.some(o => trimedText.endsWith(o));
+        let trimmedText = source.trim().toLowerCase();
+        return FrenchDateTime.FutureStartTerms.some(o => trimmedText.startsWith(o)) ||
+            FrenchDateTime.FutureEndTerms.some(o => trimmedText.endsWith(o));
     }
 
     isYearToDate(source: string): boolean {
-        let trimedText = source.trim().toLowerCase();
-        return FrenchDateTime.YearToDateTerms.some(o => trimedText === o);
+        let trimmedText = source.trim().toLowerCase();
+        return FrenchDateTime.YearToDateTerms.some(o => trimmedText === o);
     }
 
     isMonthToDate(source: string): boolean {
-        let trimedText = source.trim().toLowerCase();
-        return FrenchDateTime.MonthToDateTerms.some(o => trimedText === o);
+        let trimmedText = source.trim().toLowerCase();
+        return FrenchDateTime.MonthToDateTerms.some(o => trimmedText === o);
     }
 
     isWeekOnly(source: string): boolean {
-        let trimedText = source.trim().toLowerCase();
-        return FrenchDateTime.WeekTerms.some(o => trimedText.endsWith(o)) &&
-            !FrenchDateTime.WeekendTerms.some(o => trimedText.endsWith(o));
+        let trimmedText = source.trim().toLowerCase();
+        return FrenchDateTime.WeekTerms.some(o => trimmedText.endsWith(o)) &&
+            !FrenchDateTime.WeekendTerms.some(o => trimmedText.endsWith(o));
     }
 
     isWeekend(source: string): boolean {
-        let trimedText = source.trim().toLowerCase();
-        return FrenchDateTime.WeekendTerms.some(o => trimedText.endsWith(o));
+        let trimmedText = source.trim().toLowerCase();
+        return FrenchDateTime.WeekendTerms.some(o => trimmedText.endsWith(o));
     }
 
     isMonthOnly(source: string): boolean {
-        let trimedText = source.trim().toLowerCase();
-        return FrenchDateTime.MonthTerms.some(o => trimedText.endsWith(o));
+        let trimmedText = source.trim().toLowerCase();
+        return FrenchDateTime.MonthTerms.some(o => trimmedText.endsWith(o));
     }
 
     isYearOnly(source: string): boolean {
-        let trimedText = source.trim().toLowerCase();
-        return FrenchDateTime.YearTerms.some(o => trimedText.endsWith(o));
+        let trimmedText = source.trim().toLowerCase();
+        return FrenchDateTime.YearTerms.some(o => trimmedText.endsWith(o));
     }
 
     isLastCardinal(source: string): boolean {
-        let trimedText = source.trim().toLowerCase();
-        return FrenchDateTime.LastCardinalTerms.some(o => trimedText === o);
+        let trimmedText = source.trim().toLowerCase();
+        return FrenchDateTime.LastCardinalTerms.some(o => trimmedText === o);
     }
 }

--- a/JavaScript/packages/recognizers-date-time/src/dateTime/french/dateTimeConfiguration.ts
+++ b/JavaScript/packages/recognizers-date-time/src/dateTime/french/dateTimeConfiguration.ts
@@ -124,18 +124,18 @@ export class FrenchDateTimeParserConfiguration implements IDateTimeParserConfigu
     }
 
     getMatchedNowTimex(text: string): { matched: boolean; timex: string; } {
-        let trimedText = text.trim().toLowerCase();
+        let trimmedText = text.trim().toLowerCase();
         let timex = "";
-        if (trimedText.endsWith("maintenant")) {
+        if (trimmedText.endsWith("maintenant")) {
             timex = "PRESENT_REF";
         }
-        else if (trimedText === "récemment" || 
-            trimedText === "précédemment" ||
-            trimedText === "auparavant") {
+        else if (trimmedText === "récemment" || 
+            trimmedText === "précédemment" ||
+            trimmedText === "auparavant") {
             timex = "PAST_REF";
         }
-        else if (trimedText === "dès que possible" || 
-            trimedText === "dqp") {
+        else if (trimmedText === "dès que possible" || 
+            trimmedText === "dqp") {
             timex = "FUTURE_REF";
         }
         else {
@@ -152,19 +152,19 @@ export class FrenchDateTimeParserConfiguration implements IDateTimeParserConfigu
     }
 
     getSwiftDay(text: string): number {
-        let trimedText = text.trim().toLowerCase();
+        let trimmedText = text.trim().toLowerCase();
         let swift = 0;
 
-        if (trimedText.startsWith("prochain") || 
-            trimedText.endsWith("prochain") ||
-            trimedText.startsWith("prochaine") || 
-            trimedText.endsWith("prochaine")) {
+        if (trimmedText.startsWith("prochain") || 
+            trimmedText.endsWith("prochain") ||
+            trimmedText.startsWith("prochaine") || 
+            trimmedText.endsWith("prochaine")) {
             swift = 1;
         }
-        else if (trimedText.startsWith("dernier") || 
-            trimedText.startsWith("dernière") ||
-            trimedText.endsWith("dernier") || 
-            trimedText.endsWith("dernière")) {
+        else if (trimmedText.startsWith("dernier") || 
+            trimmedText.startsWith("dernière") ||
+            trimmedText.endsWith("dernier") || 
+            trimmedText.endsWith("dernière")) {
             swift = -1;
         }
 
@@ -173,14 +173,14 @@ export class FrenchDateTimeParserConfiguration implements IDateTimeParserConfigu
     }
 
     getHour(text: string, hour: number): number {
-        let trimedText = text.trim().toLowerCase();
+        let trimmedText = text.trim().toLowerCase();
         let result = hour;
 
         // TODO: Replace with a regex
-        if (trimedText.endsWith("matin") && hour >= 12) {
+        if (trimmedText.endsWith("matin") && hour >= 12) {
             result -= 12;
         }
-        else if (!trimedText.endsWith("matin") && hour < 12) {
+        else if (!trimmedText.endsWith("matin") && hour < 12) {
             result += 12;
         }
 

--- a/JavaScript/packages/recognizers-date-time/src/dateTime/french/dateTimePeriodConfiguration.ts
+++ b/JavaScript/packages/recognizers-date-time/src/dateTime/french/dateTimePeriodConfiguration.ts
@@ -169,28 +169,28 @@ export class FrenchDateTimePeriodParserConfiguration implements IDateTimePeriodP
     }
 
     getMatchedTimeRange(source: string): { timeStr: string; beginHour: number; endHour: number; endMin: number; success: boolean; } {
-        let trimedText = source.trim().toLowerCase();
+        let trimmedText = source.trim().toLowerCase();
         let timeStr = "";
         let beginHour = 0;
         let endHour = 0;
         let endMin = 0;
 
-        if (RegExpUtility.getFirstMatchIndex(this.morningStartEndRegex, trimedText).matched) {
+        if (RegExpUtility.getFirstMatchIndex(this.morningStartEndRegex, trimmedText).matched) {
             timeStr = "TMO";
             beginHour = 8;
             endHour = 12;
         }
-        else if (RegExpUtility.getFirstMatchIndex(this.afternoonStartEndRegex, trimedText).matched) {
+        else if (RegExpUtility.getFirstMatchIndex(this.afternoonStartEndRegex, trimmedText).matched) {
             timeStr = "TAF";
             beginHour = 12;
             endHour = 16;
         }
-        else if (RegExpUtility.getFirstMatchIndex(this.eveningStartEndRegex, trimedText).matched) {
+        else if (RegExpUtility.getFirstMatchIndex(this.eveningStartEndRegex, trimmedText).matched) {
             timeStr = "TEV";
             beginHour = 16;
             endHour = 20;
         }
-        else if (RegExpUtility.getFirstMatchIndex(this.nightStartEndRegex, trimedText).matched) {
+        else if (RegExpUtility.getFirstMatchIndex(this.nightStartEndRegex, trimmedText).matched) {
             timeStr = "TNI";
             beginHour = 20;
             endHour = 23;
@@ -217,20 +217,20 @@ export class FrenchDateTimePeriodParserConfiguration implements IDateTimePeriodP
     }
 
     getSwiftPrefix(source: string): number {
-        let trimedText = source.trim().toLowerCase();
+        let trimmedText = source.trim().toLowerCase();
         let swift = 0;
 
         // TODO: Replace with a regex
-        if (trimedText.startsWith("prochain") || 
-            trimedText.endsWith("prochain") ||
-            trimedText.startsWith("prochaine") || 
-            trimedText.endsWith("prochaine")) {
+        if (trimmedText.startsWith("prochain") || 
+            trimmedText.endsWith("prochain") ||
+            trimmedText.startsWith("prochaine") || 
+            trimmedText.endsWith("prochaine")) {
             swift = 1;
         }
-        else if (trimedText.startsWith("derniere") || 
-            trimedText.startsWith("dernier")||
-            trimedText.endsWith("derniere") || 
-            trimedText.endsWith("dernier")) {
+        else if (trimmedText.startsWith("derniere") || 
+            trimmedText.startsWith("dernier")||
+            trimmedText.endsWith("derniere") || 
+            trimmedText.endsWith("dernier")) {
             swift = -1;
         }
 

--- a/JavaScript/packages/recognizers-date-time/src/dateTime/french/holidayConfiguration.ts
+++ b/JavaScript/packages/recognizers-date-time/src/dateTime/french/holidayConfiguration.ts
@@ -116,16 +116,16 @@ export class FrenchHolidayParserConfiguration extends BaseHolidayParserConfigura
     protected static LabourDay(year: number): Date { return new Date(year, 5, 1);}
 
     getSwiftYear(text: string): number {
-        let trimedText = text.trim().toLowerCase();
+        let trimmedText = text.trim().toLowerCase();
         let swift = -10;
 
-        if (trimedText.endsWith("prochain")) { // next - 'l'annee prochain')
+        if (trimmedText.endsWith("prochain")) { // next - 'l'annee prochain')
             swift = 1;
         }
-        else if (trimedText.endsWith("dernier")) { // last - 'l'annee dernier'
+        else if (trimmedText.endsWith("dernier")) { // last - 'l'annee dernier'
             swift = -1;
         }
-        else if (trimedText.startsWith("cette")) { // this - 'cette annees'
+        else if (trimmedText.startsWith("cette")) { // this - 'cette annees'
             swift = 0;
         }
 

--- a/JavaScript/packages/recognizers-date-time/src/dateTime/french/setConfiguration.ts
+++ b/JavaScript/packages/recognizers-date-time/src/dateTime/french/setConfiguration.ts
@@ -103,23 +103,23 @@ export class FrenchSetParserConfiguration implements ISetParserConfiguration {
     }
 
     getMatchedDailyTimex(text: string): { matched: boolean; timex: string; } {
-        let trimedText = text.trim().toLowerCase();
+        let trimmedText = text.trim().toLowerCase();
         let timex = "";
 
-        if (trimedText === "quotidien" || trimedText === "quotidienne" || 
-            trimedText === "jours" || trimedText === "journellement") {
+        if (trimmedText === "quotidien" || trimmedText === "quotidienne" || 
+            trimmedText === "jours" || trimmedText === "journellement") {
             timex = "P1D";
         }
-        else if (trimedText === "hebdomadaire") {
+        else if (trimmedText === "hebdomadaire") {
             timex = "P1W";
         }
-        else if (trimedText === "bihebdomadaire") {
+        else if (trimmedText === "bihebdomadaire") {
             timex = "P2W";
         }
-        else if (trimedText === "mensuel" || trimedText === "mensuelle") {
+        else if (trimmedText === "mensuel" || trimmedText === "mensuelle") {
             timex = "P1M";
         }
-        else if (trimedText === "annuel" || trimedText === "annuellement") {
+        else if (trimmedText === "annuel" || trimmedText === "annuellement") {
             timex = "P1Y";
         }
         else {
@@ -137,19 +137,19 @@ export class FrenchSetParserConfiguration implements ISetParserConfiguration {
     }
 
     getMatchedUnitTimex(text: string): { matched: boolean; timex: string; } {
-        let trimedText = text.trim().toLowerCase();
+        let trimmedText = text.trim().toLowerCase();
         let timex = "";
 
-        if (trimedText === "jour" || trimedText === "journee") {
+        if (trimmedText === "jour" || trimmedText === "journee") {
             timex = "P1D";
         }
-        else if (trimedText === "semaine") {
+        else if (trimmedText === "semaine") {
             timex = "P1W";
         }
-        else if (trimedText === "mois") {
+        else if (trimmedText === "mois") {
             timex = "P1M";
         }
-        else if (trimedText === "an" || trimedText === "annee") {
+        else if (trimmedText === "an" || trimmedText === "annee") {
             timex = "P1Y";
         }
         else {

--- a/JavaScript/packages/recognizers-date-time/src/dateTime/french/timeConfiguration.ts
+++ b/JavaScript/packages/recognizers-date-time/src/dateTime/french/timeConfiguration.ts
@@ -64,19 +64,19 @@ export class FrenchTimeParserConfiguration implements ITimeParserConfiguration {
 
     adjustByPrefix(prefix: string, adjust: { hour: number; min: number; hasMin: boolean; }) {
         let deltaMin = 0;
-        let trimedPrefix = prefix.trim().toLowerCase();
+        let trimmedPrefix = prefix.trim().toLowerCase();
 
-        if (trimedPrefix.endsWith("demie")) {
+        if (trimmedPrefix.endsWith("demie")) {
             deltaMin = 30;
         }
-        else if (trimedPrefix.endsWith("un quart") || trimedPrefix.endsWith("quart")) {
+        else if (trimmedPrefix.endsWith("un quart") || trimmedPrefix.endsWith("quart")) {
             deltaMin = 15;
         }
-        else if (trimedPrefix.endsWith("trois quarts")) {
+        else if (trimmedPrefix.endsWith("trois quarts")) {
             deltaMin = 45;
         }
         else {
-            let matches = RegExpUtility.getMatches(this.lessThanOneHour, trimedPrefix);
+            let matches = RegExpUtility.getMatches(this.lessThanOneHour, trimmedPrefix);
             if (matches.length) {
                 let match = matches[0];
                 let minStr = match.groups("deltamin").value;
@@ -92,7 +92,7 @@ export class FrenchTimeParserConfiguration implements ITimeParserConfiguration {
             }
         }
 
-        if (trimedPrefix.endsWith("à")) {
+        if (trimmedPrefix.endsWith("à")) {
             deltaMin = -deltaMin;
         }
 
@@ -106,13 +106,13 @@ export class FrenchTimeParserConfiguration implements ITimeParserConfiguration {
     }
 
     adjustBySuffix(suffix: string, adjust: { hour: number; min: number; hasMin: boolean; hasAm: boolean; hasPm: boolean; }) {
-        let trimedSuffix = suffix.trim().toLowerCase();
+        let trimmedSuffix = suffix.trim().toLowerCase();
 
         let deltaHour = 0;
-        let matches = RegExpUtility.getMatches(this.timeSuffix, trimedSuffix);
+        let matches = RegExpUtility.getMatches(this.timeSuffix, trimmedSuffix);
         if (matches.length) {
             let match = matches[0];
-            if (match.index === 0 && match.length === trimedSuffix.length) {
+            if (match.index === 0 && match.length === trimmedSuffix.length) {
                 let oclockStr = match.groups("heures").value;
                 if (!oclockStr) {
                     let amStr = match.groups("am").value;

--- a/JavaScript/packages/recognizers-date-time/src/dateTime/french/timeParser.ts
+++ b/JavaScript/packages/recognizers-date-time/src/dateTime/french/timeParser.ts
@@ -20,10 +20,10 @@ export class FrenchTimeParser extends BaseTimeParser {
 
     parseIsh(text: string, referenceTime: Date): DateTimeResolutionResult {
         let ret = new DateTimeResolutionResult();
-        let trimedText = text.trim().toLowerCase();
+        let trimmedText = text.trim().toLowerCase();
 
         let matches = RegExpUtility.getMatches(RegExpUtility.getSafeRegExp(FrenchDateTime.IshRegex), text);
-        if (matches.length && matches[0].index === 0 && matches[0].length === trimedText.length) {
+        if (matches.length && matches[0].index === 0 && matches[0].length === trimmedText.length) {
             let hourStr = matches[0].groups("hour").value;
             let hour = 12;
             if (hourStr) {

--- a/JavaScript/packages/recognizers-date-time/src/dateTime/spanish/dateConfiguration.ts
+++ b/JavaScript/packages/recognizers-date-time/src/dateTime/spanish/dateConfiguration.ts
@@ -154,26 +154,26 @@ export class SpanishDateParserConfiguration implements IDateParserConfiguration 
 
     getSwiftDay(source: string): number {
 
-        let trimedText = SpanishDateParserConfiguration.normalize(source.trim().toLowerCase());
+        let trimmedText = SpanishDateParserConfiguration.normalize(source.trim().toLowerCase());
         let swift = 0;
 
         // TODO: add the relative day logic if needed. If yes, the whole method should be abstracted.
-        if (trimedText === "hoy" || trimedText === "el dia") {
+        if (trimmedText === "hoy" || trimmedText === "el dia") {
             swift = 0;
-        } else if (trimedText === "mañana" ||
-            trimedText.endsWith("dia siguiente") ||
-            trimedText.endsWith("el dia de mañana") ||
-            trimedText.endsWith("proximo dia")) {
+        } else if (trimmedText === "mañana" ||
+            trimmedText.endsWith("dia siguiente") ||
+            trimmedText.endsWith("el dia de mañana") ||
+            trimmedText.endsWith("proximo dia")) {
             swift = 1;
-        } else if (trimedText === "ayer") {
+        } else if (trimmedText === "ayer") {
             swift = -1;
-        } else if (trimedText.endsWith("pasado mañana") ||
-            trimedText.endsWith("dia despues de mañana")) {
+        } else if (trimmedText.endsWith("pasado mañana") ||
+            trimmedText.endsWith("dia despues de mañana")) {
             swift = 2;
-        } else if (trimedText.endsWith("anteayer") ||
-            trimedText.endsWith("dia antes de ayer")) {
+        } else if (trimmedText.endsWith("anteayer") ||
+            trimmedText.endsWith("dia antes de ayer")) {
             swift = -2;
-        } else if (trimedText.endsWith("ultimo dia")) {
+        } else if (trimmedText.endsWith("ultimo dia")) {
             swift = -1;
         }
 
@@ -181,13 +181,13 @@ export class SpanishDateParserConfiguration implements IDateParserConfiguration 
     }
 
     getSwiftMonth(source: string): number {
-        let trimedText = source.trim().toLowerCase();
+        let trimmedText = source.trim().toLowerCase();
         let swift = 0;
-        if (RegExpUtility.getMatches(SpanishDateParserConfiguration.nextPrefixRegex, trimedText).length) {
+        if (RegExpUtility.getMatches(SpanishDateParserConfiguration.nextPrefixRegex, trimmedText).length) {
             swift = 1;
         }
 
-        if (RegExpUtility.getMatches(SpanishDateParserConfiguration.pastPrefixRegex, trimedText).length) {
+        if (RegExpUtility.getMatches(SpanishDateParserConfiguration.pastPrefixRegex, trimmedText).length) {
             swift = -1;
         }
 
@@ -195,8 +195,8 @@ export class SpanishDateParserConfiguration implements IDateParserConfiguration 
     }
 
     isCardinalLast(source: string): boolean {
-        let trimedText = source.trim().toLowerCase();
-        return RegExpUtility.getMatches(SpanishDateParserConfiguration.pastPrefixRegex, trimedText).length > 0;
+        let trimmedText = source.trim().toLowerCase();
+        return RegExpUtility.getMatches(SpanishDateParserConfiguration.pastPrefixRegex, trimmedText).length > 0;
     }
 
     private static normalize(source: string): string {

--- a/JavaScript/packages/recognizers-date-time/src/dateTime/spanish/datePeriodConfiguration.ts
+++ b/JavaScript/packages/recognizers-date-time/src/dateTime/spanish/datePeriodConfiguration.ts
@@ -182,14 +182,14 @@ export class SpanishDatePeriodParserConfiguration implements IDatePeriodParserCo
     }
 
     getSwiftDayOrMonth(source: string): number {
-        let trimedText = source.trim().toLowerCase();
+        let trimmedText = source.trim().toLowerCase();
         let swift = 0;
 
-        if (RegExpUtility.getFirstMatchIndex(this.nextPrefixRegex, trimedText).matched) {
+        if (RegExpUtility.getFirstMatchIndex(this.nextPrefixRegex, trimmedText).matched) {
             swift = 1;
         }
 
-        if (RegExpUtility.getFirstMatchIndex(this.pastPrefixRegex, trimedText).matched) {
+        if (RegExpUtility.getFirstMatchIndex(this.pastPrefixRegex, trimmedText).matched) {
             swift = -1;
         }
 
@@ -197,16 +197,16 @@ export class SpanishDatePeriodParserConfiguration implements IDatePeriodParserCo
     }
 
     getSwiftYear(source: string): number {
-        let trimedText = source.trim().toLowerCase();
+        let trimmedText = source.trim().toLowerCase();
         let swift = -10;
-        if (RegExpUtility.getFirstMatchIndex(this.nextPrefixRegex, trimedText).matched) {
+        if (RegExpUtility.getFirstMatchIndex(this.nextPrefixRegex, trimmedText).matched) {
             swift = 1;
         }
 
-        if (RegExpUtility.getFirstMatchIndex(this.pastPrefixRegex, trimedText).matched) {
+        if (RegExpUtility.getFirstMatchIndex(this.pastPrefixRegex, trimmedText).matched) {
             swift = -1;
         }
-        else if (RegExpUtility.getFirstMatchIndex(this.thisPrefixRegex, trimedText).matched) {
+        else if (RegExpUtility.getFirstMatchIndex(this.thisPrefixRegex, trimmedText).matched) {
             swift = 0;
         }
 
@@ -214,44 +214,44 @@ export class SpanishDatePeriodParserConfiguration implements IDatePeriodParserCo
     }
 
     isFuture(source: string): boolean {
-        let trimedText = source.trim().toLowerCase();
-        return RegExpUtility.getFirstMatchIndex(this.thisPrefixRegex, trimedText).matched ||
-            RegExpUtility.getFirstMatchIndex(this.nextPrefixRegex, trimedText).matched;
+        let trimmedText = source.trim().toLowerCase();
+        return RegExpUtility.getFirstMatchIndex(this.thisPrefixRegex, trimmedText).matched ||
+            RegExpUtility.getFirstMatchIndex(this.nextPrefixRegex, trimmedText).matched;
     }
 
     isYearToDate(source: string): boolean {
-        let trimedText = source.trim().toLowerCase();
-        return SpanishDateTime.YearToDateTerms.some(o => trimedText === o);
+        let trimmedText = source.trim().toLowerCase();
+        return SpanishDateTime.YearToDateTerms.some(o => trimmedText === o);
     }
 
     isMonthToDate(source: string): boolean {
-        let trimedText = source.trim().toLowerCase();
-        return SpanishDateTime.MonthToDateTerms.some(o => trimedText === o);
+        let trimmedText = source.trim().toLowerCase();
+        return SpanishDateTime.MonthToDateTerms.some(o => trimmedText === o);
     }
 
     isWeekOnly(source: string): boolean {
-        let trimedText = source.trim().toLowerCase();
-        return SpanishDateTime.WeekTerms.some(o => trimedText.endsWith(o)) &&
-            !SpanishDateTime.WeekendTerms.some(o => trimedText.endsWith(o));
+        let trimmedText = source.trim().toLowerCase();
+        return SpanishDateTime.WeekTerms.some(o => trimmedText.endsWith(o)) &&
+            !SpanishDateTime.WeekendTerms.some(o => trimmedText.endsWith(o));
     }
 
     isWeekend(source: string): boolean {
-        let trimedText = source.trim().toLowerCase();
-        return SpanishDateTime.WeekendTerms.some(o => trimedText.endsWith(o));
+        let trimmedText = source.trim().toLowerCase();
+        return SpanishDateTime.WeekendTerms.some(o => trimmedText.endsWith(o));
     }
 
     isMonthOnly(source: string): boolean {
-        let trimedText = source.trim().toLowerCase();
-        return SpanishDateTime.MonthTerms.some(o => trimedText.endsWith(o));
+        let trimmedText = source.trim().toLowerCase();
+        return SpanishDateTime.MonthTerms.some(o => trimmedText.endsWith(o));
     }
 
     isYearOnly(source: string): boolean {
-        let trimedText = source.trim().toLowerCase();
-        return SpanishDateTime.YearTerms.some(o => trimedText.endsWith(o));
+        let trimmedText = source.trim().toLowerCase();
+        return SpanishDateTime.YearTerms.some(o => trimmedText.endsWith(o));
     }
 
     isLastCardinal(source: string): boolean {
-        let trimedText = source.trim().toLowerCase();
-        return RegExpUtility.getFirstMatchIndex(this.pastPrefixRegex, trimedText).matched;
+        let trimmedText = source.trim().toLowerCase();
+        return RegExpUtility.getFirstMatchIndex(this.pastPrefixRegex, trimmedText).matched;
     }
 }

--- a/JavaScript/packages/recognizers-date-time/src/dateTime/spanish/dateTimeConfiguration.ts
+++ b/JavaScript/packages/recognizers-date-time/src/dateTime/spanish/dateTimeConfiguration.ts
@@ -126,16 +126,16 @@ export class SpanishDateTimeParserConfiguration implements IDateTimeParserConfig
     }
 
     getMatchedNowTimex(text: string): { matched: boolean; timex: string; } {
-        let trimedText = text.trim().toLowerCase();
+        let trimmedText = text.trim().toLowerCase();
         let timex = "";
-        if (trimedText.endsWith("ahora") || trimedText.endsWith("mismo") || trimedText.endsWith("momento")) {
+        if (trimmedText.endsWith("ahora") || trimmedText.endsWith("mismo") || trimmedText.endsWith("momento")) {
             timex = "PRESENT_REF";
         }
-        else if (trimedText.endsWith("posible") || trimedText.endsWith("pueda") ||
-            trimedText.endsWith("puedas") || trimedText.endsWith("podamos") || trimedText.endsWith("puedan")) {
+        else if (trimmedText.endsWith("posible") || trimmedText.endsWith("pueda") ||
+            trimmedText.endsWith("puedas") || trimmedText.endsWith("podamos") || trimmedText.endsWith("puedan")) {
             timex = "FUTURE_REF";
         }
-        else if (trimedText.endsWith("mente")) {
+        else if (trimmedText.endsWith("mente")) {
             timex = "PAST_REF";
         }
         else {
@@ -152,13 +152,13 @@ export class SpanishDateTimeParserConfiguration implements IDateTimeParserConfig
     }
 
     getSwiftDay(text: string): number {
-        let trimedText = text.trim().toLowerCase();
+        let trimmedText = text.trim().toLowerCase();
         let swift = 0;
 
-        if (RegExpUtility.getFirstMatchIndex(this.pastPrefixRegex, trimedText).matched) {
+        if (RegExpUtility.getFirstMatchIndex(this.pastPrefixRegex, trimmedText).matched) {
             swift = -1;
         }
-        else if (RegExpUtility.getFirstMatchIndex(this.nextPrefixRegex, trimedText).matched) {
+        else if (RegExpUtility.getFirstMatchIndex(this.nextPrefixRegex, trimmedText).matched) {
             swift = 1;
         }
 
@@ -167,14 +167,14 @@ export class SpanishDateTimeParserConfiguration implements IDateTimeParserConfig
     }
 
     getHour(text: string, hour: number): number {
-        let trimedText = text.trim().toLowerCase();
+        let trimmedText = text.trim().toLowerCase();
         let result = hour;
 
         // TODO: Replace with a regex
-        if ((trimedText.endsWith("mañana") || trimedText.endsWith("madrugada")) && hour >= 12) {
+        if ((trimmedText.endsWith("mañana") || trimmedText.endsWith("madrugada")) && hour >= 12) {
             result -= 12;
         }
-        else if (!(trimedText.endsWith("mañana") || trimedText.endsWith("madrugada")) && hour < 12) {
+        else if (!(trimmedText.endsWith("mañana") || trimmedText.endsWith("madrugada")) && hour < 12) {
             result += 12;
         }
 

--- a/JavaScript/packages/recognizers-date-time/src/dateTime/spanish/dateTimePeriodConfiguration.ts
+++ b/JavaScript/packages/recognizers-date-time/src/dateTime/spanish/dateTimePeriodConfiguration.ts
@@ -158,33 +158,33 @@ export class SpanishDateTimePeriodParserConfiguration implements IDateTimePeriod
     }
 
     getMatchedTimeRange(source: string): { timeStr: string; beginHour: number; endHour: number; endMin: number; success: boolean; } {
-        let trimedText = source.trim().toLowerCase();
+        let trimmedText = source.trim().toLowerCase();
         let timeStr = "";
         let beginHour = 0;
         let endHour = 0;
         let endMin = 0;
 
-        if (trimedText.endsWith("madrugada")) {
+        if (trimmedText.endsWith("madrugada")) {
             timeStr = "TDA";
             beginHour = 4;
             endHour = 8;
         }
-        else if (trimedText.endsWith("mañana")) {
+        else if (trimmedText.endsWith("mañana")) {
             timeStr = "TMO";
             beginHour = 8;
             endHour = 12;
         }
-        else if (trimedText.includes("pasado mediodia") || trimedText.includes("pasado el mediodia")) {
+        else if (trimmedText.includes("pasado mediodia") || trimmedText.includes("pasado el mediodia")) {
             timeStr = "TAF";
             beginHour = 12;
             endHour = 16;
         }
-        else if (trimedText.endsWith("tarde")) {
+        else if (trimmedText.endsWith("tarde")) {
             timeStr = "TEV";
             beginHour = 16;
             endHour = 20;
         }
-        else if (trimedText.endsWith("noche")) {
+        else if (trimmedText.endsWith("noche")) {
             timeStr = "TNI";
             beginHour = 20;
             endHour = 23;
@@ -211,15 +211,15 @@ export class SpanishDateTimePeriodParserConfiguration implements IDateTimePeriod
     }
 
     getSwiftPrefix(source: string): number {
-        let trimedText = source.trim().toLowerCase();
+        let trimmedText = source.trim().toLowerCase();
         let swift = 0;
 
         // TODO: Replace with a regex
-        if (RegExpUtility.getFirstMatchIndex(this.pastPrefixRegex, trimedText).matched ||
-            trimedText === "anoche") {
+        if (RegExpUtility.getFirstMatchIndex(this.pastPrefixRegex, trimmedText).matched ||
+            trimmedText === "anoche") {
             swift = -1;
         }
-        else if (RegExpUtility.getFirstMatchIndex(this.nextPrefixRegex, trimedText).matched) {
+        else if (RegExpUtility.getFirstMatchIndex(this.nextPrefixRegex, trimmedText).matched) {
             swift = 1;
         }
 

--- a/JavaScript/packages/recognizers-date-time/src/dateTime/spanish/dateTimePeriodParser.ts
+++ b/JavaScript/packages/recognizers-date-time/src/dateTime/spanish/dateTimePeriodParser.ts
@@ -11,10 +11,10 @@ export class SpanishDateTimePeriodParser extends BaseDateTimePeriodParser {
     protected parseSpecificTimeOfDay(source: string, referenceDate: Date): DateTimeResolutionResult {
 
         let ret = new DateTimeResolutionResult();
-        let trimedText = source.trim().toLowerCase();
+        let trimmedText = source.trim().toLowerCase();
 
         // handle morning, afternoon..
-        let match = this.config.getMatchedTimeRange(trimedText);
+        let match = this.config.getMatchedTimeRange(trimmedText);
         let beginHour = match.beginHour;
         let endHour = match.endHour;
         let endMin = match.endMin;
@@ -23,9 +23,9 @@ export class SpanishDateTimePeriodParser extends BaseDateTimePeriodParser {
             return ret;
         }
 
-        let matches = RegExpUtility.getMatches(this.config.specificTimeOfDayRegex, trimedText);
-        if (matches.length && matches[0].index === 0 && matches[0].length === trimedText.length) {
-            let swift = this.config.getSwiftPrefix(trimedText);
+        let matches = RegExpUtility.getMatches(this.config.specificTimeOfDayRegex, trimmedText);
+        if (matches.length && matches[0].index === 0 && matches[0].length === trimmedText.length) {
+            let swift = this.config.getSwiftPrefix(trimmedText);
 
             let date = DateUtils.addDays(referenceDate, swift)
             date.setHours(0, 0, 0, 0);
@@ -44,16 +44,16 @@ export class SpanishDateTimePeriodParser extends BaseDateTimePeriodParser {
             return ret;
         }
 
-        let startIndex = trimedText.indexOf(SpanishDateTime.Tomorrow) === 0 ? SpanishDateTime.Tomorrow.length : 0;
+        let startIndex = trimmedText.indexOf(SpanishDateTime.Tomorrow) === 0 ? SpanishDateTime.Tomorrow.length : 0;
 
         // handle Date followed by morning, afternoon
         // Add handling code to handle morning, afternoon followed by Date
         // Add handling code to handle early/late morning, afternoon
-        // TODO: use regex from config: match = this.config.TimeOfDayRegex.Match(trimedText.Substring(startIndex));
-        matches = RegExpUtility.getMatches(RegExpUtility.getSafeRegExp(SpanishDateTime.TimeOfDayRegex), trimedText.substring(startIndex));
+        // TODO: use regex from config: match = this.config.TimeOfDayRegex.Match(trimmedText.Substring(startIndex));
+        matches = RegExpUtility.getMatches(RegExpUtility.getSafeRegExp(SpanishDateTime.TimeOfDayRegex), trimmedText.substring(startIndex));
         if (matches.length) {
             let match = matches[0];
-            let beforeStr = trimedText.substring(0, match.index + startIndex).trim();
+            let beforeStr = trimmedText.substring(0, match.index + startIndex).trim();
             let ers = this.config.dateExtractor.extract(beforeStr, referenceDate);
             if (ers.length === 0) {
                 return ret;

--- a/JavaScript/packages/recognizers-date-time/src/dateTime/spanish/holidayConfiguration.ts
+++ b/JavaScript/packages/recognizers-date-time/src/dateTime/spanish/holidayConfiguration.ts
@@ -74,17 +74,17 @@ export class SpanishHolidayParserConfiguration extends BaseHolidayParserConfigur
     private static EasterDay(year: number): Date { return DateUtils.minValue(); }
 
     getSwiftYear(text: string): number {
-        let trimedText = text.trim().toLowerCase();
+        let trimmedText = text.trim().toLowerCase();
         let swift = -10;
 
-        if (RegExpUtility.getFirstMatchIndex(this.nextPrefixRegex, trimedText).matched) {
+        if (RegExpUtility.getFirstMatchIndex(this.nextPrefixRegex, trimmedText).matched) {
             swift = 1;
         }
 
-        if (RegExpUtility.getFirstMatchIndex(this.pastPrefixRegex, trimedText).matched) {
+        if (RegExpUtility.getFirstMatchIndex(this.pastPrefixRegex, trimmedText).matched) {
             swift = -1;
         }
-        else if (RegExpUtility.getFirstMatchIndex(this.thisPrefixRegex, trimedText).matched) {
+        else if (RegExpUtility.getFirstMatchIndex(this.thisPrefixRegex, trimmedText).matched) {
             swift = 0;
         }
 

--- a/JavaScript/packages/recognizers-date-time/src/dateTime/spanish/setConfiguration.ts
+++ b/JavaScript/packages/recognizers-date-time/src/dateTime/spanish/setConfiguration.ts
@@ -103,22 +103,22 @@ export class SpanishSetParserConfiguration implements ISetParserConfiguration {
     }
 
     getMatchedDailyTimex(text: string): { matched: boolean; timex: string; } {
-        let trimedText = text.trim().toLowerCase();
+        let trimmedText = text.trim().toLowerCase();
         let timex = "";
 
-        if (trimedText.endsWith("diario") || trimedText.endsWith("diariamente")) {
+        if (trimmedText.endsWith("diario") || trimmedText.endsWith("diariamente")) {
             timex = "P1D";
         }
-        else if (trimedText === "semanalmente") {
+        else if (trimmedText === "semanalmente") {
             timex = "P1W";
         }
-        else if (trimedText === "quincenalmente") {
+        else if (trimmedText === "quincenalmente") {
             timex = "P2W";
         }
-        else if (trimedText === "mensualmente") {
+        else if (trimmedText === "mensualmente") {
             timex = "P1M";
         }
-        else if (trimedText === "anualmente") {
+        else if (trimmedText === "anualmente") {
             timex = "P1Y";
         }
         else {
@@ -136,20 +136,20 @@ export class SpanishSetParserConfiguration implements ISetParserConfiguration {
     }
 
     getMatchedUnitTimex(text: string): { matched: boolean; timex: string; } {
-        let trimedText = text.trim().toLowerCase();
+        let trimmedText = text.trim().toLowerCase();
         let timex = "";
 
-        if (trimedText === "día" || trimedText === "dia" ||
-            trimedText === "días" || trimedText === "dias") {
+        if (trimmedText === "día" || trimmedText === "dia" ||
+            trimmedText === "días" || trimmedText === "dias") {
             timex = "P1D";
         }
-        else if (trimedText === "semana" || trimedText === "semanas") {
+        else if (trimmedText === "semana" || trimmedText === "semanas") {
             timex = "P1W";
         }
-        else if (trimedText === "mes" || trimedText === "meses") {
+        else if (trimmedText === "mes" || trimmedText === "meses") {
             timex = "P1M";
         }
-        else if (trimedText === "año" || trimedText === "años") {
+        else if (trimmedText === "año" || trimmedText === "años") {
             timex = "P1Y";
         }
         else {

--- a/JavaScript/packages/recognizers-date-time/src/dateTime/spanish/timeConfiguration.ts
+++ b/JavaScript/packages/recognizers-date-time/src/dateTime/spanish/timeConfiguration.ts
@@ -66,19 +66,19 @@ export class SpanishTimeParserConfiguration implements ITimeParserConfiguration 
 
     adjustByPrefix(prefix: string, adjust: { hour: number; min: number; hasMin: boolean; }) {
         let deltaMin = 0;
-        let trimedPrefix = prefix.trim().toLowerCase();
+        let trimmedPrefix = prefix.trim().toLowerCase();
 
-        if (trimedPrefix.startsWith("cuarto") || trimedPrefix.startsWith("y cuarto")) {
+        if (trimmedPrefix.startsWith("cuarto") || trimmedPrefix.startsWith("y cuarto")) {
             deltaMin = 15;
         }
-        else if (trimedPrefix.startsWith("menos cuarto")) {
+        else if (trimmedPrefix.startsWith("menos cuarto")) {
             deltaMin = -15;
         }
-        else if (trimedPrefix.startsWith("media") || trimedPrefix.startsWith("y media")) {
+        else if (trimmedPrefix.startsWith("media") || trimmedPrefix.startsWith("y media")) {
             deltaMin = 30;
         }
         else {
-            let matches = RegExpUtility.getMatches(this.lessThanOneHour, trimedPrefix);
+            let matches = RegExpUtility.getMatches(this.lessThanOneHour, trimmedPrefix);
             if (matches.length) {
                 let match = matches[0];
                 let minStr = match.groups("deltamin").value;
@@ -94,13 +94,13 @@ export class SpanishTimeParserConfiguration implements ITimeParserConfiguration 
             }
         }
 
-        if (trimedPrefix.endsWith("pasadas") || trimedPrefix.endsWith("pasados") ||
-            trimedPrefix.endsWith("pasadas las") || trimedPrefix.endsWith("pasados las") ||
-            trimedPrefix.endsWith("pasadas de las") || trimedPrefix.endsWith("pasados de las")) {
+        if (trimmedPrefix.endsWith("pasadas") || trimmedPrefix.endsWith("pasados") ||
+            trimmedPrefix.endsWith("pasadas las") || trimmedPrefix.endsWith("pasados las") ||
+            trimmedPrefix.endsWith("pasadas de las") || trimmedPrefix.endsWith("pasados de las")) {
             // deltaMin it's positive
         }
-        else if (trimedPrefix.endsWith("para la") || trimedPrefix.endsWith("para las") ||
-            trimedPrefix.endsWith("antes de la") || trimedPrefix.endsWith("antes de las")) {
+        else if (trimmedPrefix.endsWith("para la") || trimmedPrefix.endsWith("para las") ||
+            trimmedPrefix.endsWith("antes de la") || trimmedPrefix.endsWith("antes de las")) {
             deltaMin = -deltaMin;
         }
 
@@ -114,14 +114,14 @@ export class SpanishTimeParserConfiguration implements ITimeParserConfiguration 
     }
 
     adjustBySuffix(suffix: string, adjust: { hour: number; min: number; hasMin: boolean; hasAm: boolean; hasPm: boolean; }) {
-        let trimedSuffix = suffix.trim().toLowerCase();
-        this.adjustByPrefix(trimedSuffix, adjust);
+        let trimmedSuffix = suffix.trim().toLowerCase();
+        this.adjustByPrefix(trimmedSuffix, adjust);
 
         let deltaHour = 0;
-        let matches = RegExpUtility.getMatches(this.timeSuffix, trimedSuffix);
+        let matches = RegExpUtility.getMatches(this.timeSuffix, trimmedSuffix);
         if (matches.length) {
             let match = matches[0];
-            if (match.index === 0 && match.length === trimedSuffix.length) {
+            if (match.index === 0 && match.length === trimmedSuffix.length) {
                 let oclockStr = match.groups("oclock").value;
                 if (!oclockStr) {
                     let amStr = match.groups("am").value;

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/spanish/parsers.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/spanish/parsers.py
@@ -51,7 +51,7 @@ class SpanishDateTimePeriodParser(BaseDateTimePeriodParser):
         # handle Date followed by morning, afternoon
         # Add handling code to handle morning, afternoon followed by Date
         # Add handling code to handle early/late morning, afternoon
-        # TODO: use regex from config: match = this.config.TimeOfDayRegex.Match(trimedText.Substring(startIndex));
+        # TODO: use regex from config: match = this.config.TimeOfDayRegex.Match(trimmedText.Substring(startIndex));
         matches = list(RegExpUtility.get_safe_reg_exp(SpanishDateTime.TimeOfDayRegex).finditer(trimmed_text[start_index:]))
         if matches:
             match = matches[0]


### PR DESCRIPTION
- Rename variable containing `trimed` to `trimmed`