### PR TITLE
[python-sequence] Support to URL models

### DIFF
--- a/Python/libraries/recognizers-sequence/recognizers_sequence/sequence/chinese/extractors.py
+++ b/Python/libraries/recognizers-sequence/recognizers_sequence/sequence/chinese/extractors.py
@@ -59,4 +59,5 @@ class ChineseURLExtractorConfiguration(URLConfiguration):
     def __init__(self, options):
         self.__url_regex = RegExpUtility.get_safe_reg_exp(ChineseURL.UrlRegex)
         self.__ip_url_regex = RegExpUtility.get_safe_reg_exp(ChineseURL.IpUrlRegex)
+
         super().__init__(options)

--- a/Python/libraries/recognizers-sequence/recognizers_sequence/sequence/english/extractors.py
+++ b/Python/libraries/recognizers-sequence/recognizers_sequence/sequence/english/extractors.py
@@ -65,10 +65,6 @@ class EnglishURLExtractorConfiguration(URLConfiguration):
         super().__init__(options)
 
 
-class ChineseURLExtractorConfiguration(URLConfiguration):
-    pass
-
-
 class EnglishGUIDExtractor(BaseGUIDExtractor):
     pass
 

--- a/Python/libraries/recognizers-sequence/recognizers_sequence/sequence/english/extractors.py
+++ b/Python/libraries/recognizers-sequence/recognizers_sequence/sequence/english/extractors.py
@@ -59,8 +59,9 @@ class EnglishURLExtractorConfiguration(URLConfiguration):
         self.__url_regex = url_regex
 
     def __init__(self, options):
-        self.__ip_url_regex = RegExpUtility.get_safe_reg_exp(BaseURL.UrlRegex)
-        self.__url_regex = RegExpUtility.get_safe_reg_exp(BaseURL.IpUrlRegex)
+        self.__ip_url_regex = RegExpUtility.get_safe_reg_exp(BaseURL.IpUrlRegex)
+        self.__url_regex = RegExpUtility.get_safe_reg_exp(BaseURL.UrlRegex)
+
         super().__init__(options)
 
 

--- a/Python/libraries/recognizers-sequence/recognizers_sequence/sequence/extractors.py
+++ b/Python/libraries/recognizers-sequence/recognizers_sequence/sequence/extractors.py
@@ -245,16 +245,8 @@ class BaseURLExtractor(SequenceExtractor):
     def config(self, config):
         self._config = config
 
-    @property
-    def tld_matcher(self) -> Match:
-        return self._tld_matcher
-
-    @tld_matcher.setter
-    def tld_matcher(self, tld_matcher):
-        self._tld_matcher = tld_matcher
-
     def _is_valid_match(self, match: Match) -> bool:
-        #For cases like "7.am" or "8.pm" which are more likely time terms.
+        # For cases like "7.am" or "8.pm" which are more likely time terms.
         return re.match(self.ambiguous_time_term.re, match.group(0)) is None
 
     @property

--- a/Python/libraries/recognizers-sequence/recognizers_sequence/sequence/extractors.py
+++ b/Python/libraries/recognizers-sequence/recognizers_sequence/sequence/extractors.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 from typing import List, Dict, Set, Pattern, Match
 from collections import namedtuple
 import regex as re
-
+from recognizers_sequence.sequence.config.url_configuration import URLConfiguration
 from .constants import *
 from recognizers_text.utilities import RegExpUtility
 from recognizers_text.extractor import Extractor, ExtractResult
@@ -72,6 +72,9 @@ class SequenceExtractor(Extractor):
     @staticmethod
     def _pre_check_str(source: str) -> bool:
         return len(source) != 0
+
+    def _is_valid_match(self, source: str) -> bool:
+        return True
 
 
 class BasePhoneNumberExtractor(SequenceExtractor):
@@ -228,6 +231,23 @@ class BaseURLExtractor(SequenceExtractor):
         return Constants.SYS_URL
 
     @property
+    def config(self) -> URLConfiguration:
+        return self._config
+
+    @config.setter
+    def config(self, config):
+        self._config = config
+
+    def _is_valid_match(self, source: Match) -> bool:
+        is_valid_tld = False
+        is_ip_URL = source.groups('IPurl')
+
+        if is_ip_URL is not True:
+            tld_string = source.groups('Tld')
+
+        return True
+
+    @property
     def regexes(self) -> List[ReVal]:
         return self._regexes
 
@@ -239,7 +259,9 @@ class BaseURLExtractor(SequenceExtractor):
         self.config = config
 
         self._regexes = [
-            ReVal(RegExpUtility.get_safe_reg_exp(BaseURL.UrlRegex), Constants.URL_REGEX)
+            ReVal(RegExpUtility.get_safe_reg_exp(BaseURL.UrlRegex), Constants.URL_REGEX),
+            ReVal(RegExpUtility.get_safe_reg_exp(BaseURL.IpUrlRegex), Constants.URL_REGEX),
+            ReVal(RegExpUtility.get_safe_reg_exp(BaseURL.UrlRegex2), Constants.URL_REGEX)
         ]
 
         self._ambiguous_time_term = RegExpUtility.get_safe_reg_exp(BaseURL.AmbiguousTimeTerm)

--- a/Python/libraries/recognizers-sequence/recognizers_sequence/sequence/extractors.py
+++ b/Python/libraries/recognizers-sequence/recognizers_sequence/sequence/extractors.py
@@ -288,11 +288,10 @@ class BaseURLExtractor(SequenceExtractor):
 
         validate_ambiguous_time_term = MatchesVal(matches=list(re.finditer(self.ambiguous_time_term.re, match)),
                                                   val=self.ambiguous_time_term.val)
-
-        validate_URL = MatchesVal(matches=list(re.finditer(self.regexes[0].re, match)), val=self.regexes[0].val)
-
-        if validate_ambiguous_time_term[0].__len__() != 0 and validate_URL.matches.__len__() > 0:
-            return False
+        #si comienza con numero
+        if validate_ambiguous_time_term[0].__len__() != 0:
+            if source.string[0].isdigit():
+                return False
 
         return is_valid_tld or is_ip_URL
 
@@ -309,7 +308,7 @@ class BaseURLExtractor(SequenceExtractor):
             ReVal(RegExpUtility.get_safe_reg_exp(BaseURL.UrlRegex2), Constants.URL_REGEX)
         ]
 
-        self._ambiguous_time_term = ReVal(RegExpUtility.get_safe_reg_exp("^(\\D1?[0-9]|2?[0-9]).[ap]m$"), Constants.URL_REGEX)
+        self._ambiguous_time_term = ReVal(RegExpUtility.get_safe_reg_exp(r"^(\D1?[0-9]|2?[0-9]).[ap]m$"), Constants.URL_REGEX)
 
     @staticmethod
     def get_ext(url):

--- a/Python/libraries/recognizers-sequence/recognizers_sequence/sequence/sequence_recognizer.py
+++ b/Python/libraries/recognizers-sequence/recognizers_sequence/sequence/sequence_recognizer.py
@@ -1,7 +1,6 @@
 from enum import IntFlag
-from recognizers_sequence.sequence.chinese.extractors import ChinesePhoneNumberExtractorConfiguration, \
-    BasePhoneNumberExtractor
-from recognizers_text import Culture, Recognizer
+from .chinese.extractors import *
+from recognizers_text import *
 from .english.extractors import *
 from .english.parsers import *
 from .models import *
@@ -67,6 +66,8 @@ class SequenceRecognizer(Recognizer[SequenceOptions]):
         return self.get_model('HashtagModel', culture, fallback_to_default_culture)
 
     def get_url_model(self, culture: str = None, fallback_to_default_culture: bool = True) -> Model:
+        if culture and (culture.lower().startswith("zh-") or culture.lower().startswith("ja-")):
+            return self.get_model('URLModel', Culture.Chinese, fallback_to_default_culture)
         return self.get_model('URLModel', culture, fallback_to_default_culture)
 
     def get_guid_model(self, culture: str = None, fallback_to_default_culture: bool = True) -> Model:

--- a/Python/tests/runner.py
+++ b/Python/tests/runner.py
@@ -24,12 +24,12 @@ def split_all(path):
 
 def get_suite_config(json_path):
     parts = split_all(json_path)
-    filename = os.path.splitext(parts[5])[0]
+    filename = os.path.splitext(parts[4])[0]
     model, entity, options = ENTITY_PATTERN.search(filename).groups()
     if model == 'Merged' and entity == 'Parser':
         entity = f'{model}{entity}'
-    return {'recognizer': parts[3], 'model': model,
-            'entity': entity, 'options': options, 'language': parts[4]}
+    return {'recognizer': parts[2], 'model': model,
+            'entity': entity, 'options': options, 'language': parts[3]}
 
 
 def get_suite(json_path):
@@ -39,7 +39,7 @@ def get_suite(json_path):
 
 
 def get_all_specs():
-    files = glob.glob('../../Specs/**/*.json', recursive=True)
+    files = glob.glob('../Specs/**/*.json', recursive=True)
     result = list(map(get_suite, files))
     return result
 

--- a/Python/tests/runner.py
+++ b/Python/tests/runner.py
@@ -24,12 +24,12 @@ def split_all(path):
 
 def get_suite_config(json_path):
     parts = split_all(json_path)
-    filename = os.path.splitext(parts[4])[0]
+    filename = os.path.splitext(parts[5])[0]
     model, entity, options = ENTITY_PATTERN.search(filename).groups()
     if model == 'Merged' and entity == 'Parser':
         entity = f'{model}{entity}'
-    return {'recognizer': parts[2], 'model': model,
-            'entity': entity, 'options': options, 'language': parts[3]}
+    return {'recognizer': parts[3], 'model': model,
+            'entity': entity, 'options': options, 'language': parts[4]}
 
 
 def get_suite(json_path):
@@ -39,7 +39,7 @@ def get_suite(json_path):
 
 
 def get_all_specs():
-    files = glob.glob('../Specs/**/*.json', recursive=True)
+    files = glob.glob('../../Specs/**/*.json', recursive=True)
     result = list(map(get_suite, files))
     return result
 

--- a/Specs/Sequence/Chinese/URLModel.json
+++ b/Specs/Sequence/Chinese/URLModel.json
@@ -1,7 +1,6 @@
 [
   {
     "Input": "https://abc.com",
-    "NotSupportedByDesign": "",
     "Results": [
       {
         "Text": "https://abc.com",
@@ -14,7 +13,6 @@
   },
   {
     "Input": "ftp://abc.com",
-    "NotSupportedByDesign": "",
     "Results": [
       {
         "Text": "ftp://abc.com",
@@ -27,7 +25,6 @@
   },
   {
     "Input": "http://abc.com",
-    "NotSupportedByDesign": "",
     "Results": [
       {
         "Text": "http://abc.com",
@@ -40,7 +37,6 @@
   },
   {
     "Input": "www.abc.com",
-    "NotSupportedByDesign": "",
     "Results": [
       {
         "Text": "www.abc.com",
@@ -53,7 +49,6 @@
   },
   {
     "Input": "www.abc.com.cn",
-    "NotSupportedByDesign": "",
     "Results": [
       {
         "Text": "www.abc.com.cn",
@@ -66,7 +61,6 @@
   },
   {
     "Input": "abc.com",
-    "NotSupportedByDesign": "",
     "Results": [
       {
         "Text": "abc.com",
@@ -79,7 +73,6 @@
   },
   {
     "Input": "http://abc.com/file_name",
-    "NotSupportedByDesign": "",
     "Results": [
       {
         "Text": "http://abc.com/file_name",
@@ -92,7 +85,6 @@
   },
   {
     "Input": "http://abc.com/file_path/",
-    "NotSupportedByDesign": "",
     "Results": [
       {
         "Text": "http://abc.com/file_path/",
@@ -105,7 +97,6 @@
   },
   {
     "Input": "http://abc.com/file_path/123.html",
-    "NotSupportedByDesign": "",
     "Results": [
       {
         "Text": "http://abc.com/file_path/123.html",
@@ -118,7 +109,6 @@
   },
   {
     "Input": "http://abc.com/search?id=123",
-    "NotSupportedByDesign": "",
     "Results": [
       {
         "Text": "http://abc.com/search?id=123",
@@ -131,7 +121,6 @@
   },
   {
     "Input": "http://abc.com/search?id=123&name=Alice",
-    "NotSupportedByDesign": "",
     "Results": [
       {
         "Text": "http://abc.com/search?id=123&name=Alice",
@@ -144,7 +133,6 @@
   },
   {
     "Input": "http://abc.com/123#cite_1",
-    "NotSupportedByDesign": "",
     "Results": [
       {
         "Text": "http://abc.com/123#cite_1",
@@ -157,7 +145,6 @@
   },
   {
     "Input": "http://abc.com:8080",
-    "NotSupportedByDesign": "",
     "Results": [
       {
         "Text": "http://abc.com:8080",
@@ -170,7 +157,6 @@
   },
   {
     "Input": "你好，@伊芙，你可以在这里看到我的简历https://frank.website.com/CV/#cite_2",
-    "NotSupportedByDesign": "",
     "Results": [
       {
         "Text": "https://frank.website.com/CV/#cite_2",
@@ -183,32 +169,26 @@
   },
   {
     "Input": "Alice@abc.com是个邮箱不是个url地址",
-    "NotSupportedByDesign": "",
     "Results": []
   },
   {
     "Input": "https:// 是不合法的",
-    "NotSupportedByDesign": "",
     "Results": []
   },
   {
     "Input": "http://#是不合法的",
-    "NotSupportedByDesign": "",
     "Results": []
   },
   {
     "Input": "httt://abc.com是不合法的, 没有这样的协议地址",
-    "NotSupportedByDesign": "",
     "Results": []
   },
   {
     "Input": "你好， @Carol,请发送邮件到Dave@abc.com以获取更多关于#A1的信息",
-    "NotSupportedByDesign": "",
     "Results": []
   },
   {
     "Input": "http://127.0.0.1:8080",
-    "NotSupportedByDesign": "",
     "Results": [
       {
         "Text": "http://127.0.0.1:8080",
@@ -221,7 +201,6 @@
   },
   {
     "Input": "http://localhost:8080",
-    "NotSupportedByDesign": "",
     "Results": [
       {
         "Text": "http://localhost:8080",
@@ -234,7 +213,6 @@
   },
   {
     "Input": "http://localhost:8080#123",
-    "NotSupportedByDesign": "",
     "Results": [
       {
         "Text": "http://localhost:8080#123",
@@ -247,7 +225,6 @@
   },
   {
     "Input": "http://localhost:8080/#/123",
-    "NotSupportedByDesign": "",
     "Results": [
       {
         "Text": "http://localhost:8080/#/123",
@@ -260,7 +237,6 @@
   },
   {
     "Input": "http://127.0.0.1:8080/#/123",
-    "NotSupportedByDesign": "",
     "Results": [
       {
         "Text": "http://127.0.0.1:8080/#/123",
@@ -273,7 +249,6 @@
   },
   {
     "Input": "['http://twitter.com/#!/KCGtechnoly/status/9042443475840', None]",
-    "NotSupportedByDesign": "",
     "Results": [
       {
         "Text": "http://twitter.com/#!/KCGtechnoly/status/9042443475840",
@@ -286,12 +261,10 @@
   },
   {
     "Input": "DNS服务器地址是8.8.8.8",
-    "NotSupportedByDesign": "",
     "Results": []
   },
   {
     "Input": "更多详情:https://bit.ly/2jm6eu3",
-    "NotSupportedByDesign": "",
     "Results": [
       {
         "Text": "https://bit.ly/2jm6eu3",
@@ -306,7 +279,6 @@
   },
   {
     "Input": "五月五.https://t.co/YCUZfuyyHZ",
-    "NotSupportedByDesign": "",
     "Results": [
       {
         "Text": "https://t.co/YCUZfuyyHZ",
@@ -321,7 +293,6 @@
   },
   {
     "Input": "以下皆为合法地址：bit.ly, nyti.ms, sound.academy, pep.si, lero.aws...",
-    "NotSupportedByDesign": "",
     "Results": [
       {
         "Text": "bit.ly",
@@ -372,12 +343,10 @@
   },
   {
     "Input": "john.de@cooso.com.au",
-    "NotSupportedByDesign": "",
     "Results": []
   },
   {
     "Input": "请访问https://luis.ai?action=add以获取更多信息",
-    "NotSupportedByDesign": "",
     "Results": [
       {
         "Text": "https://luis.ai?action=add",
@@ -392,17 +361,14 @@
   },
   {
     "Input": "working..是一个不合法的网址",
-    "NotSupportedByDesign": "",
     "Results": []
   },
   {
     "Input": "7.am更像是一个日期而不是一个网址。",
-    "NotSupportedByDesign": "",
     "Results": []
   },
   {
     "Input": "请访问https://7.am以获取更多信息。",
-    "NotSupportedByDesign": "",
     "Results": [
       {
         "Text": "https://7.am",
@@ -417,7 +383,6 @@
   },
   {
     "Input": "请访问27.pm和s7.am以获取更多信息。",
-    "NotSupportedByDesign": "",
     "Results": [
       {
         "Text": "27.pm",
@@ -442,13 +407,11 @@
   {
     "Input": "百度.com 是不合法地址",
     "Notsupport": "java",
-    "NotSupportedByDesign": "",
     "Results": []
   },
   {
     "Input": "网址是microsoft.com",
     "Notsupport": "java",
-    "NotSupportedByDesign": "",
     "Results": [
       {
         "Text": "microsoft.com",
@@ -464,7 +427,6 @@
   {
     "Input": "微软的官网是microsoft.com哦",
     "Notsupport": "java",
-    "NotSupportedByDesign": "",
     "Results": [
       {
         "Text": "microsoft.com",
@@ -480,7 +442,6 @@
   {
     "Input": "微软的官网是：microsoft.com",
     "Notsupport": "java",
-    "NotSupportedByDesign": "",
     "Results": [
       {
         "Text": "microsoft.com",
@@ -496,7 +457,6 @@
   {
     "Input": "微软的官网是：www.microsoft.com",
     "Notsupport": "java",
-    "NotSupportedByDesign": "",
     "Results": [
       {
         "Text": "www.microsoft.com",
@@ -512,7 +472,6 @@
   {
     "Input": "微软的官网是：http://www.microsoft.com",
     "Notsupport": "java",
-    "NotSupportedByDesign": "",
     "Results": [
       {
         "Text": "http://www.microsoft.com",

--- a/Specs/Sequence/Chinese/URLModel.json
+++ b/Specs/Sequence/Chinese/URLModel.json
@@ -1,7 +1,7 @@
 [
   {
     "Input": "https://abc.com",
-    "NotSupportedByDesign": "python",
+    "NotSupportedByDesign": "",
     "Results": [
       {
         "Text": "https://abc.com",
@@ -14,7 +14,7 @@
   },
   {
     "Input": "ftp://abc.com",
-    "NotSupportedByDesign": "python",
+    "NotSupportedByDesign": "",
     "Results": [
       {
         "Text": "ftp://abc.com",
@@ -27,7 +27,7 @@
   },
   {
     "Input": "http://abc.com",
-    "NotSupportedByDesign": "python",
+    "NotSupportedByDesign": "",
     "Results": [
       {
         "Text": "http://abc.com",
@@ -40,7 +40,7 @@
   },
   {
     "Input": "www.abc.com",
-    "NotSupportedByDesign": "python",
+    "NotSupportedByDesign": "",
     "Results": [
       {
         "Text": "www.abc.com",
@@ -53,7 +53,7 @@
   },
   {
     "Input": "www.abc.com.cn",
-    "NotSupportedByDesign": "python",
+    "NotSupportedByDesign": "",
     "Results": [
       {
         "Text": "www.abc.com.cn",
@@ -66,7 +66,7 @@
   },
   {
     "Input": "abc.com",
-    "NotSupportedByDesign": "python",
+    "NotSupportedByDesign": "",
     "Results": [
       {
         "Text": "abc.com",
@@ -79,7 +79,7 @@
   },
   {
     "Input": "http://abc.com/file_name",
-    "NotSupportedByDesign": "python",
+    "NotSupportedByDesign": "",
     "Results": [
       {
         "Text": "http://abc.com/file_name",
@@ -92,7 +92,7 @@
   },
   {
     "Input": "http://abc.com/file_path/",
-    "NotSupportedByDesign": "python",
+    "NotSupportedByDesign": "",
     "Results": [
       {
         "Text": "http://abc.com/file_path/",
@@ -105,7 +105,7 @@
   },
   {
     "Input": "http://abc.com/file_path/123.html",
-    "NotSupportedByDesign": "python",
+    "NotSupportedByDesign": "",
     "Results": [
       {
         "Text": "http://abc.com/file_path/123.html",
@@ -118,7 +118,7 @@
   },
   {
     "Input": "http://abc.com/search?id=123",
-    "NotSupportedByDesign": "python",
+    "NotSupportedByDesign": "",
     "Results": [
       {
         "Text": "http://abc.com/search?id=123",
@@ -131,7 +131,7 @@
   },
   {
     "Input": "http://abc.com/search?id=123&name=Alice",
-    "NotSupportedByDesign": "python",
+    "NotSupportedByDesign": "",
     "Results": [
       {
         "Text": "http://abc.com/search?id=123&name=Alice",
@@ -144,7 +144,7 @@
   },
   {
     "Input": "http://abc.com/123#cite_1",
-    "NotSupportedByDesign": "python",
+    "NotSupportedByDesign": "",
     "Results": [
       {
         "Text": "http://abc.com/123#cite_1",
@@ -157,7 +157,7 @@
   },
   {
     "Input": "http://abc.com:8080",
-    "NotSupportedByDesign": "python",
+    "NotSupportedByDesign": "",
     "Results": [
       {
         "Text": "http://abc.com:8080",
@@ -170,7 +170,7 @@
   },
   {
     "Input": "你好，@伊芙，你可以在这里看到我的简历https://frank.website.com/CV/#cite_2",
-    "NotSupportedByDesign": "python",
+    "NotSupportedByDesign": "",
     "Results": [
       {
         "Text": "https://frank.website.com/CV/#cite_2",
@@ -183,32 +183,32 @@
   },
   {
     "Input": "Alice@abc.com是个邮箱不是个url地址",
-    "NotSupportedByDesign": "python",
+    "NotSupportedByDesign": "",
     "Results": []
   },
   {
     "Input": "https:// 是不合法的",
-    "NotSupportedByDesign": "python",
+    "NotSupportedByDesign": "",
     "Results": []
   },
   {
     "Input": "http://#是不合法的",
-    "NotSupportedByDesign": "python",
+    "NotSupportedByDesign": "",
     "Results": []
   },
   {
     "Input": "httt://abc.com是不合法的, 没有这样的协议地址",
-    "NotSupportedByDesign": "python",
+    "NotSupportedByDesign": "",
     "Results": []
   },
   {
     "Input": "你好， @Carol,请发送邮件到Dave@abc.com以获取更多关于#A1的信息",
-    "NotSupportedByDesign": "python",
+    "NotSupportedByDesign": "",
     "Results": []
   },
   {
     "Input": "http://127.0.0.1:8080",
-    "NotSupportedByDesign": "python",
+    "NotSupportedByDesign": "",
     "Results": [
       {
         "Text": "http://127.0.0.1:8080",
@@ -221,7 +221,7 @@
   },
   {
     "Input": "http://localhost:8080",
-    "NotSupportedByDesign": "python",
+    "NotSupportedByDesign": "",
     "Results": [
       {
         "Text": "http://localhost:8080",
@@ -234,7 +234,7 @@
   },
   {
     "Input": "http://localhost:8080#123",
-    "NotSupportedByDesign": "python",
+    "NotSupportedByDesign": "",
     "Results": [
       {
         "Text": "http://localhost:8080#123",
@@ -247,7 +247,7 @@
   },
   {
     "Input": "http://localhost:8080/#/123",
-    "NotSupportedByDesign": "python",
+    "NotSupportedByDesign": "",
     "Results": [
       {
         "Text": "http://localhost:8080/#/123",
@@ -260,7 +260,7 @@
   },
   {
     "Input": "http://127.0.0.1:8080/#/123",
-    "NotSupportedByDesign": "python",
+    "NotSupportedByDesign": "",
     "Results": [
       {
         "Text": "http://127.0.0.1:8080/#/123",
@@ -273,7 +273,7 @@
   },
   {
     "Input": "['http://twitter.com/#!/KCGtechnoly/status/9042443475840', None]",
-    "NotSupportedByDesign": "python",
+    "NotSupportedByDesign": "",
     "Results": [
       {
         "Text": "http://twitter.com/#!/KCGtechnoly/status/9042443475840",
@@ -286,12 +286,12 @@
   },
   {
     "Input": "DNS服务器地址是8.8.8.8",
-    "NotSupportedByDesign": "python",
+    "NotSupportedByDesign": "",
     "Results": []
   },
   {
     "Input": "更多详情:https://bit.ly/2jm6eu3",
-    "NotSupportedByDesign": "python",
+    "NotSupportedByDesign": "",
     "Results": [
       {
         "Text": "https://bit.ly/2jm6eu3",
@@ -306,7 +306,7 @@
   },
   {
     "Input": "五月五.https://t.co/YCUZfuyyHZ",
-    "NotSupportedByDesign": "python",
+    "NotSupportedByDesign": "",
     "Results": [
       {
         "Text": "https://t.co/YCUZfuyyHZ",
@@ -321,7 +321,7 @@
   },
   {
     "Input": "以下皆为合法地址：bit.ly, nyti.ms, sound.academy, pep.si, lero.aws...",
-    "NotSupportedByDesign": "python",
+    "NotSupportedByDesign": "",
     "Results": [
       {
         "Text": "bit.ly",
@@ -372,12 +372,12 @@
   },
   {
     "Input": "john.de@cooso.com.au",
-    "NotSupportedByDesign": "python",
+    "NotSupportedByDesign": "",
     "Results": []
   },
   {
     "Input": "请访问https://luis.ai?action=add以获取更多信息",
-    "NotSupportedByDesign": "python",
+    "NotSupportedByDesign": "",
     "Results": [
       {
         "Text": "https://luis.ai?action=add",
@@ -392,17 +392,17 @@
   },
   {
     "Input": "working..是一个不合法的网址",
-    "NotSupportedByDesign": "python",
+    "NotSupportedByDesign": "",
     "Results": []
   },
   {
     "Input": "7.am更像是一个日期而不是一个网址。",
-    "NotSupportedByDesign": "python",
+    "NotSupportedByDesign": "",
     "Results": []
   },
   {
     "Input": "请访问https://7.am以获取更多信息。",
-    "NotSupportedByDesign": "python",
+    "NotSupportedByDesign": "",
     "Results": [
       {
         "Text": "https://7.am",
@@ -417,7 +417,7 @@
   },
   {
     "Input": "请访问27.pm和s7.am以获取更多信息。",
-    "NotSupportedByDesign": "python",
+    "NotSupportedByDesign": "",
     "Results": [
       {
         "Text": "27.pm",
@@ -442,13 +442,13 @@
   {
     "Input": "百度.com 是不合法地址",
     "Notsupport": "java",
-    "NotSupportedByDesign": "python",
+    "NotSupportedByDesign": "",
     "Results": []
   },
   {
     "Input": "网址是microsoft.com",
     "Notsupport": "java",
-    "NotSupportedByDesign": "python",
+    "NotSupportedByDesign": "",
     "Results": [
       {
         "Text": "microsoft.com",
@@ -464,7 +464,7 @@
   {
     "Input": "微软的官网是microsoft.com哦",
     "Notsupport": "java",
-    "NotSupportedByDesign": "python",
+    "NotSupportedByDesign": "",
     "Results": [
       {
         "Text": "microsoft.com",
@@ -480,7 +480,7 @@
   {
     "Input": "微软的官网是：microsoft.com",
     "Notsupport": "java",
-    "NotSupportedByDesign": "python",
+    "NotSupportedByDesign": "",
     "Results": [
       {
         "Text": "microsoft.com",
@@ -496,7 +496,7 @@
   {
     "Input": "微软的官网是：www.microsoft.com",
     "Notsupport": "java",
-    "NotSupportedByDesign": "python",
+    "NotSupportedByDesign": "",
     "Results": [
       {
         "Text": "www.microsoft.com",
@@ -512,7 +512,7 @@
   {
     "Input": "微软的官网是：http://www.microsoft.com",
     "Notsupport": "java",
-    "NotSupportedByDesign": "python",
+    "NotSupportedByDesign": "",
     "Results": [
       {
         "Text": "http://www.microsoft.com",

--- a/Specs/Sequence/English/URLModel.json
+++ b/Specs/Sequence/English/URLModel.json
@@ -189,7 +189,6 @@
   },
   {
     "Input": "http://127.0.0.1:8080",
-    "NotSupportedByDesign": "",
     "Results": [
       {
         "Text": "http://127.0.0.1:8080",
@@ -202,7 +201,6 @@
   },
   {
     "Input": "http://localhost:8080",
-    "NotSupportedByDesign": "",
     "Results": [
       {
         "Text": "http://localhost:8080",
@@ -215,7 +213,6 @@
   },
   {
     "Input": "http://localhost:8080#123",
-    "NotSupportedByDesign": "",
     "Results": [
       {
         "Text": "http://localhost:8080#123",
@@ -228,7 +225,6 @@
   },
   {
     "Input": "http://localhost:8080/#/123",
-    "NotSupportedByDesign": "",
     "Results": [
       {
         "Text": "http://localhost:8080/#/123",
@@ -241,7 +237,6 @@
   },
   {
     "Input": "http://127.0.0.1:8080/#/123",
-    "NotSupportedByDesign": "",
     "Results": [
       {
         "Text": "http://127.0.0.1:8080/#/123",
@@ -352,7 +347,6 @@
   },
   {
     "Input": "Please visit https://luis.ai?action=add for more information",
-    "NotSupportedByDesign": "",
     "Results": [
       {
         "Text": "https://luis.ai?action=add",
@@ -376,7 +370,6 @@
   },
   {
     "Input": "7.am is more likely a datetime string rather than a valid domain name.",
-    "NotSupportedByDesign": "",
     "Results": []
   },
   {
@@ -395,7 +388,6 @@
   },
   {
     "Input": "Please visit 27.pm and s7.am for more information.",
-    "NotSupportedByDesign": "",
     "Results": [
       {
         "Text": "27.pm",
@@ -439,7 +431,6 @@
   },
   {
     "Input": "http://dafdafdasf-dajfdlkajfkla-fdafd-dafdafafs-dafdafdaf.",
-    "NotSupportedByDesign": "",
     "Results": []
   },
   {
@@ -477,7 +468,6 @@
   {
     "Input": "http://a.b-.co",
     "NotSupportedBy": "dotnet,python,java",
-    "NotSupportedByDesign": "",
     "Results": [
       {
         "Text": "http://a.b-.co",

--- a/Specs/Sequence/English/URLModel.json
+++ b/Specs/Sequence/English/URLModel.json
@@ -188,7 +188,7 @@
     "Results": []
   },
   {
-    "Input": "http://127.0.0.1.com:8080",
+    "Input": "http://127.0.0.1:8080",
     "NotSupportedByDesign": "python",
     "Results": [
       {

--- a/Specs/Sequence/English/URLModel.json
+++ b/Specs/Sequence/English/URLModel.json
@@ -189,7 +189,7 @@
   },
   {
     "Input": "http://127.0.0.1:8080",
-    "NotSupportedByDesign": "python",
+    "NotSupportedByDesign": "",
     "Results": [
       {
         "Text": "http://127.0.0.1:8080",
@@ -202,7 +202,7 @@
   },
   {
     "Input": "http://localhost:8080",
-    "NotSupportedByDesign": "python",
+    "NotSupportedByDesign": "",
     "Results": [
       {
         "Text": "http://localhost:8080",
@@ -215,7 +215,7 @@
   },
   {
     "Input": "http://localhost:8080#123",
-    "NotSupportedByDesign": "python",
+    "NotSupportedByDesign": "",
     "Results": [
       {
         "Text": "http://localhost:8080#123",
@@ -228,7 +228,7 @@
   },
   {
     "Input": "http://localhost:8080/#/123",
-    "NotSupportedByDesign": "python",
+    "NotSupportedByDesign": "",
     "Results": [
       {
         "Text": "http://localhost:8080/#/123",
@@ -241,7 +241,7 @@
   },
   {
     "Input": "http://127.0.0.1:8080/#/123",
-    "NotSupportedByDesign": "python",
+    "NotSupportedByDesign": "",
     "Results": [
       {
         "Text": "http://127.0.0.1:8080/#/123",
@@ -352,7 +352,7 @@
   },
   {
     "Input": "Please visit https://luis.ai?action=add for more information",
-    "NotSupportedByDesign": "python",
+    "NotSupportedByDesign": "",
     "Results": [
       {
         "Text": "https://luis.ai?action=add",
@@ -376,7 +376,7 @@
   },
   {
     "Input": "7.am is more likely a datetime string rather than a valid domain name.",
-    "NotSupportedByDesign": "python",
+    "NotSupportedByDesign": "",
     "Results": []
   },
   {
@@ -395,7 +395,7 @@
   },
   {
     "Input": "Please visit 27.pm and s7.am for more information.",
-    "NotSupportedByDesign": "python",
+    "NotSupportedByDesign": "",
     "Results": [
       {
         "Text": "27.pm",
@@ -439,7 +439,7 @@
   },
   {
     "Input": "http://dafdafdasf-dajfdlkajfkla-fdafd-dafdafafs-dafdafdaf.",
-    "NotSupportedByDesign": "python",
+    "NotSupportedByDesign": "",
     "Results": []
   },
   {
@@ -477,7 +477,7 @@
   {
     "Input": "http://a.b-.co",
     "NotSupportedBy": "dotnet,python,java",
-    "NotSupportedByDesign": "python",
+    "NotSupportedByDesign": "",
     "Results": [
       {
         "Text": "http://a.b-.co",

--- a/Specs/Sequence/Japanese/URLModel.json
+++ b/Specs/Sequence/Japanese/URLModel.json
@@ -2,7 +2,7 @@
   {
     "Input": "はmicrosoft.comです",
     "Notsupport": "java",
-    "NotSupportedByDesign": "python",
+    "NotSupportedByDesign": "",
     "Results": [
       {
         "Text": "microsoft.com",

--- a/Specs/Sequence/Japanese/URLModel.json
+++ b/Specs/Sequence/Japanese/URLModel.json
@@ -2,7 +2,6 @@
   {
     "Input": "はmicrosoft.comです",
     "Notsupport": "java",
-    "NotSupportedByDesign": "",
     "Results": [
       {
         "Text": "microsoft.com",


### PR DESCRIPTION
### Description

This PR will Support URL models in Recognizers text.


### Changes made

- Add `_is_valid_match` method in the `BaseURLExtractor` class  and use it on the `extract` method  in the `SequenceExtractor` class. **Important:** There is a class called `StringMatcher` in C# that is not migrated to either JavaScript or Python, therefore, only the tests that run in JavaScript will run in Python

- Allow that the `regex` variable in the `SequenceExtractor` class could use both Chinese Regex and English Regex

- Modify the `get_url_model` method in `SequenceRecognizer` class to use the same Regex to Japanese and Chinese

- Remove the `NotSupportedByDesign` tag  from the `URLModel.json` where the word `python` was located in the `Sequence` folder to run the tests

### Testing

- Run the tests from python's terminal and execute this `pytest test_runner_sequence.py` 

![image](https://user-images.githubusercontent.com/37625424/62247190-b1843a80-b3bb-11e9-8528-00a11ccfd178.png)





