### PR TITLE
Update Appveyor CI to save the wheels package as build artifacts

### DIFF
--- a/Python/CreateAllPackages.cmd
+++ b/Python/CreateAllPackages.cmd
@@ -1,0 +1,41 @@
+rem Install wheel package
+call pip install wheel
+
+rem Go through Sub-packages
+pushd .\libraries\recognizers-text\
+call CreatePackage.cmd
+popd
+pushd .\libraries\recognizers-number\
+call CreatePackage.cmd
+popd
+pushd .\libraries\recognizers-number-with-unit\
+call CreatePackage.cmd
+popd
+pushd .\libraries\recognizers-date-time\
+call CreatePackage.cmd
+popd
+pushd .\libraries\recognizers-sequence\
+call CreatePackage.cmd
+popd
+rem Exit .Python dir
+popd
+
+GOTO END
+
+:NOSPECDIR
+echo "Please specify a directory where the package directories containing .cmd scripts should be found. Abort."
+
+GOTO BADEND
+
+:NODIR
+echo "Dir %dir% not found. Abort."
+
+rem exit 1
+GOTO BADEND
+
+:BADEND
+exit /b 1
+
+GOTO END
+
+:END

--- a/Python/build.ci.cmd
+++ b/Python/build.ci.cmd
@@ -43,4 +43,14 @@ IF %ERRORLEVEL% == 1 (
 	)
 )
 
+ECHO.
+ECHO # Running CreateAllPackages.cmd
+CALL CreateAllPackages.cmd
+IF %ERRORLEVEL% NEQ 0 (
+	ECHO # Failed to create packages.
+	EXIT /b -1
+)
+
+EXIT /b 0
+
 ECHO ============================== PYTHON BUILD/TEST END ==============================

--- a/Python/libraries/recognizers-date-time/CreatePackage.cmd
+++ b/Python/libraries/recognizers-date-time/CreatePackage.cmd
@@ -1,0 +1,18 @@
+@echo off
+echo *** Building Microsoft.Recognizers.Text.DateTime
+setlocal
+setlocal enabledelayedexpansion
+setlocal enableextensions
+
+if not exist ..\dist mkdir ..\dist
+if exist ..\dist\Microsoft.Recognizers.Text.DateTime*.whl erase /s ..\dist\Microsoft.Recognizers.Text.DateTime*.whl
+python setup.py bdist_wheel -d ..\dist\
+
+set error=%errorlevel%
+set packageName=Microsoft.Recognizers.Text.DateTime
+if %error% NEQ 0 (
+	echo *** Failed to build %packageName%
+	exit /b %error%
+) else (
+	echo *** Succeeded to build %packageName%
+)

--- a/Python/libraries/recognizers-number-with-unit/CreatePackage.cmd
+++ b/Python/libraries/recognizers-number-with-unit/CreatePackage.cmd
@@ -1,0 +1,18 @@
+@echo off
+echo *** Building Microsoft.Recognizers.Text.NumberWithUnit
+setlocal
+setlocal enabledelayedexpansion
+setlocal enableextensions
+
+if not exist ..\dist mkdir ..\dist
+if exist ..\dist\Microsoft.Recognizers.Text.NumberWithUnit*.whl erase /s ..\dist\Microsoft.Recognizers.Text.NumberWithUnit*.whl
+python setup.py bdist_wheel -d ..\dist\
+
+set error=%errorlevel%
+set packageName=Microsoft.Recognizers.Text.NumberWithUnit
+if %error% NEQ 0 (
+	echo *** Failed to build %packageName%
+	exit /b %error%
+) else (
+	echo *** Succeeded to build %packageName%
+)

--- a/Python/libraries/recognizers-number/CreatePackage.cmd
+++ b/Python/libraries/recognizers-number/CreatePackage.cmd
@@ -1,0 +1,18 @@
+@echo off
+echo *** Building Microsoft.Recognizers.Text.Number
+setlocal
+setlocal enabledelayedexpansion
+setlocal enableextensions
+
+if not exist ..\dist mkdir ..\dist
+if exist ..\dist\Microsoft.Recognizers.Text.Number*.whl erase /s ..\dist\Microsoft.Recognizers.Text.Number*.whl
+python setup.py bdist_wheel -d ..\dist\
+
+set error=%errorlevel%
+set packageName=Microsoft.Recognizers.Text.Number
+if %error% NEQ 0 (
+	echo *** Failed to build %packageName%
+	exit /b %error%
+) else (
+	echo *** Succeeded to build %packageName%
+)

--- a/Python/libraries/recognizers-sequence/CreatePackage.cmd
+++ b/Python/libraries/recognizers-sequence/CreatePackage.cmd
@@ -1,0 +1,18 @@
+@echo off
+echo *** Microsoft.Recognizers.Text.Sequence
+setlocal
+setlocal enabledelayedexpansion
+setlocal enableextensions
+
+if not exist ..\dist mkdir ..\dist
+if exist ..\dist\Microsoft.Recognizers.Text.Sequence*.whl erase /s ..\dist\Microsoft.Recognizers.Text.Sequence*.whl
+python setup.py bdist_wheel -d ..\dist\
+
+set error=%errorlevel%
+set packageName=Microsoft.Recognizers.Text.Sequence
+if %error% NEQ 0 (
+	echo *** Failed to build %packageName%
+	exit /b %error%
+) else (
+	echo *** Succeeded to build %packageName%
+)

--- a/Python/libraries/recognizers-text/CreatePackage.cmd
+++ b/Python/libraries/recognizers-text/CreatePackage.cmd
@@ -1,0 +1,18 @@
+@echo off
+echo *** Building Microsoft.Recognizers.Text
+setlocal
+setlocal enabledelayedexpansion
+setlocal enableextensions
+
+if not exist ..\dist mkdir ..\dist
+if exist ..\dist\Microsoft.Recognizers.Text*.whl erase /s ..\dist\Microsoft.Recognizers.Text*.whl
+python setup.py bdist_wheel -d ..\dist\
+
+set error=%errorlevel%
+set packageName=Microsoft.Recognizers.Text
+if %error% NEQ 0 (
+	echo *** Failed to build %packageName%
+	exit /b %error%
+) else (
+	echo *** Succeeded to build %packageName%
+)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,17 +32,17 @@ build:
 build_script:
 - cmd: >-
     CALL wmic os get caption, version, osarchitecture
-
+    
     CALL node -v
-
+    
     CALL npm -v
-
+    
     CALL node -e "console.log(process.versions.v8);"
-
+    
     cd .NET\
     
     build.ci.cmd
-
+    
     cd ..\JavaScript\
     
     build.ci.cmd
@@ -50,7 +50,7 @@ build_script:
     cd ..\Python\
     
     build.ci.cmd
-
+    
     cd ..\java\
     
     build.ci.cmd
@@ -75,3 +75,5 @@ artifacts:
       name: NuGets
     - path: 'Java\libraries\**\recognizers-text*.jar'
       name: JARs
+    - path: 'Python\libraries\dist\*'
+      name: Wheels


### PR DESCRIPTION
## Description
Update the Appveyor file in order to save the wheels packages of the python libraries as part of the build artifacts

## Specific Changes
- Update appveyor.yml file to save the python wheels packages in the build artifacts
- Add .cmd files to create python wheels package

## Testing
To test these changes, we configured an Appveyor app connected to a test branch.
![image](https://user-images.githubusercontent.com/37461749/57809472-e5947b80-773b-11e9-9680-5e96eea245c8.png)
The artifacts are successfully being saved as part of the build result. 
![image](https://user-images.githubusercontent.com/37461749/57809480-e88f6c00-773b-11e9-9a64-29fdf9cf3f2f.png)
