### PR TITLE
[Python] Port changes for Utilities (MatchingUtil and AgoLaterUtil)

### DIFF
--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/base_date.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/base_date.py
@@ -16,6 +16,11 @@ import calendar
 class DateTimeUtilityConfiguration(ABC):
     @property
     @abstractmethod
+    def date_unit_regex(self) -> Pattern:
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
     def ago_regex(self) -> Pattern:
         raise NotImplementedError
 
@@ -47,6 +52,16 @@ class DateTimeUtilityConfiguration(ABC):
     @property
     @abstractmethod
     def am_pm_desc_regex(self) -> Pattern:
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def check_both_befor_after(self) -> Pattern:
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def range_prefix_regex(self) -> Pattern:
         raise NotImplementedError
 
 

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/base_date.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/base_date.py
@@ -56,7 +56,7 @@ class DateTimeUtilityConfiguration(ABC):
 
     @property
     @abstractmethod
-    def check_both_befor_after(self) -> Pattern:
+    def check_both_before_after(self) -> Pattern:
         raise NotImplementedError
 
     @property

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/english/base_configs.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/english/base_configs.py
@@ -14,8 +14,8 @@ class EnglishDateTimeUtilityConfiguration(DateTimeUtilityConfiguration):
         return self._range_prefix_regex
 
     @property
-    def check_both_befor_after(self) -> Pattern:
-        return self._check_both_befor_after
+    def check_both_before_after(self) -> Pattern:
+        return self._check_both_before_after
 
     @property
     def ago_regex(self) -> Pattern:
@@ -78,7 +78,7 @@ class EnglishDateTimeUtilityConfiguration(DateTimeUtilityConfiguration):
             EnglishDateTime.WithinNextPrefixRegex)
         self._common_date_prefix_regex = RegExpUtility.get_safe_reg_exp(
             EnglishDateTime.CommonDatePrefixRegex)
-        self._check_both_befor_after = EnglishDateTime.CheckBothBeforeAfter
+        self._check_both_before_after = EnglishDateTime.CheckBothBeforeAfter
         self._range_prefix_regex = RegExpUtility.get_safe_reg_exp(
             EnglishDateTime.RangePrefixRegex
         )

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/english/base_configs.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/english/base_configs.py
@@ -6,6 +6,18 @@ from recognizers_date_time.resources.english_date_time import EnglishDateTime
 
 class EnglishDateTimeUtilityConfiguration(DateTimeUtilityConfiguration):
     @property
+    def date_unit_regex(self) -> Pattern:
+        return self._date_unit_regex
+
+    @property
+    def range_prefix_regex(self) -> Pattern:
+        return self._range_prefix_regex
+
+    @property
+    def check_both_befor_after(self) -> Pattern:
+        return self._check_both_befor_after
+
+    @property
     def ago_regex(self) -> Pattern:
         return self._ago_regex
 
@@ -66,3 +78,10 @@ class EnglishDateTimeUtilityConfiguration(DateTimeUtilityConfiguration):
             EnglishDateTime.WithinNextPrefixRegex)
         self._common_date_prefix_regex = RegExpUtility.get_safe_reg_exp(
             EnglishDateTime.CommonDatePrefixRegex)
+        self._check_both_befor_after = EnglishDateTime.CheckBothBeforeAfter
+        self._range_prefix_regex = RegExpUtility.get_safe_reg_exp(
+            EnglishDateTime.RangePrefixRegex
+        )
+        self._date_unit_regex = RegExpUtility.get_safe_reg_exp(
+            EnglishDateTime.DateUnitRegex
+        )

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/french/base_configs.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/french/base_configs.py
@@ -10,8 +10,8 @@ class FrenchDateTimeUtilityConfiguration(DateTimeUtilityConfiguration):
         return self._date_unit_regex
 
     @property
-    def check_both_befor_after(self) -> Pattern:
-        return self._check_both_befor_after
+    def check_both_before_after(self) -> Pattern:
+        return self._check_both_before_after
 
     @property
     def range_prefix_regex(self) -> Pattern:
@@ -78,7 +78,7 @@ class FrenchDateTimeUtilityConfiguration(DateTimeUtilityConfiguration):
             FrenchDateTime.WithinNextPrefixRegex)
         self._common_date_prefix_regex = RegExpUtility.get_safe_reg_exp(
             FrenchDateTime.CommonDatePrefixRegex)
-        self._check_both_befor_after = FrenchDateTime.CheckBothBeforeAfter
+        self._check_both_before_after = FrenchDateTime.CheckBothBeforeAfter
         self._range_prefix_regex = RegExpUtility.get_safe_reg_exp(
             FrenchDateTime.RangePrefixRegex
         )

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/french/base_configs.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/french/base_configs.py
@@ -6,6 +6,18 @@ from ..base_date import DateTimeUtilityConfiguration
 
 class FrenchDateTimeUtilityConfiguration(DateTimeUtilityConfiguration):
     @property
+    def date_unit_regex(self) -> Pattern:
+        return self._date_unit_regex
+
+    @property
+    def check_both_befor_after(self) -> Pattern:
+        return self._check_both_befor_after
+
+    @property
+    def range_prefix_regex(self) -> Pattern:
+        return self._range_prefix_regex
+
+    @property
     def ago_regex(self) -> Pattern:
         return self._ago_regex
 
@@ -66,3 +78,10 @@ class FrenchDateTimeUtilityConfiguration(DateTimeUtilityConfiguration):
             FrenchDateTime.WithinNextPrefixRegex)
         self._common_date_prefix_regex = RegExpUtility.get_safe_reg_exp(
             FrenchDateTime.CommonDatePrefixRegex)
+        self._check_both_befor_after = FrenchDateTime.CheckBothBeforeAfter
+        self._range_prefix_regex = RegExpUtility.get_safe_reg_exp(
+            FrenchDateTime.RangePrefixRegex
+        )
+        self._date_unit_regex = RegExpUtility.get_safe_reg_exp(
+            FrenchDateTime.DateUnitRegex
+        )

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/spanish/base_configs.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/spanish/base_configs.py
@@ -10,8 +10,8 @@ class SpanishDateTimeUtilityConfiguration(DateTimeUtilityConfiguration):
         return self._date_unit_regex
 
     @property
-    def check_both_befor_after(self) -> Pattern:
-        return self._check_both_befor_after
+    def check_both_before_after(self) -> Pattern:
+        return self._check_both_before_after
 
     @property
     def range_prefix_regex(self) -> Pattern:
@@ -78,7 +78,7 @@ class SpanishDateTimeUtilityConfiguration(DateTimeUtilityConfiguration):
             SpanishDateTime.WithinNextPrefixRegex)
         self._common_date_prefix_regex = RegExpUtility.get_safe_reg_exp(
             SpanishDateTime.CommonDatePrefixRegex)
-        self._check_both_befor_after = SpanishDateTime.CheckBothBeforeAfter
+        self._check_both_before_after = SpanishDateTime.CheckBothBeforeAfter
         self._range_prefix_regex = RegExpUtility.get_safe_reg_exp(
             SpanishDateTime.RangePrefixRegex
         )

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/spanish/base_configs.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/spanish/base_configs.py
@@ -6,6 +6,18 @@ from recognizers_date_time.resources.spanish_date_time import SpanishDateTime
 
 class SpanishDateTimeUtilityConfiguration(DateTimeUtilityConfiguration):
     @property
+    def date_unit_regex(self) -> Pattern:
+        return self._date_unit_regex
+
+    @property
+    def check_both_befor_after(self) -> Pattern:
+        return self._check_both_befor_after
+
+    @property
+    def range_prefix_regex(self) -> Pattern:
+        return self._range_prefix_regex
+
+    @property
     def ago_regex(self) -> Pattern:
         return self._ago_regex
 
@@ -66,3 +78,10 @@ class SpanishDateTimeUtilityConfiguration(DateTimeUtilityConfiguration):
             SpanishDateTime.WithinNextPrefixRegex)
         self._common_date_prefix_regex = RegExpUtility.get_safe_reg_exp(
             SpanishDateTime.CommonDatePrefixRegex)
+        self._check_both_befor_after = SpanishDateTime.CheckBothBeforeAfter
+        self._range_prefix_regex = RegExpUtility.get_safe_reg_exp(
+            SpanishDateTime.RangePrefixRegex
+        )
+        self._date_unit_regex = RegExpUtility.get_safe_reg_exp(
+            SpanishDateTime.DateUnitRegex
+        )

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/utilities.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/utilities.py
@@ -533,10 +533,11 @@ class MatchingUtil:
     @staticmethod
     def get_ago_later_index(source: str, regexp: Pattern, in_suffix) -> MatchedIndex:
         result = MatchedIndex(matched=False, index=-1)
-        match = RegExpUtility.match_begin(regexp, source, True) if in_suffix else RegExpUtility.match_end(regexp, source, True)
+        trimmed_source = source.strip().lower()
+        match = RegExpUtility.match_begin(regexp, trimmed_source, True) if in_suffix else RegExpUtility.match_end(regexp, trimmed_source, True)
 
         if match and match.success:
-            result.index = match.index() + (match.length if in_suffix else 0)
+            result.index = source.lower().find(match.group()) + (match.length if in_suffix else 0)
             result.matched = True
 
         return result
@@ -590,10 +591,10 @@ class AgoLaterUtil:
                     # Cases like "2 days before today" or "2 weeks from today" are also supported
 
                     is_day_match = RegExpUtility.get_group(
-                        config.ago_regex.match(after_string), Constants.DAY_GROUP_NAME)
+                        regexp.match(after_string), Constants.DAY_GROUP_NAME)
 
                     index = MatchingUtil.get_ago_later_index(
-                        after_string, config.ago_regex, True).index
+                        after_string, regexp, True).index
 
                     if not(is_time_duration and is_day_match):
                         token_after = Token(extract_result.start, extract_result.start +
@@ -601,10 +602,10 @@ class AgoLaterUtil:
                         is_match = True
 
                 if config.check_both_befor_after:
-                    before_after_str = before_string + after_string[0:index]
+                    before_after_str = before_string + after_string
                     is_range_match = RegExpUtility.match_begin(config.range_prefix_regex, after_string[:index], True)
                     index_start = MatchingUtil.get_ago_later_index(before_after_str, regexp, False)
-                    if not is_range_match and index_start:
+                    if not is_range_match and index_start.matched:
                         is_day_match = regexp.match(before_after_str)
 
                         if is_day_match and not (is_time_duration and is_day_match):
@@ -649,13 +650,10 @@ class AgoLaterUtil:
                         if not is_unit_match:
                             if extract_result.start is not None and extract_result.length is not None and extract_result.start >= index or is_match_after:
                                 start = extract_result.start - (index if not is_match_after else 0)
-                                end = extract_result.start + extract_result.length + (index if not is_match_after else 0)
+                                end = extract_result.start + extract_result.length + (index if is_match_after else 0)
                                 ret.append(Token(start, end))
                         break
         return ret
-
-
-
 
     @staticmethod
     def parse_duration_with_ago_and_later(source: str, reference: datetime,
@@ -706,7 +704,25 @@ class AgoLaterUtil:
             unit_map: Dict[str, str], src_unit: str, after_str: str,
             before_str: str, reference: datetime,
             utility_configuration: DateTimeUtilityConfiguration, mode: AgoLaterMode):
+
         result = DateTimeResolutionResult()
+        timex = duration_parse_result.timex_str
+
+        if duration_parse_result.value.mod == TimeTypeConstants.MORE_THAN_MOD:
+            result.mod = TimeTypeConstants.MORE_THAN_MOD
+        elif duration_parse_result.value.mod == TimeTypeConstants.LESS_THAN_MOD:
+            result.mod = TimeTypeConstants.LESS_THAN_MOD
+
+        swift = 0
+        is_match, is_later = False
+        day_str = None
+
+        ago_later_regex_tuples
+
+
+
+
+
         unit_str = unit_map.get(src_unit)
 
         if not unit_str:

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/utilities.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/utilities.py
@@ -478,7 +478,7 @@ class DateTimeUtilityConfiguration(ABC):
 
     @property
     @abstractmethod
-    def check_both_befor_after(self) -> Pattern:
+    def check_both_before_after(self) -> Pattern:
         raise NotImplementedError
 
 
@@ -606,7 +606,7 @@ class AgoLaterUtil:
                                             extract_result.length + index)
                         is_match = True
 
-                if config.check_both_befor_after:
+                if config.check_both_before_after:
                     before_after_str = before_string + after_string
                     is_range_match = RegExpUtility.match_begin(config.range_prefix_regex, after_string[:index], True)
                     index_start = MatchingUtil.get_ago_later_index(before_after_str, regexp, False)
@@ -644,7 +644,7 @@ class AgoLaterUtil:
                     index = MatchingUtil.get_term_index(before_string, regexp[0]).index
                     if index > 0:
                         is_match = True
-                    elif config.check_both_befor_after and MatchingUtil.get_ago_later_index(after_string, regexp[0], True).matched:
+                    elif config.check_both_before_after and MatchingUtil.get_ago_later_index(after_string, regexp[0], True).matched:
                         is_match = is_match_after = True
 
                     if is_match:

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/utilities.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/utilities.py
@@ -413,6 +413,16 @@ class DateUtils:
 class DateTimeUtilityConfiguration(ABC):
     @property
     @abstractmethod
+    def date_unit_regex(self) -> Pattern:
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def range_prefix_regex(self) -> Pattern:
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
     def ago_regex(self) -> Pattern:
         raise NotImplementedError
 
@@ -461,6 +471,11 @@ class DateTimeUtilityConfiguration(ABC):
     def common_date_prefix_regex(self) -> Pattern:
         raise NotImplementedError
 
+    @property
+    @abstractmethod
+    def check_both_befor_after(self) -> Pattern:
+        raise NotImplementedError
+
 
 class MatchedIndex:
     def __init__(self, matched: bool, index: int):
@@ -471,7 +486,7 @@ class MatchedIndex:
 class MatchingUtil:
 
     @staticmethod
-    def pre_process_text_remove_superfluous_words(text: str, matcher: Pattern) -> str:
+    def pre_process_text_remove_superfluous_words(text: str, matcher: Pattern):
         superfluous_word_matches = MatchingUtil.remove_sub_matches(matcher.find(text))
 
         bias = 0[0]
@@ -516,23 +531,22 @@ class MatchingUtil:
         return match_results
 
     @staticmethod
-    def get_ago_later_index(source: str, regexp: Pattern) -> MatchedIndex:
+    def get_ago_later_index(source: str, regexp: Pattern, in_suffix) -> MatchedIndex:
         result = MatchedIndex(matched=False, index=-1)
-        referenced_matches = regex.match(regexp, source.strip().lower())
+        match = RegExpUtility.match_begin(regexp, source, True) if in_suffix else RegExpUtility.match_end(regexp, source, True)
 
-        if referenced_matches and referenced_matches.start() == 0:
-            result.index = source.lower().find(referenced_matches.group()) + \
-                len(referenced_matches.group())
+        if match and match.success:
+            result.index = match.index() + (match.length if in_suffix else 0)
             result.matched = True
 
         return result
 
     @staticmethod
-    def contains_ago_later_index(source: str, regexp: Pattern) -> bool:
-        return MatchingUtil.get_ago_later_index(source, regexp).matched
+    def contains_ago_later_index(source: str, regexp: Pattern, in_suffix) -> bool:
+        return MatchingUtil.get_ago_later_index(source, regexp, in_suffix).matched
 
     @staticmethod
-    def get_in_index(source: str, regexp: Pattern) -> MatchedIndex:
+    def get_term_index(source: str, regexp: Pattern) -> MatchedIndex:
         result = MatchedIndex(matched=False, index=-1)
         referenced_match = regex.search(
             regexp, source.strip().lower().split(' ').pop())
@@ -544,8 +558,8 @@ class MatchingUtil:
         return result
 
     @staticmethod
-    def contains_in_index(source: str, regexp: Pattern) -> bool:
-        return MatchingUtil.get_in_index(source, regexp).matched
+    def contains_term_index(source: str, regexp: Pattern) -> bool:
+        return MatchingUtil.get_term_index(source, regexp).matched
 
 
 class AgoLaterMode(Enum):
@@ -558,64 +572,90 @@ class AgoLaterUtil:
     def extractor_duration_with_before_and_after(source: str, extract_result: ExtractResult,
                                                  ret: List[Token], config: DateTimeUtilityConfiguration) -> List[Token]:
         pos = extract_result.start + extract_result.length
-
+        index = 0
         if pos <= len(source):
             after_string = source[pos:]
             before_string = source[0: extract_result.start]
             is_time_duration = config.time_unit_regex.search(extract_result.text)
+            ago_later_regexes = [config.ago_regex, config.later_regex]
+            is_match = False
 
-            if MatchingUtil.get_ago_later_index(after_string, config.ago_regex).matched:
-                # We don't support cases like "5 minutes from today" for now
-                # Cases like "5 minutes ago" or "5 minutes from now" are supported
-                # Cases like "2 days before today" or "2 weeks from today" are also supported
-                is_day_match_in_after_string = RegExpUtility.get_group(
-                    config.ago_regex.match(after_string), Constants.DAY_GROUP_NAME)
+            for regexp in ago_later_regexes:
+                token_after = token_before = None
+                is_day_match = False
+                # Check after_string
+                if MatchingUtil.get_ago_later_index(after_string, regexp, True).matched:
+                    # We don't support cases like "5 minutes from today" for now
+                    # Cases like "5 minutes ago" or "5 minutes from now" are supported
+                    # Cases like "2 days before today" or "2 weeks from today" are also supported
 
-                value = MatchingUtil.get_ago_later_index(
-                    after_string, config.ago_regex)
+                    is_day_match = RegExpUtility.get_group(
+                        config.ago_regex.match(after_string), Constants.DAY_GROUP_NAME)
 
-                if not(is_time_duration and is_day_match_in_after_string):
-                    ret.append(Token(extract_result.start, extract_result.start +
-                                     extract_result.length + value.index))
+                    index = MatchingUtil.get_ago_later_index(
+                        after_string, config.ago_regex, True).index
 
-            elif MatchingUtil.get_ago_later_index(after_string, config.later_regex).matched:
+                    if not(is_time_duration and is_day_match):
+                        token_after = Token(extract_result.start, extract_result.start +
+                                         extract_result.length + index)
+                        is_match = True
 
-                is_day_match_in_after_string = RegExpUtility.get_group(
-                    config.later_regex.search(after_string), Constants.DAY_GROUP_NAME)
+                if config.check_both_befor_after:
+                    before_after_str = before_string + after_string[0:index]
+                    is_range_match = RegExpUtility.match_begin(config.range_prefix_regex, after_string[:index], True)
+                    index_start = MatchingUtil.get_ago_later_index(before_after_str, regexp, False)
+                    if not is_range_match and index_start:
+                        is_day_match = regexp.match(before_after_str)
 
-                value = MatchingUtil.get_ago_later_index(
-                    after_string, config.later_regex)
+                        if is_day_match and not (is_time_duration and is_day_match):
+                            ret.append(Token(index_start.index, (extract_result.start + extract_result.length or 0) + index))
+                            is_match = True
+                    index = MatchingUtil.get_ago_later_index(before_string, regexp, False).index
+                    if MatchingUtil.get_ago_later_index(before_string, regexp, False).matched:
+                        is_day_match = RegExpUtility.get_group(regexp.match(before_string), 'day')
 
-                if not(is_time_duration and is_day_match_in_after_string):
-                    ret.append(Token(extract_result.start, extract_result.start +
-                                     extract_result.length + value.index))
+                        if not (is_day_match and is_time_duration):
+                            token_before = Token(index, extract_result.start + extract_result.length or 0)
+                            is_match = True
 
-            elif MatchingUtil.get_in_index(before_string, config.in_connector_regex).matched:
-                # For range unit like "week, month, year", it should output dateRange or datetimeRange
-                if not (config.range_unit_regex.search(extract_result.text)):
-                    value = MatchingUtil.get_in_index(
-                        before_string, config.in_connector_regex)
+                if token_after is not None and token_before is not None and token_before.start + token_before.length > token_after.start:
+                    ret.append(Token(token_before.start, token_after.start + token_after.length - token_before.start))
+                elif token_after is not None:
+                    ret.append(token_after)
+                elif token_before is not None:
+                    ret.append(token_before)
+                if is_match:
+                    break
 
-                    if extract_result.start is not None\
-                            and extract_result.length is not None\
-                            and extract_result.start >= value.index:
-                        ret.append(Token(extract_result.start - value.index,
-                                         extract_result.start + extract_result.length))
+            if not is_match:
+                in_within_regex_tuples = [
+                    (config.in_connector_regex, [config.range_unit_regex]),
+                    (config.within_next_prefix_regex,[config.date_unit_regex, config.time_unit_regex])
+                ]
 
-            elif MatchingUtil.get_in_index(before_string, config.within_next_prefix_regex).matched:
+                for regexp in in_within_regex_tuples:
+                    is_match_after = False
+                    index = MatchingUtil.get_term_index(before_string, regexp[0]).index
+                    if index > 0:
+                        is_match = True
+                    elif config.check_both_befor_after and MatchingUtil.get_ago_later_index(after_string, regexp[0], True).matched:
+                        is_match = is_match_after = True
 
-                # For range unit like "week, month, year, day, second, minute, hour",
-                # it should output dateRange or datetimeRange
-                if not (config.range_unit_regex.search(extract_result.text)) and not config.time_unit_regex.search(
-                        extract_result.text):
-                    value = MatchingUtil.get_in_index(
-                        before_string, config.within_next_prefix_regex)
-                    if extract_result.start is not None and extract_result.length is not None and\
-                            extract_result.start >= value.index:
-                        ret.append(
-                            Token(extract_result.start - value.index, extract_result.start + extract_result.length))
+                    if is_match:
+                        is_unit_match = False
+                        for unit_regex in regexp[1]:
+                            is_unit_match = is_unit_match or unit_regex.match(extract_result.text)
 
+                        if not is_unit_match:
+                            if extract_result.start is not None and extract_result.length is not None and extract_result.start >= index or is_match_after:
+                                start = extract_result.start - (index if not is_match_after else 0)
+                                end = extract_result.start + extract_result.length + (index if not is_match_after else 0)
+                                ret.append(Token(start, end))
+                        break
         return ret
+
+
+
 
     @staticmethod
     def parse_duration_with_ago_and_later(source: str, reference: datetime,
@@ -673,10 +713,10 @@ class AgoLaterUtil:
             return result
 
         contains_ago = MatchingUtil.contains_ago_later_index(
-            after_str, utility_configuration.ago_regex)
+            after_str, utility_configuration.ago_regex, True)
         contains_later_or_in = MatchingUtil.contains_ago_later_index(
-            after_str, utility_configuration.later_regex) or\
-            MatchingUtil.contains_in_index(before_str, utility_configuration.in_connector_regex)
+            after_str, utility_configuration.later_regex, False) or\
+            MatchingUtil.contains_term_index(before_str, utility_configuration.in_connector_regex)
 
         if contains_ago:
             result = AgoLaterUtil.get_date_result(

--- a/Python/libraries/recognizers-text/recognizers_text/utilities.py
+++ b/Python/libraries/recognizers-text/recognizers_text/utilities.py
@@ -25,7 +25,7 @@ class StringUtility:
 
 class ConditionalMatch:
 
-    def __init__(self, match: Pattern, success: bool):
+    def __init__(self, match: Match, success: bool):
         self._match = match,
         self._success = success
 
@@ -51,7 +51,7 @@ class ConditionalMatch:
 
     @property
     def length(self) -> int:
-        return len(self.match[0].group())
+        return len(self.match[0].group()) or 0
 
     def group(self, grp):
         return self.match[0].group(grp)
@@ -110,7 +110,7 @@ class RegExpUtility:
         match = regex.match(regexp, text)
 
         if match is None:
-            return ConditionalMatch(regexp, False)
+            return None
 
         srt_after = text[text.index(match.group()) + (match.end() - match.start()):]
 

--- a/Python/libraries/recognizers-text/recognizers_text/utilities.py
+++ b/Python/libraries/recognizers-text/recognizers_text/utilities.py
@@ -2,6 +2,7 @@ import re
 from typing import Pattern, Union, List, Match
 import regex
 from emoji import UNICODE_EMOJI
+from multipledispatch import dispatch
 
 
 class StringUtility:
@@ -53,6 +54,11 @@ class ConditionalMatch:
     def length(self) -> int:
         return len(self.match[0].group()) or 0
 
+    @dispatch()
+    def group(self):
+        return self.match[0].group()
+
+    @dispatch(str)
     def group(self, grp):
         return self.match[0].group(grp)
 


### PR DESCRIPTION
### Description

This PR ports the changes made on PR# 1839] and PR# 1936 for .NET to Python.

### Changes Made

**MatchingUtil** 

- `get_ago_later_index` (logic changes) [# 1936] using [# 1839]
- `get_in_index` to `get_term_index` (rename for parity)

**AgoLaterUtil**

- `extractor_duration_with_before_and_after` (logic changes)  [# 1839] + [# 1936]

**DateTimeUtilityConfiguration**

- `@ property range_prefix_regex` (new property).
- `@property check_both_befor_after` (new property).
- `@property date_unit_regex` (new property).
- `extract_in_connector` update the logic to avoid issues when there is no match.
