### PR TITLE
[Python] Recognizers-text - Add emoji as required dependency

### DIFF
--- a/Python/libraries/recognizers-text/setup.py
+++ b/Python/libraries/recognizers-text/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 NAME = "recognizers-text"
 VERSION = "1.0.0.a0"
-REQUIRES = []
+REQUIRES = ['emoji']
 
 setup(
     name=NAME,

--- a/Python/requirements.txt
+++ b/Python/requirements.txt
@@ -1,4 +1,3 @@
-emoji
 pre-commit==1.16.1
 autopep8
 flake8


### PR DESCRIPTION
Fixes ISSUE 1740

### Description
When running some test methods from a file with a reference to _recognizers-text_ after installing this package directly (i.e, by using the _pip install_ command instead of the _build.cmd_ file), and without having the `emoji` package installed in your environment, the next error will be prompted:

![image](https://user-images.githubusercontent.com/43762887/62055062-438c1780-b1f1-11e9-82f5-e89f65c80a9b.png)

In order to fix this, it's necessary to add `emoji` as a requirement in the `setup.py` file.

### Reproduce ISSUE
For reproducing the current ISSUE, follow these steps without the changes performed in this PR:
1. Ensure that _emoji_ is not installed in your environment
1. Add a reference to _recognizers-text_ in, for example, _test_initialization_number_with_unit_recognizer.py_ file:
![image](https://user-images.githubusercontent.com/43762887/62054574-3ae71180-b1f0-11e9-9d4e-985b022f5a81.png)
1. Manually install the _recognizers-text_ package using `pip install -e .\libraries\recognizers-text`
1. Run the test methods from the file where you added the reference to _recognizers-text_ package with the command `pytest`. The next error will be prompted:
![image](https://user-images.githubusercontent.com/43762887/62055104-5272ca00-b1f1-11e9-8d4a-8ca36f8d9e5f.png)

### Changes made
- Add `emoji` as a requirement in the `setup.py` file.
- Remove `emoji` from the `requirements.txt` file.

### Testing
Using this PR's changes, follow the next steps:
1. Add a reference to _recognizers-text_ in, for example, _test_initialization_number_with_unit_recognizer.py_ file
1. Manually install the _recognizers-text_ package using `pip install -e .\libraries\recognizers-text`. In this case, you will see that the `emoji` package is being installed:
![image](https://user-images.githubusercontent.com/43762887/62055150-6a4a4e00-b1f1-11e9-89e1-ea47671b896a.png)
1.  Run the test methods from the file where you added the reference to _recognizers-text_ (_pytest tests\test_initialization_number_with_unit_recognizer.py_). The test successfully pass:
![image](https://user-images.githubusercontent.com/43762887/62055172-73d3b600-b1f1-11e9-8685-2bdc867463b8.png)
