### PR TITLE
[DotNet][DateTime] Refactor GetModAndDate method since it has too many parameters

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/GetModAndDateResult.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/GetModAndDateResult.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using DateObject = System.DateTime;
+
+namespace Microsoft.Recognizers.Text.DateTime.Utilities
+{
+    public class GetModAndDateResult
+    {
+        public GetModAndDateResult(DateObject beginDate, DateObject endDate, string mod, List<DateObject> dateList)
+        {
+            this.BeginDate = beginDate;
+            this.EndDate = endDate;
+            this.Mod = mod;
+            this.DateList = dateList;
+        }
+
+        public GetModAndDateResult(DateObject beginDate, DateObject endDate)
+        {
+            this.BeginDate = beginDate;
+            this.EndDate = endDate;
+            this.Mod = string.Empty;
+            this.DateList = null;
+        }
+
+        public DateObject BeginDate { get; set; }
+
+        public DateObject EndDate { get; set; }
+
+        public string Mod { get; set; }
+
+        public List<DateObject> DateList { get; set; }
+    }
+}

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/ModAndDateResult.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/ModAndDateResult.cs
@@ -4,9 +4,9 @@ using DateObject = System.DateTime;
 
 namespace Microsoft.Recognizers.Text.DateTime.Utilities
 {
-    public class GetModAndDateResult
+    public class ModAndDateResult
     {
-        public GetModAndDateResult(DateObject beginDate, DateObject endDate, string mod, List<DateObject> dateList)
+        public ModAndDateResult(DateObject beginDate, DateObject endDate, string mod, List<DateObject> dateList)
         {
             this.BeginDate = beginDate;
             this.EndDate = endDate;
@@ -14,7 +14,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Utilities
             this.DateList = dateList;
         }
 
-        public GetModAndDateResult(DateObject beginDate, DateObject endDate)
+        public ModAndDateResult(DateObject beginDate, DateObject endDate)
         {
             this.BeginDate = beginDate;
             this.EndDate = endDate;


### PR DESCRIPTION
- Created new class ModAndDateResult containing the properties we need to return in the method GetModAndDate
- Redesigned GetModAndDate method to remove the out/ref parameters and return an instance of a ModAndDateResult object.