### PR TITLE
Python/issue fixing extractors tests English

### DIFF
--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/english/base_configs.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/english/base_configs.py
@@ -38,10 +38,6 @@ class EnglishDateTimeUtilityConfiguration(DateTimeUtilityConfiguration):
         return self._time_unit_regex
 
     @property
-    def time_unit_regex(self) -> Pattern:
-        return self._time_unit_regex
-
-    @property
     def within_next_prefix_regex(self) -> Pattern:
         return self._within_next_prefix_regex
 

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/english/dateperiod_extractor_config.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/english/dateperiod_extractor_config.py
@@ -239,6 +239,8 @@ class EnglishDatePeriodExtractorConfiguration(DatePeriodExtractorConfiguration):
             EnglishDateTime.CenturySuffixRegex
         )
         self._ordinal_extractor = EnglishOrdinalExtractor()
+        # TODO When the implementation for these properties is added, change the None values to their respective Regexps
+        self._cardinal_extractor = None
 
     def get_from_token_index(self, source: str) -> MatchedIndex:
         return MatchedIndex(True, source.rfind('from')) if source.endswith('from') else MatchedIndex(False, -1)

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/english/datetime_extractor_config.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/english/datetime_extractor_config.py
@@ -4,7 +4,6 @@ import regex
 from recognizers_text.utilities import RegExpUtility
 from ...resources.english_date_time import EnglishDateTime
 from ..extractors import DateTimeExtractor
-from ..utilities import DateTimeUtilityConfiguration
 from ..base_date import BaseDateExtractor
 from ..base_time import BaseTimeExtractor
 from ..base_duration import BaseDurationExtractor
@@ -13,7 +12,6 @@ from .base_configs import EnglishDateTimeUtilityConfiguration
 from .date_extractor_config import EnglishDateExtractorConfiguration
 from .time_extractor_config import EnglishTimeExtractorConfiguration
 from .duration_extractor_config import EnglishDurationExtractorConfiguration
-from ..utilities import DateTimeOptions
 
 
 class EnglishDateTimeExtractorConfiguration(DateTimeExtractorConfiguration):
@@ -70,7 +68,7 @@ class EnglishDateTimeExtractorConfiguration(DateTimeExtractorConfiguration):
         return self._unit_regex
 
     @property
-    def utility_configuration(self) -> DateTimeUtilityConfiguration:
+    def utility_configuration(self) -> EnglishDateTimeUtilityConfiguration:
         return self._utility_configuration
 
     @property

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/english/duration_extractor_config.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/english/duration_extractor_config.py
@@ -5,7 +5,6 @@ from recognizers_number.number.extractors import BaseNumberExtractor
 from recognizers_number.number.english.extractors import EnglishCardinalExtractor
 from ...resources.english_date_time import EnglishDateTime
 from ..base_duration import DurationExtractorConfiguration
-from ..utilities import DateTimeOptionsConfiguration
 
 
 class EnglishDurationExtractorConfiguration(DurationExtractorConfiguration):

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/english/duration_parser_config.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/english/duration_parser_config.py
@@ -87,6 +87,6 @@ class EnglishDurationParserConfiguration(DurationParserConfiguration):
             EnglishDateTime.HalfRegex)
         self._inexact_number_unit_regex: Pattern = RegExpUtility.get_safe_reg_exp(
             EnglishDateTime.InexactNumberUnitRegex)
-        self._unit_map: Dict[str, int] = EnglishDateTime.UnitMap
+        self._unit_map: Dict[str, str] = EnglishDateTime.UnitMap
         self._unit_value_map: Dict[str, int] = EnglishDateTime.UnitValueMap
         self._double_numbers: Dict[str, float] = EnglishDateTime.DoubleNumbers

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/english/duration_parser_config.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/english/duration_parser_config.py
@@ -64,11 +64,12 @@ class EnglishDurationParserConfiguration(DurationParserConfiguration):
     def double_numbers(self) -> Dict[str, float]:
         return self._double_numbers
 
+    @property
     def duration_extractor(self) -> DateTimeExtractor:
         return self._duration_extractor
 
     def __init__(self, config):
-        self.duration_extractor = BaseDurationExtractor(
+        self._duration_extractor = BaseDurationExtractor(
             EnglishDurationExtractorConfiguration(), False)
         self._cardinal_extractor: BaseNumberExtractor = EnglishCardinalExtractor()
         self._number_parser: BaseNumberParser = BaseNumberParser(

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/english/merged_extractor_config.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/english/merged_extractor_config.py
@@ -30,15 +30,15 @@ from ...resources.base_date_time import BaseDateTime
 class EnglishMergedExtractorConfiguration(MergedExtractorConfiguration):
     @property
     def time_zone_extractor(self):
-        pass
+        return self._time_zone_extractor
 
     @property
     def datetime_alt_extractor(self):
-        pass
+        return self._datetime_alt_extractor
 
     @property
     def term_filter_regexes(self) -> List[Pattern]:
-        pass
+        return self._term_filter_regexes
 
     @property
     def ambiguity_filters_dict(self) -> Pattern:
@@ -200,3 +200,7 @@ class EnglishMergedExtractorConfiguration(MergedExtractorConfiguration):
         self._fail_fast_regex = RegExpUtility.get_safe_reg_exp(
             EnglishDateTime.FailFastRegex
         )
+        # TODO When the implementation for these properties is added, change the None values to their respective Regexps
+        self._time_zone_extractor = None
+        self._term_filter_regexes = None
+        self._datetime_alt_extractor = None

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/english/time_extractor_config.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/english/time_extractor_config.py
@@ -1,6 +1,5 @@
 from typing import List, Pattern
 
-from ..utilities import DateTimeOptions
 from recognizers_text.utilities import RegExpUtility
 from ...resources.english_date_time import EnglishDateTime
 from ..base_time import TimeExtractorConfiguration
@@ -48,3 +47,5 @@ class EnglishTimeExtractorConfiguration(TimeExtractorConfiguration):
             EnglishDateTime.IshRegex)
         self._time_before_after_regex: Pattern = RegExpUtility.get_safe_reg_exp(
             EnglishDateTime.TimeBeforeAfterRegex)
+        # TODO When the implementation for these properties is added, change the None values to their respective Regexps
+        self._time_zone_extractor = None


### PR DESCRIPTION
### Description
This internal PR adds the implementation of Matcher on the Datetime library, basing off .NET to port it to Python.

This part has the English files.

### Changes made
`english/base_configs.py`
`english/dateperiod_extractor_config.py`
`english/datetime_extractor_config.py`
`english/duration_extractor_config.py`
`english/duration_parser_config.py`
`english/merged_extractor_config.py`
`english/time_extractor_config.py`
`english/timeperiod_extractor_config.py`


### Testing
Below you can find the screenshot of the running tests passing successfully:
![image](https://user-images.githubusercontent.com/24591490/66597116-afd1b280-eb74-11e9-89b5-8cc93bcafc3f.png)
