### PR TITLE
[Python] Timex migration – English classes

### DIFF
--- a/Python/libraries/datatypes-timex-expression/datatypes_timex_expression/english/__init__.py
+++ b/Python/libraries/datatypes-timex-expression/datatypes_timex_expression/english/__init__.py
@@ -1,0 +1,3 @@
+from .english_timex_relative_convert import english_convert_timex_to_string_relative
+from .english_timex_convert import *
+from .timex_constants import *

--- a/Python/libraries/datatypes-timex-expression/datatypes_timex_expression/english/english_timex_convert.py
+++ b/Python/libraries/datatypes-timex-expression/datatypes_timex_expression/english/english_timex_convert.py
@@ -1,0 +1,139 @@
+from ..timex_set import TimexSet
+from ..timex import Timex
+
+from .timex_constants import EnglishConstants
+from ..timex_inference import *
+
+
+def english_convert_date(timex: Timex):
+    if timex.day_of_week is not None:
+        return EnglishConstants.DAYS[timex.day_of_week - 1]
+
+    month = EnglishConstants.MONTHS[timex.month - 1]
+    date = str(timex.day_of_month)
+    abbreviation = EnglishConstants.DATE_ABBREVIATION[int(
+        str(date[len(date) - 1]))]
+
+    if timex.year is not None:
+        return f'{date}{abbreviation} {month} {timex.year}'
+
+    return f'{date}{abbreviation} {month}'
+
+
+def convert_time(timex: Timex):
+    if timex.hour == 0 and timex.minute == 0 and timex.second == 0:
+        return 'midnight'
+    if timex.hour == 12 and timex.minute == 0 and timex.second == 0:
+        return 'midday'
+
+    hour = '12' if timex.hour == 0 else str(
+        timex.hour - 12) if timex.hour > 12 else str(timex.hour)
+    minute = '' if timex.minute == 0 and timex.second == 0 else ':' + \
+        str(timex.minute).rjust(2, '0')
+    second = '' if timex.second == 0 else ':' + str(timex.second).rjust(2, '0')
+    period = 'AM' if timex.hour < 12 else 'PM'
+
+    return f'{hour}{minute}{second}{period}'
+
+
+def convert_duration_property_to_string(value, prop, include_single_count):
+    if value == 1:
+        return f'1 {prop}' if include_single_count else prop
+    else:
+        return f'{value} {prop}s'
+
+
+def convert_timex_duration_to_string(timex: Timex, include_single_count):
+    if timex.years is not None:
+        return convert_duration_property_to_string(timex.years, 'year', include_single_count)
+    if timex.months is not None:
+        return convert_duration_property_to_string(timex.months, 'month', include_single_count)
+    if timex.weeks is not None:
+        return convert_duration_property_to_string(timex.weeks, 'week', include_single_count)
+    if timex.days is not None:
+        return convert_duration_property_to_string(timex.days, 'day', include_single_count)
+    if timex.hours is not None:
+        return convert_duration_property_to_string(timex.hours, 'hour', include_single_count)
+    if timex.minutes is not None:
+        return convert_duration_property_to_string(timex.minutes, 'minute', include_single_count)
+    if timex.seconds is not None:
+        return convert_duration_property_to_string(timex.seconds, 'second', include_single_count)
+    return ''
+
+
+def convert_duration(timex: Timex):
+    return convert_timex_duration_to_string(timex, True)
+
+
+def convert_date_range(timex: Timex):
+    season = EnglishConstants.SEASONS[timex.season] if timex.season is not None else ''
+    year = str(timex.year) if timex.year is not None else ''
+    if timex.week_of_year is not None and timex.weekend is not None:
+        raise NotImplementedError
+
+    if timex.month is not None:
+        month = str(EnglishConstants.MONTHS[timex.month - 1])
+        if timex.week_of_month is not None:
+            return str(EnglishConstants.WEEKS[timex.week_of_month - 1]) + "week of " + month
+        else:
+            return str(month).strip() + str(year).strip()
+    return f'{season.strip()} {year.strip()}'
+
+
+def convert_time_range(timex: Timex):
+    return EnglishConstants.DAY_PARTS[timex.part_of_day]
+
+
+def convert_date_time(timex: Timex):
+    return f'{convert_time(timex)} {english_convert_date(timex)}'
+
+
+def convert_date(timex):
+    if timex.day_of_week is not None:
+        return EnglishConstants.DAYS[timex.day_of_week - 1]
+
+    month = EnglishConstants.MONTHS[timex.month - 1]
+    date = str(timex.day_of_month)
+    abbreviation = EnglishConstants.DATE_ABBREVIATION[int(date)]
+
+    if timex.year is not None:
+        return f'{date}{abbreviation} {month} {timex.year}'
+    return f'{date}{abbreviation} {month}'
+
+
+def convert_date_time_range(timex: Timex):
+    if Constants.TIMEX_TYPES_TIMERANGE in timex.types:
+        return f'{convert_date(timex)} {convert_time_range(timex)}'
+    return ''
+
+
+def convert_timex_to_string(timex: Timex):
+    types = timex.types if len(timex.types) != 0 else TimexInference.infer(timex)
+
+    if Constants.TIMEX_TYPES_PRESENT in types:
+        return 'now'
+    if Constants.TIMEX_TYPES_DATETIMERANGE in types:
+        return convert_date_time_range(timex)
+    if Constants.TIMEX_TYPES_DATERANGE in types:
+        return convert_date_range(timex)
+    if Constants.TIMEX_TYPES_DURATION in types:
+        return convert_duration(timex)
+    if Constants.TIMEX_TYPES_TIMERANGE in types:
+        return convert_time_range(timex)
+    if Constants.TIMEX_TYPES_DATETIME in types:
+        return convert_date_time(timex)
+    if Constants.TIMEX_TYPES_DATE in types:
+        return english_convert_date(timex)
+    if Constants.TIMEX_TYPES_TIME in types:
+        return convert_time(timex)
+
+    return ''
+
+
+def convert_timex_set_to_string(timex_set: TimexSet):
+    timex = timex_set.timex
+
+    if Constants.TIMEX_TYPES_DURATION in timex.types():
+        return 'every ' + convert_timex_duration_to_string(timex, False)
+    else:
+        return 'every ' + convert_timex_to_string(timex)

--- a/Python/libraries/datatypes-timex-expression/datatypes_timex_expression/english/english_timex_relative_convert.py
+++ b/Python/libraries/datatypes-timex-expression/datatypes_timex_expression/english/english_timex_relative_convert.py
@@ -1,0 +1,105 @@
+from datetime import datetime
+from .english_timex_convert import *
+from ..timex_date_helpers import *
+
+
+def get_date_day(date) -> str:
+    return EnglishConstants.DAYS[int(date)]
+
+
+def convert_date(timex: Timex, date: datetime):
+    if timex.year is not None and timex.month is not None and timex.day_of_month is not None:
+        timex_date = datetime(timex.year, timex.month, timex.day_of_month)
+        if TimexDateHelpers.date_part_equal(timex_date, date):
+            return 'today'
+        tomorrow = TimexDateHelpers.tomorrow(date)
+        if TimexDateHelpers.date_part_equal(timex_date, tomorrow):
+            return 'tomorrow'
+        yesterday = TimexDateHelpers.yesterday(date)
+        if TimexDateHelpers.date_part_equal(timex_date, yesterday):
+            return 'yesterday'
+        if TimexDateHelpers.is_this_week(timex_date, date):
+            return 'this ' + get_date_day(timex_date.weekday())
+        if TimexDateHelpers.is_next_week(timex_date, date):
+            return 'next ' + get_date_day(timex_date.weekday())
+        if TimexDateHelpers.is_last_week(timex_date, date):
+            return 'last ' + get_date_day(timex_date.weekday())
+
+    return english_convert_date(timex)
+
+
+def convert_date_time(timex: Timex, date: datetime):
+    return str(convert_date(timex, date)) + ' ' + str(convert_time(timex))
+
+
+def convert_date_range(timex: Timex, date: datetime):
+    if timex.year is not None:
+        year = date.year
+
+        if timex.year == year:
+            if timex.week_of_year is not None:
+                this_week = TimexDateHelpers.week_of_year(date)
+                if this_week == timex.week_of_year:
+                    return "this weekend" if timex.weekend is True else "this week"
+                if this_week == timex.week_of_year + 1:
+                    return "last weekend" if timex.weekend is True else "last week"
+                if this_week == timex.week_of_year - 1:
+                    return "next weekend" if timex.weekend is True else "next week"
+
+            if timex.month is not None:
+                if timex.month == date.month:
+                    return "this month"
+                if timex.month == date.month + 1:
+                    return "next month"
+                if timex.month == date.month - 1:
+                    return "last month"
+
+            return 'this ' + str(EnglishConstants.SEASONS[timex.season]) if timex.season is not None else "this year"
+
+        if timex.year == year + 1:
+            return 'next ' + str(EnglishConstants.SEASONS[timex.season]) if timex.season is not None else "next year"
+
+        if timex.year == year - 1:
+            return 'last ' + str(EnglishConstants.SEASONS[timex.season]) if timex.season is not None else "last year"
+
+    return ''
+
+
+def convert_date_time_range(timex: Timex, date: datetime):
+    if timex.year is not None and timex.month is not None and timex.day_of_month is not None:
+        timex_date = datetime(timex.year, timex.month, timex.day_of_month)
+        if timex.part_of_day is not None:
+            if TimexDateHelpers.date_part_equal(timex_date, date):
+                if timex.part_of_day == 'NI':
+                    return 'tonight'
+                else:
+                    return f'this {str(EnglishConstants.DAY_PARTS[timex.part_of_day])}'
+
+            tomorrow = TimexDateHelpers.tomorrow(date)
+            if TimexDateHelpers.date_part_equal(timex_date, tomorrow):
+                return f'tomorrow {EnglishConstants.DAY_PARTS[timex.part_of_day]}'
+
+            yesterday = TimexDateHelpers.yesterday(date)
+            if TimexDateHelpers.date_part_equal(timex_date, yesterday):
+                return f'yesterday {EnglishConstants.DAY_PARTS[timex.part_of_day]}'
+
+            if TimexDateHelpers.is_this_week(timex_date, date):
+                return f'next {get_date_day(timex_date.weekday())} {EnglishConstants.DAY_PARTS[timex.part_of_day]}'
+            if TimexDateHelpers.is_next_week(timex_date, date):
+                return f'next {get_date_day(timex_date.weekday())} {EnglishConstants.DAY_PARTS[timex.part_of_day]}'
+    return ''
+
+
+def english_convert_timex_to_string_relative(timex: Timex, date: datetime):
+    types = timex.types if len(timex.types) is not 0 else TimexInference.infer(timex)
+
+    if Constants.TIMEX_TYPES_DATETIMERANGE in types:
+        return convert_date_time_range(timex, date)
+    if Constants.TIMEX_TYPES_DATERANGE in types:
+        return convert_date_range(timex, date)
+    if Constants.TIMEX_TYPES_DATETIME in types:
+        return convert_date_time(timex, date)
+    if Constants.TIMEX_TYPES_DATE in types:
+        return convert_date(timex, date)
+
+    return convert_timex_to_string(timex)

--- a/Python/libraries/datatypes-timex-expression/datatypes_timex_expression/english/timex_constants.py
+++ b/Python/libraries/datatypes-timex-expression/datatypes_timex_expression/english/timex_constants.py
@@ -1,0 +1,60 @@
+class EnglishConstants:
+    DAYS: [str] = [
+        'Monday',
+        'Tuesday',
+        'Wednesday',
+        'Thursday',
+        'Friday',
+        'Saturday',
+        'Sunday'
+    ]
+
+    MONTHS: [str] = [
+        'January',
+        'Februrary',
+        'March',
+        'April',
+        'May',
+        'June',
+        'July',
+        'August',
+        'September',
+        'October',
+        'November',
+        'December'
+    ]
+
+    DATE_ABBREVIATION: {int, str} = {
+        0: 'th',
+        1: 'st',
+        2: 'nd',
+        3: 'rd',
+        4: 'th',
+        5: 'th',
+        6: 'th',
+        7: 'th',
+        8: 'th',
+        9: 'th'
+    }
+
+    HOURS: [str] = [
+        'midnight', '1AM', '2AM', '3AM', '4AM', '5AM', '6AM', '7AM', '8AM', '9AM', '10AM', '11AM',
+        'midday', '1PM', '2PM', '3PM', '4PM', '5PM', '6PM', '7PM', '8PM', '9PM', '10PM', '11PM'
+    ]
+
+    SEASONS: {str, str} = {
+        'SP': 'spring',
+        'SU': 'summer',
+        'FA': 'fall',
+        'WI': 'winter'
+    }
+
+    WEEKS: [str] = ['first', 'second', 'third', 'forth']
+
+    DAY_PARTS: {str, str} = {
+        'DT': 'daytime',
+        'NI': 'night',
+        'MO': 'morning',
+        'AF': 'afternoon',
+        'EV': 'evening'
+    }


### PR DESCRIPTION
### **Timex migration – English classes**
### Description
Based on `Microsoft.Recognizers.Text.DataTypes.TimexExpression`, we migrated 
English folder with their respectives classes: TimexConstants, TimexConvert, and TimexRelativeConvert.

 ### Changes made
Porting of the English modules: `english_timex_ convert`,`english_timex_relative_convert`, and `timex_constants`.

Find each file’ details below:

**timex_constants** file
- days
- months
- date_abbreviation
- hours
- seasons
- weeks
- day_parts

**english_timex_convert** file
- english_convert_date
- convert_time
- convert_duration_property_to_string
- convert_timex_duration_to_string
- convert_duration
- convert_date_range
- convert_time_range
- convert_date_time
- convert_date_time_range
- convert_timex_to_string
- convert_timex_set_to_string

**english_relative_convert** file
- get_date_day
- convert_date
- convert_date_time
- convert_date_range
- convert_date_time_range
- convert_timex_to_string_relative

Notice that the C#'s **TimexRelativeConvert** and **TimexConvert** are no longer classes in python, as we emulated the JS implementation and used modules. 
Because of this, there are changes in the naming of the files from C# to Python:  **TimexRelativeConvert** and **TimexConvert** are now **english_relative_convert** and **english_convert_date** respectively.

Additionally, as we took advantage of modules instead of classes, we had to be more specific when naming the files for the imports, as seen on the imports section of _english_relative_convert_.
![image](https://user-images.githubusercontent.com/42946515/61141699-82596800-a4a4-11e9-8356-45dc9702f709.png)
### Additional information
See the files and folder structure in `datetypes_timex_expression/english`, as shown below:
![image](https://user-images.githubusercontent.com/42946515/61074995-6ba50980-a3ef-11e9-9f57-fb8cbb3f9763.png)