### PR TITLE
[Python] Apply feedback in French files

### DIFF
--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/french/dateperiod_extractor_config.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/french/dateperiod_extractor_config.py
@@ -1,7 +1,7 @@
 from typing import List, Pattern
 
 from recognizers_text.utilities import RegExpUtility
-from recognizers_number.number import BaseNumberParser, BaseNumberExtractor
+from recognizers_number.number import BaseNumberParser
 from recognizers_number.number.french.extractors import FrenchIntegerExtractor
 from recognizers_number.number.french.parsers import FrenchNumberParserConfiguration
 from ...resources.base_date_time import BaseDateTime
@@ -234,6 +234,9 @@ class FrenchDatePeriodExtractorConfiguration(DatePeriodExtractorConfiguration):
             FrenchDateTime.CenturySuffixRegex
         )
         self._ordinal_extractor = FrenchOrdinalExtractor()
+        # ToDo When the implementation for these properties is added, change the None values to the respective Regexps
+        self._time_unit_regex = None
+        self._cardinal_extractor = None
 
     def get_from_token_index(self, source: str) -> MatchedIndex:
         match = self.from_regex.search(source)

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/french/dateperiod_extractor_config.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/french/dateperiod_extractor_config.py
@@ -234,7 +234,7 @@ class FrenchDatePeriodExtractorConfiguration(DatePeriodExtractorConfiguration):
             FrenchDateTime.CenturySuffixRegex
         )
         self._ordinal_extractor = FrenchOrdinalExtractor()
-        # ToDo When the implementation for these properties is added, change the None values to the respective Regexps
+        # TODO When the implementation for these properties is added, change the None values to their respective Regexps
         self._time_unit_regex = None
         self._cardinal_extractor = None
 

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/french/datetime_extractor_config.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/french/datetime_extractor_config.py
@@ -4,7 +4,6 @@ import regex
 from recognizers_text.utilities import RegExpUtility
 from ...resources.french_date_time import FrenchDateTime
 from ..extractors import DateTimeExtractor
-from ..utilities import DateTimeUtilityConfiguration
 from ..base_date import BaseDateExtractor
 from ..base_time import BaseTimeExtractor
 from ..base_duration import BaseDurationExtractor
@@ -13,7 +12,6 @@ from .base_configs import FrenchDateTimeUtilityConfiguration
 from .date_extractor_config import FrenchDateExtractorConfiguration
 from .time_extractor_config import FrenchTimeExtractorConfiguration
 from .duration_extractor_config import FrenchDurationExtractorConfiguration
-from ..utilities import DateTimeOptions
 
 
 class FrenchDateTimeExtractorConfiguration(DateTimeExtractorConfiguration):
@@ -79,7 +77,7 @@ class FrenchDateTimeExtractorConfiguration(DateTimeExtractorConfiguration):
         return self._unit_regex
 
     @property
-    def utility_configuration(self) -> DateTimeUtilityConfiguration:
+    def utility_configuration(self) -> FrenchDateTimeUtilityConfiguration:
         return self._utility_configuration
 
     @property

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/french/duration_extractor_config.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/french/duration_extractor_config.py
@@ -5,7 +5,6 @@ from recognizers_number.number.extractors import BaseNumberExtractor
 from recognizers_number.number.french.extractors import FrenchCardinalExtractor
 from ...resources.french_date_time import FrenchDateTime
 from ..base_duration import DurationExtractorConfiguration
-from ..utilities import DateTimeOptions
 
 
 class FrenchDurationExtractorConfiguration(DurationExtractorConfiguration):
@@ -47,11 +46,11 @@ class FrenchDurationExtractorConfiguration(DurationExtractorConfiguration):
         return self._relative_duration_unit_regex
 
     @property
-    def more_than_regex(self) -> BaseNumberExtractor:
+    def more_than_regex(self) -> Pattern:
         return self._more_than_regex
 
     @property
-    def less_than_regex(self) -> BaseNumberExtractor:
+    def less_than_regex(self) -> Pattern:
         return self._less_than_regex
 
     @property
@@ -77,14 +76,6 @@ class FrenchDurationExtractorConfiguration(DurationExtractorConfiguration):
     @property
     def duration_connector_regex(self) -> Pattern:
         return self._duration_connector_regex
-
-    @property
-    def more_than_regex(self) -> Pattern:
-        return self._more_than_regex
-
-    @property
-    def less_than_regex(self) -> Pattern:
-        return self._less_than_regex
 
     def __init__(self):
         super().__init__()

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/french/duration_parser_config.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/french/duration_parser_config.py
@@ -84,5 +84,5 @@ class FrenchDurationParserConfiguration(DurationParserConfiguration):
         self._unit_map = config.unit_map
         self._unit_value_map = config.unit_value_map
         self._double_numbers = config.double_numbers
-        # ToDo When the implementation for this property is added, change the None value to the respective Regexp
+        # TODO When the implementation for this property is added, change the None value to their respective Regexp
         self._duration_extractor = None

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/french/duration_parser_config.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/french/duration_parser_config.py
@@ -3,10 +3,7 @@ from typing import Pattern, Dict
 from recognizers_text.utilities import RegExpUtility
 from recognizers_number.number.extractors import BaseNumberExtractor
 from recognizers_number.number.parsers import BaseNumberParser
-from recognizers_number.number.french.extractors import FrenchCardinalExtractor
-from recognizers_number.number.french.parsers import FrenchNumberParserConfiguration
 from ...resources.french_date_time import FrenchDateTime
-from ..base_duration import DurationParserConfiguration
 
 from ..extractors import DateTimeExtractor
 from ..base_duration import DurationParserConfiguration, BaseDurationExtractor
@@ -87,3 +84,5 @@ class FrenchDurationParserConfiguration(DurationParserConfiguration):
         self._unit_map = config.unit_map
         self._unit_value_map = config.unit_value_map
         self._double_numbers = config.double_numbers
+        # ToDo When the implementation for this property is added, change the None value to the respective Regexp
+        self._duration_extractor = None

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/french/merged_extractor_config.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/french/merged_extractor_config.py
@@ -194,7 +194,7 @@ class FrenchMergedExtractorConfiguration(MergedExtractorConfiguration):
         self._suffix_after_regex = RegExpUtility.get_safe_reg_exp(
             FrenchDateTime.SuffixAfterRegex
         )
-        # ToDo When the implementation for these properties is added, change the None values to the respective Regexps
+        # TODO When the implementation for these properties is added, change the None values to their respective Regexps
         self._superfluous_word_matcher = None
         self._fail_fast_regex = None
         self._term_filter_regexes = None

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/french/merged_extractor_config.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/french/merged_extractor_config.py
@@ -30,27 +30,23 @@ from ...resources.base_date_time import BaseDateTime
 class FrenchMergedExtractorConfiguration(MergedExtractorConfiguration):
     @property
     def time_zone_extractor(self):
-        pass
+        return self._time_zone_extractor
 
     @property
     def datetime_alt_extractor(self):
-        pass
+        return self._datetime_alt_extractor
 
     @property
     def term_filter_regexes(self) -> List[Pattern]:
-        pass
+        return self._term_filter_regexes
 
     @property
     def fail_fast_regex(self) -> Pattern:
-        pass
+        return self._fail_fast_regex
 
     @property
     def superfluous_word_matcher(self) -> Pattern:
-        pass
-
-    @property
-    def ambiguity_filters_dict(self) -> Pattern:
-        return None
+        return self._superfluous_word_matcher
 
     @property
     def unspecified_date_period_regex(self) -> Pattern:
@@ -133,6 +129,14 @@ class FrenchMergedExtractorConfiguration(MergedExtractorConfiguration):
         return self._preposition_suffix_regex
 
     @property
+    def number_ending_pattern(self) -> Pattern:
+        return self._number_ending_pattern
+
+    @property
+    def filter_word_regex_list(self) -> List[Pattern]:
+        return self._filter_word_regex_list
+
+    @property
     def ambiguous_range_modifier_prefix(self) -> Pattern:
         return None
 
@@ -141,12 +145,8 @@ class FrenchMergedExtractorConfiguration(MergedExtractorConfiguration):
         return None
 
     @property
-    def number_ending_pattern(self) -> Pattern:
-        return self._number_ending_pattern
-
-    @property
-    def filter_word_regex_list(self) -> List[Pattern]:
-        return self._filter_word_regex_list
+    def ambiguity_filters_dict(self) -> Pattern:
+        return None
 
     def __init__(self):
         self._before_regex = RegExpUtility.get_safe_reg_exp(
@@ -194,3 +194,9 @@ class FrenchMergedExtractorConfiguration(MergedExtractorConfiguration):
         self._suffix_after_regex = RegExpUtility.get_safe_reg_exp(
             FrenchDateTime.SuffixAfterRegex
         )
+        # ToDo When the implementation for these properties is added, change the None values to the respective Regexps
+        self._superfluous_word_matcher = None
+        self._fail_fast_regex = None
+        self._term_filter_regexes = None
+        self._datetime_alt_extractor = None
+        self._time_zone_extractor = None

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/french/time_extractor_config.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/french/time_extractor_config.py
@@ -8,10 +8,6 @@ from ..utilities import DateTimeOptions
 
 class FrenchTimeExtractorConfiguration(TimeExtractorConfiguration):
     @property
-    def dmy_date_format(self) -> bool:
-        return self._dmy_date_format
-
-    @property
     def time_zone_extractor(self):
         return self._time_zone_extractor
 
@@ -42,6 +38,8 @@ class FrenchTimeExtractorConfiguration(TimeExtractorConfiguration):
         self._time_before_after_regex: Pattern = RegExpUtility.get_safe_reg_exp(
             FrenchDateTime.TimeBeforeAfterRegex)
         self._options = DateTimeOptions.NONE
+        # ToDo When the implementation for these properties is added, change the None values to the respective Regexps
+        self._time_zone_extractor = None
 
     @staticmethod
     def get_time_regex_list() -> List[Pattern]:

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/french/time_extractor_config.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/french/time_extractor_config.py
@@ -38,7 +38,7 @@ class FrenchTimeExtractorConfiguration(TimeExtractorConfiguration):
         self._time_before_after_regex: Pattern = RegExpUtility.get_safe_reg_exp(
             FrenchDateTime.TimeBeforeAfterRegex)
         self._options = DateTimeOptions.NONE
-        # ToDo When the implementation for these properties is added, change the None values to the respective Regexps
+        # TODO When the implementation for these properties is added, change the None values to their respective Regexps
         self._time_zone_extractor = None
 
     @staticmethod

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/french/timeperiod_extractor_config.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/french/timeperiod_extractor_config.py
@@ -9,7 +9,6 @@ from ..base_timeperiod import TimePeriodExtractorConfiguration, MatchedIndex
 from ..base_time import BaseTimeExtractor
 from .time_extractor_config import FrenchTimeExtractorConfiguration
 from .base_configs import FrenchDateTimeUtilityConfiguration
-from ..utilities import DateTimeOptions
 
 
 class FrenchTimePeriodExtractorConfiguration(TimePeriodExtractorConfiguration):
@@ -90,7 +89,7 @@ class FrenchTimePeriodExtractorConfiguration(TimePeriodExtractorConfiguration):
 
         return MatchedIndex(False, -1)
 
-    def has_connector_token(self, source: str) -> bool:
+    def has_connector_token(self, source: str) -> MatchedIndex:
         match = self.connector_and_regex.search(source)
         if match:
             return MatchedIndex(True, match.start())


### PR DESCRIPTION
### Description 

This PR fix PEP8 conventions, change non-descriptive variable names to increase readability and add non-implemented properties on the files that have been modified during the DateTime library migration.

### Changes made

The changes were made on the following files:

- dateperiod_extractor_config.py
- datetime_extractor_config.py
- duration_extractor_config.py
- duration_parser_config.py
- merged_extractor_config.py
- time_extractor_config.
- timeperiod_extractor_config.py

### Testing

Below you will find a screenshot of the current tests status:

![image](https://user-images.githubusercontent.com/54330145/66497849-7e34ea80-ea93-11e9-8e62-3ac82d5fc4aa.png)