### PR TITLE
[MANX-434][StyleCop] Fix all the warnings in Dutch Parsers

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Parsers/DutchCommonDateTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Parsers/DutchCommonDateTimeParserConfiguration.cs
@@ -9,7 +9,6 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
 {
     public class DutchCommonDateTimeParserConfiguration : BaseDateParserConfiguration, ICommonDateTimeParserConfiguration
     {
-
         public DutchCommonDateTimeParserConfiguration(IOptionsConfiguration config)
             : base(config)
         {

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Parsers/DutchDateParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Parsers/DutchDateParserConfiguration.cs
@@ -8,6 +8,52 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
 {
     public class DutchDateParserConfiguration : BaseOptionsConfiguration, IDateParserConfiguration
     {
+        public DutchDateParserConfiguration(ICommonDateTimeParserConfiguration config)
+            : base(config)
+        {
+            DateTokenPrefix = DateTimeDefinitions.DateTokenPrefix;
+            IntegerExtractor = config.IntegerExtractor;
+            OrdinalExtractor = config.OrdinalExtractor;
+            CardinalExtractor = config.CardinalExtractor;
+            NumberParser = config.NumberParser;
+            DurationExtractor = config.DurationExtractor;
+            DateExtractor = config.DateExtractor;
+            DurationParser = config.DurationParser;
+            DateRegexes = new DutchDateExtractorConfiguration(this).DateRegexList;
+            OnRegex = DutchDateExtractorConfiguration.OnRegex;
+            SpecialDayRegex = DutchDateExtractorConfiguration.SpecialDayRegex;
+            SpecialDayWithNumRegex = DutchDateExtractorConfiguration.SpecialDayWithNumRegex;
+            NextRegex = DutchDateExtractorConfiguration.NextDateRegex;
+            ThisRegex = DutchDateExtractorConfiguration.ThisRegex;
+            LastRegex = DutchDateExtractorConfiguration.LastDateRegex;
+            UnitRegex = DutchDateExtractorConfiguration.DateUnitRegex;
+            WeekDayRegex = DutchDateExtractorConfiguration.WeekDayRegex;
+            MonthRegex = DutchDateExtractorConfiguration.MonthRegex;
+            WeekDayOfMonthRegex = DutchDateExtractorConfiguration.WeekDayOfMonthRegex;
+            ForTheRegex = DutchDateExtractorConfiguration.ForTheRegex;
+            WeekDayAndDayOfMothRegex = DutchDateExtractorConfiguration.WeekDayAndDayOfMothRegex;
+            WeekDayAndDayRegex = DutchDateExtractorConfiguration.WeekDayAndDayRegex;
+            RelativeMonthRegex = DutchDateExtractorConfiguration.RelativeMonthRegex;
+            YearSuffix = DutchDateExtractorConfiguration.YearSuffix;
+            RelativeWeekDayRegex = DutchDateExtractorConfiguration.RelativeWeekDayRegex;
+            RelativeDayRegex = new Regex(DateTimeDefinitions.RelativeDayRegex, RegexOptions.Singleline);
+            NextPrefixRegex = new Regex(DateTimeDefinitions.NextPrefixRegex, RegexOptions.Singleline);
+            PreviousPrefixRegex = new Regex(DateTimeDefinitions.PreviousPrefixRegex, RegexOptions.Singleline);
+            UpcomingPrefixRegex = new Regex(DateTimeDefinitions.UpcomingPrefixRegex, RegexOptions.Singleline);
+            PastPrefixRegex = new Regex(DateTimeDefinitions.PastPrefixRegex, RegexOptions.Singleline);
+            DayOfMonth = config.DayOfMonth;
+            DayOfWeek = config.DayOfWeek;
+            MonthOfYear = config.MonthOfYear;
+            CardinalMap = config.CardinalMap;
+            UnitMap = config.UnitMap;
+            UtilityConfiguration = config.UtilityConfiguration;
+            SameDayTerms = DateTimeDefinitions.SameDayTerms.ToImmutableList();
+            PlusOneDayTerms = DateTimeDefinitions.PlusOneDayTerms.ToImmutableList();
+            PlusTwoDayTerms = DateTimeDefinitions.PlusTwoDayTerms.ToImmutableList();
+            MinusOneDayTerms = DateTimeDefinitions.MinusOneDayTerms.ToImmutableList();
+            MinusTwoDayTerms = DateTimeDefinitions.MinusTwoDayTerms.ToImmutableList();
+        }
+
         public string DateTokenPrefix { get; }
 
         public IExtractor IntegerExtractor { get; }
@@ -89,52 +135,6 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
         public IImmutableList<string> MinusTwoDayTerms { get; }
 
         public IDateTimeUtilityConfiguration UtilityConfiguration { get; }
-
-        public DutchDateParserConfiguration(ICommonDateTimeParserConfiguration config)
-            : base(config)
-        {
-            DateTokenPrefix = DateTimeDefinitions.DateTokenPrefix;
-            IntegerExtractor = config.IntegerExtractor;
-            OrdinalExtractor = config.OrdinalExtractor;
-            CardinalExtractor = config.CardinalExtractor;
-            NumberParser = config.NumberParser;
-            DurationExtractor = config.DurationExtractor;
-            DateExtractor = config.DateExtractor;
-            DurationParser = config.DurationParser;
-            DateRegexes = new DutchDateExtractorConfiguration(this).DateRegexList;
-            OnRegex = DutchDateExtractorConfiguration.OnRegex;
-            SpecialDayRegex = DutchDateExtractorConfiguration.SpecialDayRegex;
-            SpecialDayWithNumRegex = DutchDateExtractorConfiguration.SpecialDayWithNumRegex;
-            NextRegex = DutchDateExtractorConfiguration.NextDateRegex;
-            ThisRegex = DutchDateExtractorConfiguration.ThisRegex;
-            LastRegex = DutchDateExtractorConfiguration.LastDateRegex;
-            UnitRegex = DutchDateExtractorConfiguration.DateUnitRegex;
-            WeekDayRegex = DutchDateExtractorConfiguration.WeekDayRegex;
-            MonthRegex = DutchDateExtractorConfiguration.MonthRegex;
-            WeekDayOfMonthRegex = DutchDateExtractorConfiguration.WeekDayOfMonthRegex;
-            ForTheRegex = DutchDateExtractorConfiguration.ForTheRegex;
-            WeekDayAndDayOfMothRegex = DutchDateExtractorConfiguration.WeekDayAndDayOfMothRegex;
-            WeekDayAndDayRegex = DutchDateExtractorConfiguration.WeekDayAndDayRegex;
-            RelativeMonthRegex = DutchDateExtractorConfiguration.RelativeMonthRegex;
-            YearSuffix = DutchDateExtractorConfiguration.YearSuffix;
-            RelativeWeekDayRegex = DutchDateExtractorConfiguration.RelativeWeekDayRegex;
-            RelativeDayRegex = new Regex(DateTimeDefinitions.RelativeDayRegex, RegexOptions.Singleline);
-            NextPrefixRegex = new Regex(DateTimeDefinitions.NextPrefixRegex, RegexOptions.Singleline);
-            PreviousPrefixRegex = new Regex(DateTimeDefinitions.PreviousPrefixRegex, RegexOptions.Singleline);
-            UpcomingPrefixRegex = new Regex(DateTimeDefinitions.UpcomingPrefixRegex, RegexOptions.Singleline);
-            PastPrefixRegex = new Regex(DateTimeDefinitions.PastPrefixRegex, RegexOptions.Singleline);
-            DayOfMonth = config.DayOfMonth;
-            DayOfWeek = config.DayOfWeek;
-            MonthOfYear = config.MonthOfYear;
-            CardinalMap = config.CardinalMap;
-            UnitMap = config.UnitMap;
-            UtilityConfiguration = config.UtilityConfiguration;
-            SameDayTerms = DateTimeDefinitions.SameDayTerms.ToImmutableList();
-            PlusOneDayTerms = DateTimeDefinitions.PlusOneDayTerms.ToImmutableList();
-            PlusTwoDayTerms = DateTimeDefinitions.PlusTwoDayTerms.ToImmutableList();
-            MinusOneDayTerms = DateTimeDefinitions.MinusOneDayTerms.ToImmutableList();
-            MinusTwoDayTerms = DateTimeDefinitions.MinusTwoDayTerms.ToImmutableList();
-        }
 
         public int GetSwiftMonth(string text)
         {

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Parsers/DutchDatePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Parsers/DutchDatePeriodParserConfiguration.cs
@@ -9,125 +9,23 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
 {
     public class DutchDatePeriodParserConfiguration : BaseOptionsConfiguration, IDatePeriodParserConfiguration
     {
-        public int MinYearNum { get; }
-
-        public int MaxYearNum { get; }
-
-        public string TokenBeforeDate { get; }
-
-        public static IList<string> MonthTermsPadded =
-            DateTimeDefinitions.MonthTerms.Select(str => $" {str} ").ToList();
-
-        public static IList<string> WeekendTermsPadded =
-            DateTimeDefinitions.WeekendTerms.Select(str => $" {str} ").ToList();
-
-        public static IList<string> WeekTermsPadded =
-            DateTimeDefinitions.WeekTerms.Select(str => $" {str} ").ToList();
-
-        public static IList<string> YearTermsPadded =
-            DateTimeDefinitions.YearTerms.Select(str => $" {str} ").ToList();
-
-        #region internalParsers
-
-        public IDateExtractor DateExtractor { get; }
-
-        public IExtractor CardinalExtractor { get; }
-
-        public IExtractor OrdinalExtractor { get; }
-
-        public IDateTimeExtractor DurationExtractor { get; }
-
-        public IExtractor IntegerExtractor { get; }
-
-        public IParser NumberParser { get; }
-
-        public IDateTimeParser DateParser { get; }
-
-        public IDateTimeParser DurationParser { get; }
-
-        #endregion
-
-        #region Regexes
-
-        public Regex MonthFrontBetweenRegex { get; }
-        public Regex BetweenRegex { get; }
-        public Regex MonthFrontSimpleCasesRegex { get; }
-        public Regex SimpleCasesRegex { get; }
-        public Regex OneWordPeriodRegex { get; }
-        public Regex MonthWithYear { get; }
-        public Regex MonthNumWithYear { get; }
-        public Regex YearRegex { get; }
-        public Regex PastRegex { get; }
-        public Regex FutureRegex { get; }
-        public Regex FutureSuffixRegex { get; }
-        public Regex NumberCombinedWithUnit { get; }
-        public Regex WeekOfMonthRegex { get; }
-        public Regex WeekOfYearRegex { get; }
-        public Regex QuarterRegex { get; }
-        public Regex QuarterRegexYearFront { get; }
-        public Regex AllHalfYearRegex { get; }
-        public Regex SeasonRegex { get; }
-        public Regex WhichWeekRegex { get; }
-        public Regex WeekOfRegex { get; }
-        public Regex MonthOfRegex { get; }
-        public Regex InConnectorRegex { get; }
-        public Regex WithinNextPrefixRegex { get; }
-        public Regex RestOfDateRegex { get; }
-        public Regex LaterEarlyPeriodRegex { get; }
-        public Regex WeekWithWeekDayRangeRegex { get; }
-        public Regex YearPlusNumberRegex { get; }
-        public Regex DecadeWithCenturyRegex { get; }
-        public Regex YearPeriodRegex { get; }
-        public Regex ComplexDatePeriodRegex { get; }
-        public Regex RelativeDecadeRegex { get; }
-        public Regex ReferenceDatePeriodRegex { get; }
-        public Regex AgoRegex { get; }
-        public Regex LaterRegex { get; }
-        public Regex LessThanRegex { get; }
-        public Regex MoreThanRegex { get; }
-        public Regex CenturySuffixRegex { get; }
-
         public static readonly Regex NextPrefixRegex =
             new Regex(DateTimeDefinitions.NextPrefixRegex, RegexOptions.Singleline);
+
         public static readonly Regex PreviousPrefixRegex =
             new Regex(DateTimeDefinitions.PreviousPrefixRegex, RegexOptions.Singleline);
+
         public static readonly Regex ThisPrefixRegex =
             new Regex(DateTimeDefinitions.ThisPrefixRegex, RegexOptions.Singleline);
+
         public static readonly Regex AfterNextSuffixRegex =
             new Regex(DateTimeDefinitions.AfterNextSuffixRegex, RegexOptions.Singleline);
+
         public static readonly Regex RelativeRegex =
             new Regex(DateTimeDefinitions.RelativeRegex, RegexOptions.Singleline);
+
         public static readonly Regex UnspecificEndOfRangeRegex =
             new Regex(DateTimeDefinitions.UnspecificEndOfRangeRegex, RegexOptions.Singleline);
-
-        Regex IDatePeriodParserConfiguration.NextPrefixRegex => NextPrefixRegex;
-        Regex IDatePeriodParserConfiguration.PreviousPrefixRegex => PreviousPrefixRegex;
-        Regex IDatePeriodParserConfiguration.ThisPrefixRegex => ThisPrefixRegex;
-        Regex IDatePeriodParserConfiguration.RelativeRegex => RelativeRegex;
-        Regex IDatePeriodParserConfiguration.UnspecificEndOfRangeRegex => UnspecificEndOfRangeRegex;
-
-        #endregion
-
-        #region Dictionaries
-        public IImmutableDictionary<string, string> UnitMap { get; }
-
-        public IImmutableDictionary<string, int> CardinalMap { get; }
-
-        public IImmutableDictionary<string, int> DayOfMonth { get; }
-
-        public IImmutableDictionary<string, int> MonthOfYear { get; }
-
-        public IImmutableDictionary<string, string> SeasonMap { get; }
-
-        public IImmutableDictionary<string, int> WrittenDecades { get; }
-
-        public IImmutableDictionary<string, int> Numbers { get; }
-
-        public IImmutableDictionary<string, int> SpecialDecadeCases { get; }
-
-        #endregion
-
-        public IImmutableList<string> InStringList { get; }
 
         public DutchDatePeriodParserConfiguration(ICommonDateTimeParserConfiguration config)
             : base(config)
@@ -160,7 +58,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
             AllHalfYearRegex = DutchDatePeriodExtractorConfiguration.AllHalfYearRegex;
             SeasonRegex = DutchDatePeriodExtractorConfiguration.SeasonRegex;
             WhichWeekRegex = DutchDatePeriodExtractorConfiguration.WhichWeekRegex;
-            WeekOfRegex= DutchDatePeriodExtractorConfiguration.WeekOfRegex;
+            WeekOfRegex = DutchDatePeriodExtractorConfiguration.WeekOfRegex;
             MonthOfRegex = DutchDatePeriodExtractorConfiguration.MonthOfRegex;
             RestOfDateRegex = DutchDatePeriodExtractorConfiguration.RestOfDateRegex;
             LaterEarlyPeriodRegex = DutchDatePeriodExtractorConfiguration.LaterEarlyPeriodRegex;
@@ -187,6 +85,142 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
             Numbers = config.Numbers;
             SpecialDecadeCases = config.SpecialDecadeCases;
         }
+
+        public static IList<string> MonthTermsPadded { get; private set; } =
+           DateTimeDefinitions.MonthTerms.Select(str => $" {str} ").ToList();
+
+        public static IList<string> WeekendTermsPadded { get; private set; } =
+            DateTimeDefinitions.WeekendTerms.Select(str => $" {str} ").ToList();
+
+        public static IList<string> WeekTermsPadded { get; private set; } =
+            DateTimeDefinitions.WeekTerms.Select(str => $" {str} ").ToList();
+
+        public static IList<string> YearTermsPadded { get; private set; } =
+            DateTimeDefinitions.YearTerms.Select(str => $" {str} ").ToList();
+
+        public int MinYearNum { get; }
+
+        public int MaxYearNum { get; }
+
+        public string TokenBeforeDate { get; }
+
+        public IDateExtractor DateExtractor { get; }
+
+        public IExtractor CardinalExtractor { get; }
+
+        public IExtractor OrdinalExtractor { get; }
+
+        public IDateTimeExtractor DurationExtractor { get; }
+
+        public IExtractor IntegerExtractor { get; }
+
+        public IParser NumberParser { get; }
+
+        public IDateTimeParser DateParser { get; }
+
+        public IDateTimeParser DurationParser { get; }
+
+        public Regex MonthFrontBetweenRegex { get; }
+
+        public Regex BetweenRegex { get; }
+
+        public Regex MonthFrontSimpleCasesRegex { get; }
+
+        public Regex SimpleCasesRegex { get; }
+
+        public Regex OneWordPeriodRegex { get; }
+
+        public Regex MonthWithYear { get; }
+
+        public Regex MonthNumWithYear { get; }
+
+        public Regex YearRegex { get; }
+
+        public Regex PastRegex { get; }
+
+        public Regex FutureRegex { get; }
+
+        public Regex FutureSuffixRegex { get; }
+
+        public Regex NumberCombinedWithUnit { get; }
+
+        public Regex WeekOfMonthRegex { get; }
+
+        public Regex WeekOfYearRegex { get; }
+
+        public Regex QuarterRegex { get; }
+
+        public Regex QuarterRegexYearFront { get; }
+
+        public Regex AllHalfYearRegex { get; }
+
+        public Regex SeasonRegex { get; }
+
+        public Regex WhichWeekRegex { get; }
+
+        public Regex WeekOfRegex { get; }
+
+        public Regex MonthOfRegex { get; }
+
+        public Regex InConnectorRegex { get; }
+
+        public Regex WithinNextPrefixRegex { get; }
+
+        public Regex RestOfDateRegex { get; }
+
+        public Regex LaterEarlyPeriodRegex { get; }
+
+        public Regex WeekWithWeekDayRangeRegex { get; }
+
+        public Regex YearPlusNumberRegex { get; }
+
+        public Regex DecadeWithCenturyRegex { get; }
+
+        public Regex YearPeriodRegex { get; }
+
+        public Regex ComplexDatePeriodRegex { get; }
+
+        public Regex RelativeDecadeRegex { get; }
+
+        public Regex ReferenceDatePeriodRegex { get; }
+
+        public Regex AgoRegex { get; }
+
+        public Regex LaterRegex { get; }
+
+        public Regex LessThanRegex { get; }
+
+        public Regex MoreThanRegex { get; }
+
+        public Regex CenturySuffixRegex { get; }
+
+        Regex IDatePeriodParserConfiguration.NextPrefixRegex => NextPrefixRegex;
+
+        Regex IDatePeriodParserConfiguration.PreviousPrefixRegex => PreviousPrefixRegex;
+
+        Regex IDatePeriodParserConfiguration.ThisPrefixRegex => ThisPrefixRegex;
+
+        Regex IDatePeriodParserConfiguration.RelativeRegex => RelativeRegex;
+
+        Regex IDatePeriodParserConfiguration.UnspecificEndOfRangeRegex => UnspecificEndOfRangeRegex;
+
+        public IImmutableDictionary<string, string> UnitMap { get; }
+
+        public IImmutableDictionary<string, int> CardinalMap { get; }
+
+        public IImmutableDictionary<string, int> DayOfMonth { get; }
+
+        public IImmutableDictionary<string, int> MonthOfYear { get; }
+
+        public IImmutableDictionary<string, string> SeasonMap { get; }
+
+        public IImmutableDictionary<string, int> WrittenDecades { get; }
+
+        public IImmutableDictionary<string, int> Numbers { get; }
+
+        public IImmutableDictionary<string, int> SpecialDecadeCases { get; }
+
+        public IImmutableList<string> InStringList { get; }
 
         public int GetSwiftDayOrMonth(string text)
         {
@@ -288,6 +322,5 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
             var trimmedText = text.Trim().ToLowerInvariant();
             return DateTimeDefinitions.YearToDateTerms.Any(o => trimmedText.Equals(o));
         }
-
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Parsers/DutchDateTimeAltParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Parsers/DutchDateTimeAltParserConfiguration.cs
@@ -2,6 +2,16 @@
 {
     public class DutchDateTimeAltParserConfiguration : IDateTimeAltParserConfiguration
     {
+        public DutchDateTimeAltParserConfiguration(ICommonDateTimeParserConfiguration config)
+        {
+            DateTimeParser = config.DateTimeParser;
+            DateParser = config.DateParser;
+            TimeParser = config.TimeParser;
+            DateTimePeriodParser = config.DateTimePeriodParser;
+            TimePeriodParser = config.TimePeriodParser;
+            DatePeriodParser = config.DatePeriodParser;
+        }
+
         public IDateTimeParser DateTimeParser { get; }
 
         public IDateTimeParser DateParser { get; }
@@ -13,16 +23,5 @@
         public IDateTimeParser TimePeriodParser { get; }
 
         public IDateTimeParser DatePeriodParser { get; }
-
-        public DutchDateTimeAltParserConfiguration(ICommonDateTimeParserConfiguration config)
-        {
-            DateTimeParser = config.DateTimeParser;
-            DateParser = config.DateParser;
-            TimeParser = config.TimeParser;
-            DateTimePeriodParser = config.DateTimePeriodParser;
-            TimePeriodParser = config.TimePeriodParser;
-            DatePeriodParser = config.DatePeriodParser;
-        }
-
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Parsers/DutchDateTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Parsers/DutchDateTimeParserConfiguration.cs
@@ -7,6 +7,43 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
 {
     public class DutchDateTimeParserConfiguration : BaseOptionsConfiguration, IDateTimeParserConfiguration
     {
+        public static readonly Regex AmTimeRegex =
+            new Regex(DateTimeDefinitions.AMTimeRegex, RegexOptions.Singleline);
+
+        public static readonly Regex PmTimeRegex =
+            new Regex(DateTimeDefinitions.PMTimeRegex, RegexOptions.Singleline);
+
+        public DutchDateTimeParserConfiguration(ICommonDateTimeParserConfiguration config)
+            : base(config)
+        {
+            TokenBeforeDate = DateTimeDefinitions.TokenBeforeDate;
+            TokenBeforeTime = DateTimeDefinitions.TokenBeforeTime;
+
+            DateExtractor = config.DateExtractor;
+            TimeExtractor = config.TimeExtractor;
+            DateParser = config.DateParser;
+            TimeParser = config.TimeParser;
+
+            NowRegex = DutchDateTimeExtractorConfiguration.NowRegex;
+
+            SimpleTimeOfTodayAfterRegex = DutchDateTimeExtractorConfiguration.SimpleTimeOfTodayAfterRegex;
+            SimpleTimeOfTodayBeforeRegex = DutchDateTimeExtractorConfiguration.SimpleTimeOfTodayBeforeRegex;
+            SpecificTimeOfDayRegex = DutchDateTimeExtractorConfiguration.SpecificTimeOfDayRegex;
+            SpecificEndOfRegex = DutchDateTimeExtractorConfiguration.SpecificEndOfRegex;
+            UnspecificEndOfRegex = DutchDateTimeExtractorConfiguration.UnspecificEndOfRegex;
+            UnitRegex = DutchTimeExtractorConfiguration.TimeUnitRegex;
+            DateNumberConnectorRegex = DutchDateTimeExtractorConfiguration.DateNumberConnectorRegex;
+
+            Numbers = config.Numbers;
+            CardinalExtractor = config.CardinalExtractor;
+            IntegerExtractor = config.IntegerExtractor;
+            NumberParser = config.NumberParser;
+            DurationExtractor = config.DurationExtractor;
+            DurationParser = config.DurationParser;
+            UnitMap = config.UnitMap;
+            UtilityConfiguration = config.UtilityConfiguration;
+        }
+
         public string TokenBeforeDate { get; }
 
         public string TokenBeforeTime { get; }
@@ -37,12 +74,6 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
 
         public Regex PMTimeRegex => PmTimeRegex;
 
-        public static readonly Regex AmTimeRegex =
-            new Regex(DateTimeDefinitions.AMTimeRegex, RegexOptions.Singleline);
-
-        public static readonly Regex PmTimeRegex =
-            new Regex(DateTimeDefinitions.PMTimeRegex, RegexOptions.Singleline);
-
         public Regex SimpleTimeOfTodayAfterRegex { get; }
 
         public Regex SimpleTimeOfTodayBeforeRegex { get; }
@@ -64,38 +95,6 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
         public IImmutableDictionary<string, int> Numbers { get; }
 
         public IDateTimeUtilityConfiguration UtilityConfiguration { get; }
-
-        public DutchDateTimeParserConfiguration(ICommonDateTimeParserConfiguration config)
-            : base(config)
-        {
-
-            TokenBeforeDate = DateTimeDefinitions.TokenBeforeDate;
-            TokenBeforeTime = DateTimeDefinitions.TokenBeforeTime;
-
-            DateExtractor = config.DateExtractor;
-            TimeExtractor = config.TimeExtractor;
-            DateParser = config.DateParser;
-            TimeParser = config.TimeParser;
-
-            NowRegex = DutchDateTimeExtractorConfiguration.NowRegex;
-
-            SimpleTimeOfTodayAfterRegex = DutchDateTimeExtractorConfiguration.SimpleTimeOfTodayAfterRegex;
-            SimpleTimeOfTodayBeforeRegex = DutchDateTimeExtractorConfiguration.SimpleTimeOfTodayBeforeRegex;
-            SpecificTimeOfDayRegex = DutchDateTimeExtractorConfiguration.SpecificTimeOfDayRegex;
-            SpecificEndOfRegex = DutchDateTimeExtractorConfiguration.SpecificEndOfRegex;
-            UnspecificEndOfRegex = DutchDateTimeExtractorConfiguration.UnspecificEndOfRegex;
-            UnitRegex = DutchTimeExtractorConfiguration.TimeUnitRegex;
-            DateNumberConnectorRegex = DutchDateTimeExtractorConfiguration.DateNumberConnectorRegex;
-
-            Numbers = config.Numbers;
-            CardinalExtractor = config.CardinalExtractor;
-            IntegerExtractor = config.IntegerExtractor;
-            NumberParser = config.NumberParser;
-            DurationExtractor = config.DurationExtractor;
-            DurationParser = config.DurationParser;
-            UnitMap = config.UnitMap;
-            UtilityConfiguration = config.UtilityConfiguration;
-        }
 
         public int GetHour(string text, int hour)
         {

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Parsers/DutchDateTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Parsers/DutchDateTimePeriodParserConfiguration.cs
@@ -7,6 +7,58 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
 {
     public class DutchDateTimePeriodParserConfiguration : BaseOptionsConfiguration, IDateTimePeriodParserConfiguration
     {
+        public static readonly Regex MorningStartEndRegex =
+            new Regex(DateTimeDefinitions.MorningStartEndRegex, RegexOptions.Singleline);
+
+        public static readonly Regex AfternoonStartEndRegex =
+            new Regex(DateTimeDefinitions.AfternoonStartEndRegex, RegexOptions.Singleline);
+
+        public static readonly Regex EveningStartEndRegex =
+            new Regex(DateTimeDefinitions.EveningStartEndRegex, RegexOptions.Singleline);
+
+        public static readonly Regex NightStartEndRegex =
+            new Regex(DateTimeDefinitions.NightStartEndRegex, RegexOptions.Singleline);
+
+        public DutchDateTimePeriodParserConfiguration(ICommonDateTimeParserConfiguration config)
+            : base(config)
+        {
+            TokenBeforeDate = DateTimeDefinitions.TokenBeforeDate;
+
+            DateExtractor = config.DateExtractor;
+            TimeExtractor = config.TimeExtractor;
+            DateTimeExtractor = config.DateTimeExtractor;
+            TimePeriodExtractor = config.TimePeriodExtractor;
+            CardinalExtractor = config.CardinalExtractor;
+            DurationExtractor = config.DurationExtractor;
+            NumberParser = config.NumberParser;
+            DateParser = config.DateParser;
+            TimeParser = config.TimeParser;
+            TimePeriodParser = config.TimePeriodParser;
+            DurationParser = config.DurationParser;
+            DateTimeParser = config.DateTimeParser;
+
+            PureNumberFromToRegex = DutchTimePeriodExtractorConfiguration.PureNumFromTo;
+            PureNumberBetweenAndRegex = DutchTimePeriodExtractorConfiguration.PureNumBetweenAnd;
+            SpecificTimeOfDayRegex = DutchDateTimeExtractorConfiguration.SpecificTimeOfDayRegex;
+            TimeOfDayRegex = DutchDateTimeExtractorConfiguration.TimeOfDayRegex;
+            PreviousPrefixRegex = DutchDatePeriodExtractorConfiguration.PreviousPrefixRegex;
+            FutureRegex = DutchDatePeriodExtractorConfiguration.NextPrefixRegex;
+            FutureSuffixRegex = DutchDatePeriodExtractorConfiguration.FutureSuffixRegex;
+            NumberCombinedWithUnitRegex = DutchDateTimePeriodExtractorConfiguration.TimeNumberCombinedWithUnit;
+            UnitRegex = DutchTimePeriodExtractorConfiguration.TimeUnitRegex;
+            PeriodTimeOfDayWithDateRegex = DutchDateTimePeriodExtractorConfiguration.PeriodTimeOfDayWithDateRegex;
+            RelativeTimeUnitRegex = DutchDateTimePeriodExtractorConfiguration.RelativeTimeUnitRegex;
+            RestOfDateTimeRegex = DutchDateTimePeriodExtractorConfiguration.RestOfDateTimeRegex;
+            AmDescRegex = DutchDateTimePeriodExtractorConfiguration.AmDescRegex;
+            PmDescRegex = DutchDateTimePeriodExtractorConfiguration.PmDescRegex;
+            WithinNextPrefixRegex = DutchDateTimePeriodExtractorConfiguration.WithinNextPrefixRegex;
+            PrefixDayRegex = DutchDateTimePeriodExtractorConfiguration.PrefixDayRegex;
+            BeforeRegex = DutchDateTimePeriodExtractorConfiguration.BeforeRegex;
+            AfterRegex = DutchDateTimePeriodExtractorConfiguration.AfterRegex;
+            UnitMap = config.UnitMap;
+            Numbers = config.Numbers;
+        }
+
         public string TokenBeforeDate { get; }
 
         public IDateExtractor DateExtractor { get; }
@@ -73,58 +125,6 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
 
         public IImmutableDictionary<string, int> Numbers { get; }
 
-        public DutchDateTimePeriodParserConfiguration(ICommonDateTimeParserConfiguration config)
-            : base(config)
-        {
-            TokenBeforeDate = DateTimeDefinitions.TokenBeforeDate;
-
-            DateExtractor = config.DateExtractor;
-            TimeExtractor = config.TimeExtractor;
-            DateTimeExtractor = config.DateTimeExtractor;
-            TimePeriodExtractor = config.TimePeriodExtractor;
-            CardinalExtractor = config.CardinalExtractor;
-            DurationExtractor = config.DurationExtractor;
-            NumberParser = config.NumberParser;
-            DateParser = config.DateParser;
-            TimeParser = config.TimeParser;
-            TimePeriodParser = config.TimePeriodParser;
-            DurationParser = config.DurationParser;
-            DateTimeParser = config.DateTimeParser;
-
-            PureNumberFromToRegex = DutchTimePeriodExtractorConfiguration.PureNumFromTo;
-            PureNumberBetweenAndRegex = DutchTimePeriodExtractorConfiguration.PureNumBetweenAnd;
-            SpecificTimeOfDayRegex = DutchDateTimeExtractorConfiguration.SpecificTimeOfDayRegex;
-            TimeOfDayRegex = DutchDateTimeExtractorConfiguration.TimeOfDayRegex;
-            PreviousPrefixRegex = DutchDatePeriodExtractorConfiguration.PreviousPrefixRegex;
-            FutureRegex = DutchDatePeriodExtractorConfiguration.NextPrefixRegex;
-            FutureSuffixRegex = DutchDatePeriodExtractorConfiguration.FutureSuffixRegex;
-            NumberCombinedWithUnitRegex = DutchDateTimePeriodExtractorConfiguration.TimeNumberCombinedWithUnit;
-            UnitRegex = DutchTimePeriodExtractorConfiguration.TimeUnitRegex;
-            PeriodTimeOfDayWithDateRegex = DutchDateTimePeriodExtractorConfiguration.PeriodTimeOfDayWithDateRegex;
-            RelativeTimeUnitRegex = DutchDateTimePeriodExtractorConfiguration.RelativeTimeUnitRegex;
-            RestOfDateTimeRegex = DutchDateTimePeriodExtractorConfiguration.RestOfDateTimeRegex;
-            AmDescRegex = DutchDateTimePeriodExtractorConfiguration.AmDescRegex;
-            PmDescRegex = DutchDateTimePeriodExtractorConfiguration.PmDescRegex;
-            WithinNextPrefixRegex = DutchDateTimePeriodExtractorConfiguration.WithinNextPrefixRegex;
-            PrefixDayRegex = DutchDateTimePeriodExtractorConfiguration.PrefixDayRegex;
-            BeforeRegex = DutchDateTimePeriodExtractorConfiguration.BeforeRegex;
-            AfterRegex = DutchDateTimePeriodExtractorConfiguration.AfterRegex;
-            UnitMap = config.UnitMap;
-            Numbers = config.Numbers;
-        }
-
-        public static readonly Regex MorningStartEndRegex =
-            new Regex(DateTimeDefinitions.MorningStartEndRegex, RegexOptions.Singleline);
-
-        public static readonly Regex AfternoonStartEndRegex =
-            new Regex(DateTimeDefinitions.AfternoonStartEndRegex, RegexOptions.Singleline);
-
-        public static readonly Regex EveningStartEndRegex =
-            new Regex(DateTimeDefinitions.EveningStartEndRegex, RegexOptions.Singleline);
-
-        public static readonly Regex NightStartEndRegex =
-            new Regex(DateTimeDefinitions.NightStartEndRegex, RegexOptions.Singleline);
-
         public bool GetMatchedTimeRange(string text, out string timeStr, out int beginHour, out int endHour, out int endMin)
         {
             var trimmedText = text.Trim().ToLowerInvariant();
@@ -182,6 +182,5 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
 
             return swift;
         }
-
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Parsers/DutchDurationParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Parsers/DutchDurationParserConfiguration.cs
@@ -7,6 +7,28 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
 {
     public class DutchDurationParserConfiguration : BaseOptionsConfiguration, IDurationParserConfiguration
     {
+        public DutchDurationParserConfiguration(ICommonDateTimeParserConfiguration config)
+            : base(config)
+        {
+            CardinalExtractor = config.CardinalExtractor;
+            NumberParser = config.NumberParser;
+            DurationExtractor = new BaseDurationExtractor(new DutchDurationExtractorConfiguration(this), false);
+            NumberCombinedWithUnit = DutchDurationExtractorConfiguration.NumberCombinedWithDurationUnit;
+            AnUnitRegex = DutchDurationExtractorConfiguration.AnUnitRegex;
+            DuringRegex = DutchDurationExtractorConfiguration.DuringRegex;
+            AllDateUnitRegex = DutchDurationExtractorConfiguration.AllRegex;
+            HalfDateUnitRegex = DutchDurationExtractorConfiguration.HalfRegex;
+            SuffixAndRegex = DutchDurationExtractorConfiguration.SuffixAndRegex;
+            FollowedUnit = DutchDurationExtractorConfiguration.DurationFollowedUnit;
+            ConjunctionRegex = DutchDurationExtractorConfiguration.ConjunctionRegex;
+            InexactNumberRegex = DutchDurationExtractorConfiguration.InexactNumberRegex;
+            InexactNumberUnitRegex = DutchDurationExtractorConfiguration.InexactNumberUnitRegex;
+            DurationUnitRegex = DutchDurationExtractorConfiguration.DurationUnitRegex;
+            UnitMap = config.UnitMap;
+            UnitValueMap = config.UnitValueMap;
+            DoubleNumbers = config.DoubleNumbers;
+        }
+
         public IExtractor CardinalExtractor { get; }
 
         public IExtractor DurationExtractor { get; }
@@ -40,27 +62,5 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
         public IImmutableDictionary<string, long> UnitValueMap { get; }
 
         public IImmutableDictionary<string, double> DoubleNumbers { get; }
-
-        public DutchDurationParserConfiguration(ICommonDateTimeParserConfiguration config)
-            : base(config)
-        {
-            CardinalExtractor = config.CardinalExtractor;
-            NumberParser = config.NumberParser;
-            DurationExtractor = new BaseDurationExtractor(new DutchDurationExtractorConfiguration(this), false);
-            NumberCombinedWithUnit = DutchDurationExtractorConfiguration.NumberCombinedWithDurationUnit;
-            AnUnitRegex = DutchDurationExtractorConfiguration.AnUnitRegex;
-            DuringRegex = DutchDurationExtractorConfiguration.DuringRegex;
-            AllDateUnitRegex = DutchDurationExtractorConfiguration.AllRegex;
-            HalfDateUnitRegex = DutchDurationExtractorConfiguration.HalfRegex;
-            SuffixAndRegex = DutchDurationExtractorConfiguration.SuffixAndRegex;
-            FollowedUnit = DutchDurationExtractorConfiguration.DurationFollowedUnit;
-            ConjunctionRegex = DutchDurationExtractorConfiguration.ConjunctionRegex;
-            InexactNumberRegex = DutchDurationExtractorConfiguration.InexactNumberRegex;
-            InexactNumberUnitRegex = DutchDurationExtractorConfiguration.InexactNumberUnitRegex;
-            DurationUnitRegex = DutchDurationExtractorConfiguration.DurationUnitRegex;
-            UnitMap = config.UnitMap;
-            UnitValueMap = config.UnitValueMap;
-            DoubleNumbers = config.DoubleNumbers;
-        }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Parsers/DutchHolidayParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Parsers/DutchHolidayParserConfiguration.cs
@@ -1,9 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using DateObject = System.DateTime;
-
 using Microsoft.Recognizers.Definitions.Dutch;
+using DateObject = System.DateTime;
 
 namespace Microsoft.Recognizers.Text.DateTime.Dutch
 {
@@ -14,6 +13,33 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
         {
             this.HolidayRegexList = DutchHolidayExtractorConfiguration.HolidayRegexList;
             this.HolidayNames = DateTimeDefinitions.HolidayNames.ToImmutableDictionary();
+        }
+
+        public override int GetSwiftYear(string text)
+        {
+            var trimmedText = text.Trim().ToLowerInvariant();
+            var swift = -10;
+            if (trimmedText.StartsWith("volgende"))
+            {
+                swift = 1;
+            }
+            else if (trimmedText.StartsWith("vorige") || trimmedText.StartsWith("laatste"))
+            {
+                swift = -1;
+            }
+            else if (trimmedText.StartsWith("deze"))
+            {
+                swift = 0;
+            }
+
+            return swift;
+        }
+
+        public override string SanitizeHolidayToken(string holiday)
+        {
+            return holiday
+                .Replace(" ", string.Empty)
+                .Replace("'", string.Empty);
         }
 
         protected override IDictionary<string, Func<int, DateObject>> InitHolidayFuncs()
@@ -70,69 +96,81 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
         }
 
         private static DateObject NewYear(int year) => new DateObject(year, 1, 1);
+
         private static DateObject NewYearEve(int year) => new DateObject(year, 12, 31);
+
         private static DateObject ChristmasDay(int year) => new DateObject(year, 12, 25);
+
         private static DateObject SecondChristmasDay(int year) => new DateObject(year, 12, 26);
+
         private static DateObject ChristmasEve(int year) => new DateObject(year, 12, 24);
+
         private static DateObject ValentinesDay(int year) => new DateObject(year, 2, 14);
+
         private static DateObject WhiteLoverDay(int year) => new DateObject(year, 3, 14);
+
         private static DateObject FoolDay(int year) => new DateObject(year, 4, 1);
+
         private static DateObject GirlsDay(int year) => new DateObject(year, 3, 7);
+
         private static DateObject TreePlantDay(int year) => new DateObject(year, 3, 12);
+
         private static DateObject FemaleDay(int year) => new DateObject(year, 3, 8);
+
         private static DateObject ChildrenDay(int year) => new DateObject(year, 6, 1);
+
         private static DateObject YouthDay(int year) => new DateObject(year, 5, 4);
+
         private static DateObject TeacherDay(int year) => new DateObject(year, 10, 5);
+
         private static DateObject SinglesDay(int year) => new DateObject(year, 11, 11);
+
         private static DateObject MaoBirthday(int year) => new DateObject(year, 12, 26);
+
         private static DateObject InaugurationDay(int year) => new DateObject(year, 1, 20);
+
         private static DateObject GroundhogDay(int year) => new DateObject(year, 2, 2);
+
         private static DateObject StPatrickDay(int year) => new DateObject(year, 3, 17);
+
         private static DateObject StGeorgeDay(int year) => new DateObject(year, 4, 23);
+
         private static DateObject Mayday(int year) => new DateObject(year, 5, 1);
+
         private static DateObject CincoDeMayoday(int year) => new DateObject(year, 5, 5);
+
         private static DateObject BaptisteDay(int year) => new DateObject(year, 6, 24);
+
         private static DateObject UsaIndependenceDay(int year) => new DateObject(year, 7, 4);
+
         private static DateObject BastilleDay(int year) => new DateObject(year, 7, 14);
+
         private static DateObject HalloweenDay(int year) => new DateObject(year, 10, 31);
+
         private static DateObject AllHallowDay(int year) => new DateObject(year, 11, 1);
+
         private static DateObject AllSoulsday(int year) => new DateObject(year, 11, 2);
+
         private static DateObject GuyFawkesDay(int year) => new DateObject(year, 11, 5);
+
         private static DateObject Veteransday(int year) => new DateObject(year, 11, 11);
+
         private static DateObject EasterDay(int year) => DateObject.MinValue;
+
         private static DateObject KingsDay(int year) => new DateObject(year, 4, 27);
+
         private static DateObject QueensDay(int year) => new DateObject(year, 4, 30);
+
         private static DateObject Prinsjesdag(int year) => DateObject.MinValue.SafeCreateFromValue(year, 9, GetDay(year, 9, 2, DayOfWeek.Tuesday));
+
         private static DateObject Dodenherdenking(int year) => new DateObject(year, 5, 4);
+
         private static DateObject Bevrijdingsdag(int year) => new DateObject(year, 5, 5);
+
         private static DateObject DutchTeachersDay(int year) => new DateObject(year, 10, 5);
+
         private static DateObject DutchVeteransday(int year) => DateObject.MinValue.SafeCreateFromValue(year, 6, GetLastDay(year, 6, DayOfWeek.Saturday));
+
         private static DateObject Dagvandearbeid(int year) => new DateObject(year, 5, 1);
-
-        public override int GetSwiftYear(string text)
-        {
-            var trimmedText = text.Trim().ToLowerInvariant();
-            var swift = -10;
-            if (trimmedText.StartsWith("volgende"))
-            {
-                swift = 1;
-            }
-            else if (trimmedText.StartsWith("vorige") || trimmedText.StartsWith("laatste"))
-            {
-                swift = -1;
-            }
-            else if (trimmedText.StartsWith("deze"))
-            {
-                swift = 0;
-            }
-            return swift;
-        }
-
-        public override string SanitizeHolidayToken(string holiday)
-        {
-            return holiday
-                .Replace(" ", string.Empty)
-                .Replace("'", string.Empty);
-        }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Parsers/DutchMergedParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Parsers/DutchMergedParserConfiguration.cs
@@ -6,25 +6,6 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
 {
     public sealed class DutchMergedParserConfiguration : DutchCommonDateTimeParserConfiguration, IMergedParserConfiguration
     {
-
-        public Regex BeforeRegex { get; }
-
-        public Regex AfterRegex { get; }
-
-        public Regex SinceRegex { get; }
-
-        public Regex AroundRegex { get; }
-
-        public Regex DateAfter { get; }
-
-        public Regex YearRegex { get; }
-
-        public IDateTimeParser SetParser { get; }
-
-        public IDateTimeParser HolidayParser { get; }
-
-        public StringMatcher SuperfluousWordMatcher { get; }
-
         public DutchMergedParserConfiguration(IOptionsConfiguration config)
             : base(config)
         {
@@ -43,5 +24,23 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
             HolidayParser = new BaseHolidayParser(new DutchHolidayParserConfiguration(this));
             TimeZoneParser = new BaseTimeZoneParser();
         }
+
+        public Regex BeforeRegex { get; }
+
+        public Regex AfterRegex { get; }
+
+        public Regex SinceRegex { get; }
+
+        public Regex AroundRegex { get; }
+
+        public Regex DateAfter { get; }
+
+        public Regex YearRegex { get; }
+
+        public IDateTimeParser SetParser { get; }
+
+        public IDateTimeParser HolidayParser { get; }
+
+        public StringMatcher SuperfluousWordMatcher { get; }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Parsers/DutchSetParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Parsers/DutchSetParserConfiguration.cs
@@ -5,6 +5,34 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
 {
     public class DutchSetParserConfiguration : BaseOptionsConfiguration, ISetParserConfiguration
     {
+        public DutchSetParserConfiguration(ICommonDateTimeParserConfiguration config)
+            : base(config)
+        {
+            DurationExtractor = config.DurationExtractor;
+            TimeExtractor = config.TimeExtractor;
+            DateExtractor = config.DateExtractor;
+            DateTimeExtractor = config.DateTimeExtractor;
+            DatePeriodExtractor = config.DatePeriodExtractor;
+            TimePeriodExtractor = config.TimePeriodExtractor;
+            DateTimePeriodExtractor = config.DateTimePeriodExtractor;
+
+            DurationParser = config.DurationParser;
+            TimeParser = config.TimeParser;
+            DateParser = config.DateParser;
+            DateTimeParser = config.DateTimeParser;
+            DatePeriodParser = config.DatePeriodParser;
+            TimePeriodParser = config.TimePeriodParser;
+            DateTimePeriodParser = config.DateTimePeriodParser;
+            UnitMap = config.UnitMap;
+
+            EachPrefixRegex = DutchSetExtractorConfiguration.EachPrefixRegex;
+            PeriodicRegex = DutchSetExtractorConfiguration.PeriodicRegex;
+            EachUnitRegex = DutchSetExtractorConfiguration.EachUnitRegex;
+            EachDayRegex = DutchSetExtractorConfiguration.EachDayRegex;
+            SetWeekDayRegex = DutchSetExtractorConfiguration.SetWeekDayRegex;
+            SetEachRegex = DutchSetExtractorConfiguration.SetEachRegex;
+        }
+
         public IDateTimeExtractor DurationExtractor { get; }
 
         public IDateTimeParser DurationParser { get; }
@@ -46,34 +74,6 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
         public Regex SetWeekDayRegex { get; }
 
         public Regex SetEachRegex { get; }
-
-        public DutchSetParserConfiguration(ICommonDateTimeParserConfiguration config)
-            : base(config)
-        {
-            DurationExtractor = config.DurationExtractor;
-            TimeExtractor = config.TimeExtractor;
-            DateExtractor = config.DateExtractor;
-            DateTimeExtractor = config.DateTimeExtractor;
-            DatePeriodExtractor = config.DatePeriodExtractor;
-            TimePeriodExtractor = config.TimePeriodExtractor;
-            DateTimePeriodExtractor = config.DateTimePeriodExtractor;
-
-            DurationParser = config.DurationParser;
-            TimeParser = config.TimeParser;
-            DateParser = config.DateParser;
-            DateTimeParser = config.DateTimeParser;
-            DatePeriodParser = config.DatePeriodParser;
-            TimePeriodParser = config.TimePeriodParser;
-            DateTimePeriodParser = config.DateTimePeriodParser;
-            UnitMap = config.UnitMap;
-
-            EachPrefixRegex = DutchSetExtractorConfiguration.EachPrefixRegex;
-            PeriodicRegex = DutchSetExtractorConfiguration.PeriodicRegex;
-            EachUnitRegex = DutchSetExtractorConfiguration.EachUnitRegex;
-            EachDayRegex = DutchSetExtractorConfiguration.EachDayRegex;
-            SetWeekDayRegex = DutchSetExtractorConfiguration.SetWeekDayRegex;
-            SetEachRegex = DutchSetExtractorConfiguration.SetEachRegex;
-        }
 
         public bool GetMatchedDailyTimex(string text, out string timex)
         {

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Parsers/DutchTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Parsers/DutchTimeParserConfiguration.cs
@@ -9,12 +9,6 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
 {
     public class DutchTimeParserConfiguration : BaseOptionsConfiguration, ITimeParserConfiguration
     {
-        public string TimeTokenPrefix { get; }
-
-        public Regex AtRegex { get; }
-
-        public Regex MealTimeRegex { get; }
-
         private static readonly Regex TimeSuffixFull =
             new Regex(DateTimeDefinitions.TimeSuffixFull, RegexOptions.Singleline);
 
@@ -23,14 +17,6 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
 
         private static readonly Regex NightRegex =
             new Regex(DateTimeDefinitions.NightRegex, RegexOptions.Singleline);
-
-        public IEnumerable<Regex> TimeRegexes { get; }
-
-        public IImmutableDictionary<string, int> Numbers { get; }
-
-        public IDateTimeUtilityConfiguration UtilityConfiguration { get; }
-
-        public IDateTimeParser TimeZoneParser { get; }
 
         public DutchTimeParserConfiguration(ICommonDateTimeParserConfiguration config)
             : base(config)
@@ -42,6 +28,20 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
             Numbers = config.Numbers;
             TimeZoneParser = config.TimeZoneParser;
         }
+
+        public IEnumerable<Regex> TimeRegexes { get; }
+
+        public IImmutableDictionary<string, int> Numbers { get; }
+
+        public IDateTimeUtilityConfiguration UtilityConfiguration { get; }
+
+        public IDateTimeParser TimeZoneParser { get; }
+
+        public string TimeTokenPrefix { get; }
+
+        public Regex AtRegex { get; }
+
+        public Regex MealTimeRegex { get; }
 
         public void AdjustByPrefix(string prefix, ref int hour, ref int min, ref bool hasMin)
         {
@@ -102,8 +102,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
                 var oclockStr = match.Groups["oclock"].Value;
                 if (string.IsNullOrEmpty(oclockStr))
                 {
-                    var amStr = match.Groups[Constants.AmGroupName].Value;
-                    if (!string.IsNullOrEmpty(amStr))
+                    var stringAm = match.Groups[Constants.AmGroupName].Value;
+                    if (!string.IsNullOrEmpty(stringAm))
                     {
                         if (hour >= Constants.HalfDayHourCount)
                         {
@@ -115,18 +115,18 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
                         }
                     }
 
-                    var pmStr = match.Groups[Constants.PmGroupName].Value;
-                    if (!string.IsNullOrEmpty(pmStr))
+                    var stringPm = match.Groups[Constants.PmGroupName].Value;
+                    if (!string.IsNullOrEmpty(stringPm))
                     {
                         if (hour < Constants.HalfDayHourCount)
                         {
                             deltaHour = Constants.HalfDayHourCount;
                         }
 
-                        if (LunchRegex.IsMatch(pmStr))
+                        if (LunchRegex.IsMatch(stringPm))
                         {
                             // for hour>=10, <12
-                            if (hour >=10 && hour <=Constants.HalfDayHourCount)
+                            if (hour >= 10 && hour <= Constants.HalfDayHourCount)
                             {
                                 deltaHour = 0;
                                 if (hour == Constants.HalfDayHourCount)
@@ -143,7 +143,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
                                 hasPm = true;
                             }
                         }
-                        else if (NightRegex.IsMatch(pmStr))
+                        else if (NightRegex.IsMatch(stringPm))
                         {
                             // For hour <=3 or ==12, we treat it as am, for example 1 in the night (midnight) == 1am
                             if (hour <= 3 || hour == Constants.HalfDayHourCount)
@@ -152,6 +152,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
                                 {
                                     hour = 0;
                                 }
+
                                 deltaHour = 0;
                                 hasAm = true;
                             }
@@ -164,7 +165,6 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
                         {
                             hasPm = true;
                         }
-
                     }
                 }
             }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Parsers/DutchTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Parsers/DutchTimePeriodParserConfiguration.cs
@@ -10,6 +10,24 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
 {
     public class DutchTimePeriodParserConfiguration : BaseOptionsConfiguration, ITimePeriodParserConfiguration
     {
+        public DutchTimePeriodParserConfiguration(ICommonDateTimeParserConfiguration config)
+            : base(config)
+        {
+            TimeExtractor = config.TimeExtractor;
+            IntegerExtractor = config.IntegerExtractor;
+            TimeParser = config.TimeParser;
+            TimeZoneParser = config.TimeZoneParser;
+            PureNumberFromToRegex = DutchTimePeriodExtractorConfiguration.PureNumFromTo;
+            PureNumberBetweenAndRegex = DutchTimePeriodExtractorConfiguration.PureNumBetweenAnd;
+            SpecificTimeFromToRegex = DutchTimePeriodExtractorConfiguration.SpecificTimeFromTo;
+            SpecificTimeBetweenAndRegex = DutchTimePeriodExtractorConfiguration.SpecificTimeBetweenAnd;
+            TimeOfDayRegex = DutchTimePeriodExtractorConfiguration.TimeOfDayRegex;
+            GeneralEndingRegex = DutchTimePeriodExtractorConfiguration.GeneralEndingRegex;
+            TillRegex = DutchTimePeriodExtractorConfiguration.TillRegex;
+            Numbers = config.Numbers;
+            UtilityConfiguration = config.UtilityConfiguration;
+        }
+
         public IDateTimeExtractor TimeExtractor { get; }
 
         public IDateTimeParser TimeParser { get; }
@@ -35,24 +53,6 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
         public IImmutableDictionary<string, int> Numbers { get; }
 
         public IDateTimeUtilityConfiguration UtilityConfiguration { get; }
-
-        public DutchTimePeriodParserConfiguration(ICommonDateTimeParserConfiguration config)
-            : base(config)
-        {
-            TimeExtractor = config.TimeExtractor;
-            IntegerExtractor = config.IntegerExtractor;
-            TimeParser = config.TimeParser;
-            TimeZoneParser = config.TimeZoneParser;
-            PureNumberFromToRegex = DutchTimePeriodExtractorConfiguration.PureNumFromTo;
-            PureNumberBetweenAndRegex = DutchTimePeriodExtractorConfiguration.PureNumBetweenAnd;
-            SpecificTimeFromToRegex = DutchTimePeriodExtractorConfiguration.SpecificTimeFromTo;
-            SpecificTimeBetweenAndRegex = DutchTimePeriodExtractorConfiguration.SpecificTimeBetweenAnd;
-            TimeOfDayRegex = DutchTimePeriodExtractorConfiguration.TimeOfDayRegex;
-            GeneralEndingRegex = DutchTimePeriodExtractorConfiguration.GeneralEndingRegex;
-            TillRegex = DutchTimePeriodExtractorConfiguration.TillRegex;
-            Numbers = config.Numbers;
-            UtilityConfiguration = config.UtilityConfiguration;
-        }
 
         public bool GetMatchedTimexRange(string text, out string timex, out int beginHour, out int endHour, out int endMin)
         {

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Parsers/TimeParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Parsers/TimeParser.cs
@@ -5,7 +5,9 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
     public class TimeParser : BaseTimeParser
     {
         public TimeParser(ITimeParserConfiguration configuration)
-            : base(configuration) { }
+            : base(configuration)
+        {
+        }
 
         protected override DateTimeResolutionResult InternalParse(string text, DateObject referenceTime)
         {
@@ -14,6 +16,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
             {
                 innerResult = ParseIsh(text, referenceTime);
             }
+
             return innerResult;
         }
 


### PR DESCRIPTION
- Reorder fields, properties, methods and constructors
- Add and remove spaces when needed
- Remove unnecessary parenthesis
- Reorder using statements