### PR TITLE
[Recognizers-Text] Python support for Issue #819 (hyphenated dateranges) 

### DIFF
--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/base_date.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/base_date.py
@@ -200,7 +200,8 @@ class BaseDateExtractor(DateTimeExtractor, AbstractYearExtractor):
         if reference is None:
             reference = datetime.now()
 
-        tokens = self.basic_regex_match(source)
+        tokens = []
+        tokens.extend(self.basic_regex_match(source))
         tokens.extend(self.implicit_date(source))
         tokens.extend(self.number_with_month(source, reference))
         tokens.extend(self.duration_with_before_and_after(source, reference))

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/base_dateperiod.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/base_dateperiod.py
@@ -707,7 +707,6 @@ class BaseDatePeriodExtractor(DateTimeExtractor):
                                     self.config.within_next_prefix_regex,
                                     extraction_result)
                                 )
-
         return result
 
     def is_ago_relative_duration_date(self, er: ExtractResult):
@@ -715,18 +714,14 @@ class BaseDatePeriodExtractor(DateTimeExtractor):
 
     # Cases like "2 days from today", "2 weeks before yesterday", "3 months after tomorrow"
     def is_relative_duration_date(self, er: ExtractResult):
-
         is_ago = regex.search(self.config.ago_regex, er.text)
         is_later = regex.search(self.config.later_regex, er.text)
-
         return is_ago or is_later
 
     def is_date_relative_to_now_or_today(self, er: ExtractResult):
         for flag_word in self.config.duration_date_restrictions:
-
             if flag_word in er.text:
                 return True
-
         return False
 
     @staticmethod
@@ -977,7 +972,6 @@ class DatePeriodParserConfiguration(ABC):
         raise NotImplementedError
 
 
-
 class BaseDatePeriodParser(DateTimeParser):
     @property
     def parser_type_name(self) -> str:
@@ -1136,12 +1130,12 @@ class BaseDatePeriodParser(DateTimeParser):
             inner_result = self.__parse_month_of_date(text, reference_date)
 
         if not inner_result.success:
-            # TODO: Complete definition for __parse_decade: in progress
+            # TODO: Complete definition for __parse_decade
             inner_result = self.__parse_decade(text, reference_date)
 
         # Cases like "within/less than/more than x weeks from/before/after today"
         if not inner_result.success:
-            # TODO: Complete definition  for __parse_date_point_with_ago_and_later
+            # TODO: Complete definition for __parse_date_point_with_ago_and_later
             inner_result = self.__parse_date_point_with_ago_and_later(text, reference_date)
 
         if not inner_result.success:
@@ -1935,7 +1929,6 @@ class BaseDatePeriodParser(DateTimeParser):
         ret = self.config.date_extractor.extract(source, reference)
 
         return None
-
 
     def __parse_quarter(self, source: str, reference: datetime) -> DateTimeResolutionResult:
         result = DateTimeResolutionResult()

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/base_dateperiod.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/base_dateperiod.py
@@ -1091,6 +1091,62 @@ class BaseDatePeriodParser(DateTimeParser):
 
         return result
 
+    def _parse_base_date_period(self, text: str, reference_date: datetime, date_context: DateContext) -> DateTimeResolutionResult:
+        inner_result = self.__parse_month_with_year(text, reference_date)
+        if not inner_result.success:
+            inner_result = self._parse_simple_case(text, reference_date)
+
+        if not inner_result.success:
+            # TODO: fix the reference to _parse_one_word_period
+            inner_result = self.__parse_one_word_period(text, reference_date)
+
+        if not inner_result.success:
+            inner_result = self._merge_two_times_points(text, reference_date)
+
+        if not inner_result.success:
+            inner_result = self._parse_year(text, reference_date)
+
+        if not inner_result.success:
+            inner_result = self._parse_week_of_month(text, reference_date)
+
+        if not inner_result.success:
+            inner_result = self._parse_week_of_year(text, reference_date)
+
+        if not inner_result.success:
+            inner_result = self._parse_half_year(text, reference_date)
+
+        if not inner_result.success:
+            inner_result = self.__parse_quarter(text, reference_date)
+
+        if not inner_result.success:
+            inner_result = self.__parse_season(text, reference_date)
+
+        if not inner_result.success:
+            inner_result = self.__parse_which_week(text, reference_date)
+
+        if not inner_result.success:
+            inner_result = self.__parse_week_of_date(text, reference_date)
+
+        if not inner_result.success:
+            inner_result = self.__parse_month_of_date(text, reference_date)
+
+        if not inner_result.success:
+            # TODO: Add definition for __parse_decade
+            inner_result = self.__parse_decade(text, reference_date)
+
+        # Cases like "within/less than/more than x weeks from/before/after today"
+        if not inner_result.success:
+            # TODO: Add definition for __parse_date_point_with_ago_and_later
+            inner_result = self.__parse_date_point_with_ago_and_later(text, reference_date)
+
+        if not inner_result.success:
+            inner_result = self._parse_duration(text, reference_date)
+
+        if not inner_result.success and date_context is not None:
+            inner_result = date_context.process_date_period_entity_resolution(inner_result)
+
+        return inner_result
+
     def __parse_month_with_year(self, source: str, reference: datetime) -> DateTimeResolutionResult:
         trimmed_source = source.strip().lower()
         result = DateTimeResolutionResult()

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/constants.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/constants.py
@@ -51,6 +51,9 @@ class Constants:
     MAX_TWO_DIGIT_YEAR_FUTURE_NUM: int = int(BaseDateTime.MaxTwoDigitYearFutureNum)
     MIN_TWO_DIGIT_YEAR_PAST_NUM: int = int(BaseDateTime.MinTwoDigitYearPastNum)
 
+    # timex
+    TIMEX_FUZZY_YEAR = "XXXX"
+
     EARLY_MORNING: str = "TDA"
     MORNING: str = "TMO"
     MID_DAY: str = "TMI"

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/english/dateperiod_extractor_config.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/english/dateperiod_extractor_config.py
@@ -46,6 +46,10 @@ class EnglishDatePeriodExtractorConfiguration(DatePeriodExtractorConfiguration):
         return self._past_regex
 
     @property
+    def decade_with_century_regex(self) -> Pattern:
+        return self._decade_with_century_regex
+
+    @property
     def future_regex(self) -> Pattern:
         return self._future_regex
 
@@ -138,6 +142,10 @@ class EnglishDatePeriodExtractorConfiguration(DatePeriodExtractorConfiguration):
         return self._year_period_regex
 
     @property
+    def decade_with_century_regex(self) -> Pattern:
+        return self._decade_with_century_regex
+
+    @property
     def month_num_regex(self) -> Pattern:
         return self._month_num_regex
 
@@ -153,6 +161,7 @@ class EnglishDatePeriodExtractorConfiguration(DatePeriodExtractorConfiguration):
             RegExpUtility.get_safe_reg_exp(EnglishDateTime.MonthWithYear),
             RegExpUtility.get_safe_reg_exp(EnglishDateTime.MonthNumWithYear),
             RegExpUtility.get_safe_reg_exp(EnglishDateTime.YearRegex),
+            RegExpUtility.get_safe_reg_exp(EnglishDateTime.DecadeWithCenturyRegex),
             RegExpUtility.get_safe_reg_exp(EnglishDateTime.WeekOfMonthRegex),
             RegExpUtility.get_safe_reg_exp(EnglishDateTime.WeekOfYearRegex),
             RegExpUtility.get_safe_reg_exp(
@@ -231,6 +240,9 @@ class EnglishDatePeriodExtractorConfiguration(DatePeriodExtractorConfiguration):
         self._duration_date_restrictions = EnglishDateTime.DurationDateRestrictions
         self._year_period_regex = RegExpUtility.get_safe_reg_exp(
             EnglishDateTime.YearPeriodRegex
+        )
+        self._decade_with_century_regex = RegExpUtility.get_safe_reg_exp(
+            EnglishDateTime.DecadeWithCenturyRegex
         )
         self._month_num_regex = RegExpUtility.get_safe_reg_exp(
             EnglishDateTime.MonthNumRegex

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/english/dateperiod_parser_config.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/english/dateperiod_parser_config.py
@@ -66,6 +66,10 @@ class EnglishDatePeriodParserConfiguration(DatePeriodParserConfiguration):
         return self._past_regex
 
     @property
+    def decade_with_century_regex(self) -> Pattern:
+        return self._decade_with_century_regex
+
+    @property
     def future_regex(self) -> Pattern:
         return self._future_regex
 
@@ -184,6 +188,8 @@ class EnglishDatePeriodParserConfiguration(DatePeriodParserConfiguration):
             EnglishDateTime.MonthWithYear)
         self._month_num_with_year = RegExpUtility.get_safe_reg_exp(
             EnglishDateTime.MonthNumWithYear)
+        self._decade_with_century_regex = RegExpUtility.get_safe_reg_exp(
+            EnglishDateTime.DecadeWithCenturyRegex)
         self._year_regex = RegExpUtility.get_safe_reg_exp(
             EnglishDateTime.YearRegex)
         self._past_regex = RegExpUtility.get_safe_reg_exp(

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/english/dateperiod_parser_config.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/english/dateperiod_parser_config.py
@@ -30,6 +30,10 @@ class EnglishDatePeriodParserConfiguration(DatePeriodParserConfiguration):
         return self._month_front_between_regex
 
     @property
+    def relative_regex(self) -> Pattern:
+        return self._relative_regex
+
+    @property
     def between_regex(self) -> Pattern:
         return self._between_regex
 
@@ -227,6 +231,8 @@ class EnglishDatePeriodParserConfiguration(DatePeriodParserConfiguration):
         self._unit_map = config.unit_map
         self._now_regex = RegExpUtility.get_safe_reg_exp(
             EnglishDateTime.NowRegex)
+        self._relative_regex = RegExpUtility.get_safe_reg_exp(
+            EnglishDateTime.RelativeRegex)
 
     def get_swift_day_or_month(self, source: str) -> int:
         trimmed_source = source.strip().lower()

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/utilities.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/utilities.py
@@ -844,11 +844,11 @@ class DateContext:
         return value
 
     def __set_date_range_with_context(self, original_date_range: Dict[str, str]) -> Dict[str, str]:
-        start_date = self.__set_date_with_context(original_date_range['future_value'])
-        end_date = self.__set_date_with_context(original_date_range['past_value'])
+        start_date = self.__set_date_with_context(original_date_range[TimeTypeConstants.START_DATE])
+        end_date = self.__set_date_with_context(original_date_range[TimeTypeConstants.END_DATE])
         result: Dict[str, str]
-        result['future_value'] = str(start_date)
-        result['past_value'] = str(end_date)
+        result[TimeTypeConstants.START_DATE] = str(start_date)
+        result[TimeTypeConstants.END_DATE] = str(end_date)
         return result
 
 

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/utilities.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/utilities.py
@@ -17,6 +17,7 @@ from recognizers_date_time.date_time.parsers import DateTimeParser, DateTimePars
 from recognizers_text.matcher.string_matcher import StringMatcher, MatchResult
 
 
+
 class TimeZoneUtility:
 
     @staticmethod
@@ -802,6 +803,55 @@ class AgoLaterUtil:
         return result
 
 
+class DateContext:
+    year: int
+
+    # This method is to ensure the begin date is less than the end date. As DateContext only supports common Year as
+    # context, so it subtracts one year from beginDate.
+    # @TODO problematic in other usages.
+    @staticmethod
+    def swift_date_object(begin_date: datetime, end_date: datetime) -> datetime:
+        if begin_date > end_date:
+            begin_date = begin_date - datedelta(years=1)
+        return begin_date
+
+    def process_date_entity_parsing_result(self, original_result: DateTimeParseResult) -> DateTimeParseResult:
+        if not self.is_empty():
+            original_result.TimexStr = TimexUtil.set_timex_with_context(original_result.TimexStr, self)
+            original_result.Value = self.process_date_entity_resolution(original_result.value)
+
+        return original_result
+
+    def process_date_entity_resolution(self, resolution_result: DateTimeResolutionResult) -> DateTimeResolutionResult:
+        if not self.is_empty():
+            resolution_result.timex = TimexUtil.set_timex_with_context(resolution_result.timex, self)
+            resolution_result.future_value = self.__set_date_with_context(resolution_result.future_value)
+            resolution_result.past_value = self.__set_date_with_context(resolution_result.past_value)
+        return resolution_result
+
+    def process_date_period_entity_resolution(self, resolution_result: DateTimeResolutionResult) -> DateTimeResolutionResult:
+        if not self.is_empty():
+            resolution_result.timex = TimexUtil.set_timex_with_context(resolution_result.timex, self)
+            resolution_result.future_value = self.__set_date_range_with_context(resolution_result.future_resolution)
+            resolution_result.past_value = self.__set_date_range_with_context(resolution_result.past_resolution)
+        return resolution_result
+
+    def is_empty(self) -> bool:
+        return self.year == Constants.INVALID_YEAR
+
+    def __set_date_with_context(self, original_date) -> datetime:
+        value = datetime(year=self.year, month=original_date.month, day=original_date.day)
+        return value
+
+    def __set_date_range_with_context(self, original_date_range: Dict[str, str]) -> Dict[str, str]:
+        start_date = self.__set_date_with_context(original_date_range['future_value'])
+        end_date = self.__set_date_with_context(original_date_range['past_value'])
+        result: Dict[str, str]
+        result['future_value'] = str(start_date)
+        result['past_value'] = str(end_date)
+        return result
+
+
 class TimexUtil:
     @staticmethod
     def parse_time_of_day(tod: str) -> TimeOfDayResolution:
@@ -841,4 +891,9 @@ class TimexUtil:
             result.end_hour = 23
             result.end_min = 59
 
+        return result
+
+    @staticmethod
+    def set_timex_with_context(timex: str, context: DateContext) -> str:
+        result = timex.replace(Constants.TIMEX_FUZZY_YEAR, str(context.year))
         return result

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/utilities.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/utilities.py
@@ -17,7 +17,6 @@ from recognizers_date_time.date_time.parsers import DateTimeParser, DateTimePars
 from recognizers_text.matcher.string_matcher import StringMatcher, MatchResult
 
 
-
 class TimeZoneUtility:
 
     @staticmethod
@@ -414,6 +413,13 @@ class DayOfWeek(IntEnum):
 
 class DateUtils:
     min_value = datetime(1, 1, 1, 0, 0, 0, 0)
+
+    @staticmethod
+    def int_try_parse(value):
+        try:
+            return int(value), True
+        except ValueError:
+            return value, False
 
     @staticmethod
     def safe_create_from_value(seed: datetime, year: int, month: int, day: int,

--- a/Python/tests/test_runner_datetime_issues_hyphenated_dateranges.py
+++ b/Python/tests/test_runner_datetime_issues_hyphenated_dateranges.py
@@ -1,0 +1,16 @@
+import recognizers_suite as Recognizers
+from recognizers_suite import Culture, ModelResult
+culture = Culture.English
+
+# this should be recognized as a 'DateRange'. Instead, the type resolved is 'date'
+#input = "10/1-11/5"
+
+# this is incorrect too
+input = "Nov-Dec 2015"
+#input = "Nov 2015 - Dec 2015"
+#input = "My vacation is from 10/1/2018 - 10/7/2018"
+results = Recognizers.recognize_datetime(input, culture)
+for result in results:
+    print("text: {}".format(result.text))
+    print("type_name: {}".format(result.type_name))
+    print("resolution: {}".format(result.resolution))

--- a/Python/tests/test_runner_datetime_issues_hyphenated_dateranges.py
+++ b/Python/tests/test_runner_datetime_issues_hyphenated_dateranges.py
@@ -2,13 +2,36 @@ import recognizers_suite as Recognizers
 from recognizers_suite import Culture, ModelResult
 culture = Culture.English
 
-# this should be recognized as a 'DateRange'. Instead, the type resolved is 'date'
-#input = "10/1-11/5"
+# case 1: good
+# input = "10/1-11/5"
+# text: 10/1-11/5
+# type_name: datetimeV2.daterange
+# resolution: {'values': [{'timex': '(XXXX-10-01,XXXX-11-05,P35D)', 'type': 'daterange', 'start': '2019-10-01', 'end': '2019-11-05'}]}
 
-# this is incorrect too
+# case 2: bad
 input = "Nov-Dec 2015"
+# text: nov
+# type_name: datetimeV2.daterange
+# resolution: {'values': [{'timex': 'XXXX-11', 'type': 'daterange', 'start': '2018-11-01', 'end': '2018-12-01'}, {'timex': 'XXXX-11', 'type': 'daterange', 'start': '2019-11-01', 'end': '2019-12-01'}]}
+# text: dec 2015
+# type_name: datetimeV2.daterange
+# resolution: {'values': [{'timex': '2015-12', 'type': 'daterange', 'start': '2015-12-01', 'end': '2016-01-01'}]}
+
+# case 3: good
 #input = "Nov 2015 - Dec 2015"
-#input = "My vacation is from 10/1/2018 - 10/7/2018"
+# text: nov 2015
+# type_name: datetimeV2.daterange
+# resolution: {'values': [{'timex': '2015-11', 'type': 'daterange', 'start': '2015-11-01', 'end': '2015-12-01'}]}
+# text: dec 2015
+# type_name: datetimeV2.daterange
+# resolution: {'values': [{'timex': '2015-12', 'type': 'daterange', 'start': '2015-12-01', 'end': '2016-01-01'}]}
+
+# case 4: good
+# input = "My vacation is from 10/1/2018 - 10/7/2018"
+# text: from 10/1/2018 - 10/7/2018
+# type_name: datetimeV2.daterange
+# resolution: {'values': [{'timex': '(2018-10-01,2018-10-07,P6D)', 'type': 'daterange', 'start': '2018-10-01', 'end': '2018-10-07'}]}
+
 results = Recognizers.recognize_datetime(input, culture)
 for result in results:
     print("text: {}".format(result.text))

--- a/Python/tests/test_runner_datetime_issues_hyphenated_dateranges.py
+++ b/Python/tests/test_runner_datetime_issues_hyphenated_dateranges.py
@@ -9,7 +9,7 @@ culture = Culture.English
 # resolution: {'values': [{'timex': '(XXXX-10-01,XXXX-11-05,P35D)', 'type': 'daterange', 'start': '2019-10-01', 'end': '2019-11-05'}]}
 
 # case 2: bad
-#input = "Nov-Dec 2015"
+input = "Nov-Dec 2015"
 # text: nov
 # type_name: datetimeV2.daterange
 # resolution: {'values': [{'timex': 'XXXX-11', 'type': 'daterange', 'start': '2018-11-01', 'end': '2018-12-01'}, {'timex': 'XXXX-11', 'type': 'daterange', 'start': '2019-11-01', 'end': '2019-12-01'}]}
@@ -18,7 +18,7 @@ culture = Culture.English
 # resolution: {'values': [{'timex': '2015-12', 'type': 'daterange', 'start': '2015-12-01', 'end': '2016-01-01'}]}
 
 # case 3: good ok
-input = "Nov 2015 - Dec 2015"
+#input = "Nov 2015 - Dec 2015"
 # text: nov 2015
 # type_name: datetimeV2.daterange
 # resolution: {'values': [{'timex': '2015-11', 'type': 'daterange', 'start': '2015-11-01', 'end': '2015-12-01'}]}

--- a/Python/tests/test_runner_datetime_issues_hyphenated_dateranges.py
+++ b/Python/tests/test_runner_datetime_issues_hyphenated_dateranges.py
@@ -9,7 +9,7 @@ culture = Culture.English
 # resolution: {'values': [{'timex': '(XXXX-10-01,XXXX-11-05,P35D)', 'type': 'daterange', 'start': '2019-10-01', 'end': '2019-11-05'}]}
 
 # case 2: bad
-input = "Nov-Dec 2015"
+#input = "Nov-Dec 2015"
 # text: nov
 # type_name: datetimeV2.daterange
 # resolution: {'values': [{'timex': 'XXXX-11', 'type': 'daterange', 'start': '2018-11-01', 'end': '2018-12-01'}, {'timex': 'XXXX-11', 'type': 'daterange', 'start': '2019-11-01', 'end': '2019-12-01'}]}
@@ -17,8 +17,8 @@ input = "Nov-Dec 2015"
 # type_name: datetimeV2.daterange
 # resolution: {'values': [{'timex': '2015-12', 'type': 'daterange', 'start': '2015-12-01', 'end': '2016-01-01'}]}
 
-# case 3: good
-#input = "Nov 2015 - Dec 2015"
+# case 3: good ok
+input = "Nov 2015 - Dec 2015"
 # text: nov 2015
 # type_name: datetimeV2.daterange
 # resolution: {'values': [{'timex': '2015-11', 'type': 'daterange', 'start': '2015-11-01', 'end': '2015-12-01'}]}
@@ -27,11 +27,13 @@ input = "Nov-Dec 2015"
 # resolution: {'values': [{'timex': '2015-12', 'type': 'daterange', 'start': '2015-12-01', 'end': '2016-01-01'}]}
 
 # case 4: good
-# input = "My vacation is from 10/1/2018 - 10/7/2018"
+#input = "My vacation is from 10/1/2018 - 10/7/2018"
 # text: from 10/1/2018 - 10/7/2018
 # type_name: datetimeV2.daterange
 # resolution: {'values': [{'timex': '(2018-10-01,2018-10-07,P6D)', 'type': 'daterange', 'start': '2018-10-01', 'end': '2018-10-07'}]}
 
+# case 5: bad
+#input = "My vacation is from 10-1-2018-10-7-2018"
 results = Recognizers.recognize_datetime(input, culture)
 for result in results:
     print("text: {}".format(result.text))


### PR DESCRIPTION
## Description
This PR ports changes made in the C# version of Recognizers-Text, that fixed bugs with date ranges separated using hyphens.

### Changes made
*/date_time/base_dateperiod.py*
- Add `DateContext` reference.
- Add `decade_with_century_regex` abstract method.
- Add `get_year_context` method.
- Add `parse_base_date_period` method.
- Edit `merge_two_times_points` method
- Add `parse_decade`

*date_time/constants.py* 
- Add `TIMEX_FUZZY_YEAR` string constant

*date_time/english/dateperiod_extractor_config.py*
- Add `decade_with_century_regex`
- Edit `duration_date_restrictions method`
- Edit constructor

*english/dateperiod_parser_config.py*
- Add `relative_regex property`
- Add `decade_with_century_regex property`

*utilities.py*
- Add `int_try_parse` method.
- Add Class `DateContext`
- Add `TimexUtil.set_timex_with_context` method

*tests/test_runner_datetime_issues_hyphenated_dateranges.py*
_This file is for internal testing purposes and can be not included in the repository._

### Testing
This a work in progress, and the following test is not correct.
![image](https://user-images.githubusercontent.com/24591490/68331054-0dddb100-00b3-11ea-8622-973eb1ee30b0.png)

The other cases relevant are as follows:
![image](https://user-images.githubusercontent.com/24591490/68332363-7168de00-00b5-11ea-8c97-37f1fb7518d7.png)
