### PR TITLE
[Python] Modify yaml_parser.py to parse bools correctly

### DIFF
--- a/Python/libraries/resource-generator/lib/yaml_parser.py
+++ b/Python/libraries/resource-generator/lib/yaml_parser.py
@@ -107,7 +107,7 @@ class Bool:
 
     @classmethod
     def from_yaml(cls, constructor, node):
-        return bool(node.value)
+        return True if node.value == 'true' else False
 
 
 def parse(content: str) -> dict:


### PR DESCRIPTION
### Description
According to the ISSUE#XXX, the CheckBothBeforeAfter resource definition in the YAML file is set to `false`, but when the `resource-generator` is executed in Python, the property is set as `true`.

Python considers the following things to be `False`:
- None
- False
- Zero
- Empty sequences and mappings (strings, lists, tuples, dicts)

The current implementation tries to convert the string with the value `false` to a boolean, which ends up as `True` as it is a non empty string. 

### Changes Made

To fix the issue, the method `from_yaml` from the class **Bool** was modified to return a value depending on the string (either `true` or `false`).