### PR TITLE
[Python] Port the changes on BaseMergedExtractor

### DIFF
--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/base_merged.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/base_merged.py
@@ -27,6 +27,12 @@ MatchedIndex = namedtuple('MatchedIndex', ['matched', 'index'])
 
 
 class MergedExtractorConfiguration:
+
+    @property
+    @abstractmethod
+    def check_both_before_after(self):
+        raise NotImplementedError
+
     @property
     @abstractmethod
     def date_extractor(self) -> DateTimeExtractor:
@@ -186,19 +192,6 @@ class BaseMergedExtractor(DateTimeExtractor):
     def __init__(self, config: MergedExtractorConfiguration, options: DateTimeOptions):
         self.config = config
         self.options = options
-
-    @staticmethod
-    def has_token_index(source: str, pattern: Pattern) -> MatchedIndex:
-
-        # Support cases has two or more specific tokens
-        # For example, "show me sales after 2010 and before 2018 or before 2000"
-        # When extract "before 2000", we need the second "before" which will be
-        # matched in the second Regex match
-        match = regex.search(pattern, source)
-        if match:
-            return MatchedIndex(True, match.start())
-
-        return MatchedIndex(False, -1)
 
     def extract(self, source: str, reference: datetime = None) -> List[ExtractResult]:
         if reference is None:
@@ -427,13 +420,15 @@ class BaseMergedExtractor(DateTimeExtractor):
     def try_merge_modifier_token(self, extract_result: ExtractResult, pattern: Pattern, source: str,
                                  potential_ambiguity: bool = False) -> bool:
         before_str = source[0:extract_result.start]
+        after_str = source[extract_result.start: extract_result.length]
 
         # Avoid adding mod for ambiguity cases, such as "from" in "from ... to ..." should not add mod
         if potential_ambiguity and self.config.ambiguous_range_modifier_prefix and \
                 regex.search(self.config.ambiguous_range_modifier_prefix, before_str):
             matches = list(regex.finditer(self.config.potential_ambiguous_range_regex, source))
             if matches and len(matches):
-                return self._filter_item(extract_result, matches)
+                return any(match.start() < extract_result.start + extract_result.length and match.end() > extract_result.start for match in matches)
+                # return self._filter_item(extract_result, matches)
 
         token = self.has_token_index(before_str.strip(), pattern)
         if token.matched:
@@ -444,16 +439,30 @@ class BaseMergedExtractor(DateTimeExtractor):
 
             extract_result.meta_data = self.assign_mod_metadata(extract_result.meta_data)
             return True
+        elif self.config.check_both_before_after:
+            # check also after_str
+            after_str = source[extract_result.start: extract_result.length]
+            token = self.has_token_index(after_str.strip(), pattern)
+            if token.matched:
+                mod_len = token.index + len(after_str) - len(after_str.strip())
+                extract_result.length += mod_len
+                extract_result.text = source[extract_result.start: extract_result.start + extract_result.length]
+                extract_result.data = Constants.HAS_MOD
+                extract_result.meta_data = self.assign_mod_metadata(extract_result.meta_data)
+
+                return True
 
         return False
 
-    def _filter_item(self, er: ExtractResult, matches: List[Match]) -> bool:
+    @staticmethod
+    def _filter_item(er: ExtractResult, matches: List[Match]) -> bool:
         for match in matches:
             if match.start() < er.start + er.length and match.end() > er.start:
                 return False
         return True
 
-    def assign_mod_metadata(self, meta_data: MetaData) -> MetaData:
+    @staticmethod
+    def assign_mod_metadata(meta_data: MetaData) -> MetaData:
         if not meta_data:
             meta_data = MetaData()
             meta_data.has_mod = True
@@ -462,7 +471,8 @@ class BaseMergedExtractor(DateTimeExtractor):
 
         return meta_data
 
-    def has_token_index(self, source: str, pattern: Pattern) -> MatchedIndex:
+    @staticmethod
+    def has_token_index(source: str, pattern: Pattern) -> MatchedIndex:
         # This part is different from C# because no Regex RightToLeft option in Python
         match_result = list(regex.finditer(pattern, source))
         if match_result:

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/constants.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/constants.py
@@ -169,6 +169,8 @@ class Constants:
 
     HALF = 'half'
 
+    HAS_MOD = 'mod'
+
     # Holidays
     # These should not be constants, they should go on the resources files for English
     FATHERS = 'fathers'

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/english/merged_extractor_config.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/english/merged_extractor_config.py
@@ -29,6 +29,10 @@ from ...resources.base_date_time import BaseDateTime
 
 class EnglishMergedExtractorConfiguration(MergedExtractorConfiguration):
     @property
+    def check_both_before_after(self):
+        return self._check_both_before_after
+
+    @property
     def time_zone_extractor(self):
         return self._time_zone_extractor
 
@@ -200,6 +204,7 @@ class EnglishMergedExtractorConfiguration(MergedExtractorConfiguration):
         self._fail_fast_regex = RegExpUtility.get_safe_reg_exp(
             EnglishDateTime.FailFastRegex
         )
+        self._check_both_before_after = EnglishDateTime.CheckBothBeforeAfter
         # TODO When the implementation for these properties is added, change the None values to their respective Regexps
         self._time_zone_extractor = None
         self._term_filter_regexes = None

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/french/merged_extractor_config.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/french/merged_extractor_config.py
@@ -29,6 +29,10 @@ from ...resources.base_date_time import BaseDateTime
 
 class FrenchMergedExtractorConfiguration(MergedExtractorConfiguration):
     @property
+    def check_both_before_after(self):
+        return self._check_both_before_after
+
+    @property
     def time_zone_extractor(self):
         return self._time_zone_extractor
 
@@ -194,6 +198,7 @@ class FrenchMergedExtractorConfiguration(MergedExtractorConfiguration):
         self._suffix_after_regex = RegExpUtility.get_safe_reg_exp(
             FrenchDateTime.SuffixAfterRegex
         )
+        self._check_both_before_after = FrenchDateTime.CheckBothBeforeAfter
         # TODO When the implementation for these properties is added, change the None values to their respective Regexps
         self._superfluous_word_matcher = None
         self._fail_fast_regex = None

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/spanish/merged_extractor_config.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/spanish/merged_extractor_config.py
@@ -29,6 +29,10 @@ from ...resources.base_date_time import BaseDateTime
 
 class SpanishMergedExtractorConfiguration(MergedExtractorConfiguration):
     @property
+    def check_both_before_after(self):
+        return self._check_both_before_after
+
+    @property
     def time_zone_extractor(self):
         return self._time_zone_extractor
 
@@ -200,3 +204,4 @@ class SpanishMergedExtractorConfiguration(MergedExtractorConfiguration):
         self._suffix_after_regex = RegExpUtility.get_safe_reg_exp(
             SpanishDateTime.SuffixAfterRegex
         )
+        self._check_both_before_after = SpanishDateTime.CheckBothBeforeAfter

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/resources/english_date_time.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/resources/english_date_time.py
@@ -14,7 +14,7 @@ from .base_date_time import BaseDateTime
 
 
 class EnglishDateTime:
-    CheckBothBeforeAfter = True
+    CheckBothBeforeAfter = False
     TillRegex = f'(?<till>\\b(to|(un)?till?|thru|through)\\b|{BaseDateTime.RangeConnectorSymbolRegex})'
     RangeConnectorRegex = f'(?<and>\\b(and|through|to)\\b|{BaseDateTime.RangeConnectorSymbolRegex})'
     RelativeRegex = f'\\b(?<order>following|next|(up)?coming|this|last|past|previous|current|the)\\b'

--- a/Python/libraries/recognizers-number/recognizers_number/resources/chinese_numeric.py
+++ b/Python/libraries/recognizers-number/recognizers_number/resources/chinese_numeric.py
@@ -16,7 +16,7 @@ from .base_numbers import BaseNumbers
 class ChineseNumeric:
     LangMarker = 'Chs'
     CompoundNumberLanguage = True
-    MultiDecimalSeparatorCulture = True
+    MultiDecimalSeparatorCulture = False
     DecimalSeparatorChar = '.'
     FractionMarkerToken = ''
     NonDecimalSeparatorChar = ' '

--- a/Python/libraries/recognizers-number/recognizers_number/resources/english_numeric.py
+++ b/Python/libraries/recognizers-number/recognizers_number/resources/english_numeric.py
@@ -15,7 +15,7 @@ from .base_numbers import BaseNumbers
 
 class EnglishNumeric:
     LangMarker = 'Eng'
-    CompoundNumberLanguage = True
+    CompoundNumberLanguage = False
     MultiDecimalSeparatorCulture = True
     RoundNumberIntegerRegex = f'(?:hundred|thousand|million|billion|trillion)'
     ZeroToNineIntegerRegex = f'(?:three|seven|eight|four|five|zero|nine|one|two|six)'

--- a/Python/libraries/recognizers-number/recognizers_number/resources/french_numeric.py
+++ b/Python/libraries/recognizers-number/recognizers_number/resources/french_numeric.py
@@ -15,7 +15,7 @@ from .base_numbers import BaseNumbers
 
 class FrenchNumeric:
     LangMarker = 'Fr'
-    CompoundNumberLanguage = True
+    CompoundNumberLanguage = False
     MultiDecimalSeparatorCulture = True
     RoundNumberIntegerRegex = f'(cent|mille|millions|million|milliard|milliards|billion|billions)'
     ZeroToNineIntegerRegex = f'(et un|un|une|deux|trois|quatre|cinq|six|sept|huit|neuf)'

--- a/Python/libraries/recognizers-number/recognizers_number/resources/japanese_numeric.py
+++ b/Python/libraries/recognizers-number/recognizers_number/resources/japanese_numeric.py
@@ -16,7 +16,7 @@ from .base_numbers import BaseNumbers
 class JapaneseNumeric:
     LangMarker = 'Jpn'
     CompoundNumberLanguage = True
-    MultiDecimalSeparatorCulture = True
+    MultiDecimalSeparatorCulture = False
     DecimalSeparatorChar = '.'
     FractionMarkerToken = ''
     NonDecimalSeparatorChar = ' '

--- a/Python/libraries/recognizers-number/recognizers_number/resources/portuguese_numeric.py
+++ b/Python/libraries/recognizers-number/recognizers_number/resources/portuguese_numeric.py
@@ -15,8 +15,8 @@ from .base_numbers import BaseNumbers
 
 class PortugueseNumeric:
     LangMarker = 'Por'
-    CompoundNumberLanguage = True
-    MultiDecimalSeparatorCulture = True
+    CompoundNumberLanguage = False
+    MultiDecimalSeparatorCulture = False
     HundredsNumberIntegerRegex = f'(quatrocent[ao]s|trezent[ao]s|seiscent[ao]s|setecent[ao]s|oitocent[ao]s|novecent[ao]s|duzent[ao]s|quinhent[ao]s|cem|(?<!por\\s+)(cento))'
     RoundNumberIntegerRegex = f'(mil|milh[ãa]o|milh[õo]es|bilh[ãa]o|bilh[õo]es|trilh[ãa]o|trilh[õo]es|qua[td]rilh[ãa]o|qua[td]rilh[õo]es|quintilh[ãa]o|quintilh[õo]es)'
     ZeroToNineIntegerRegex = f'(quatro|cinco|sete|nove|zero|tr[êe]s|seis|oito|dois|duas|um|uma)'

--- a/Python/libraries/recognizers-number/recognizers_number/resources/spanish_numeric.py
+++ b/Python/libraries/recognizers-number/recognizers_number/resources/spanish_numeric.py
@@ -15,7 +15,7 @@ from .base_numbers import BaseNumbers
 
 class SpanishNumeric:
     LangMarker = 'Spa'
-    CompoundNumberLanguage = True
+    CompoundNumberLanguage = False
     MultiDecimalSeparatorCulture = True
     HundredsNumberIntegerRegex = f'(cuatrocient[ao]s|trescient[ao]s|seiscient[ao]s|setecient[ao]s|ochocient[ao]s|novecient[ao]s|doscient[ao]s|quinient[ao]s|(?<!por\\s+)(cien(to)?))'
     RoundNumberIntegerRegex = f'(mil millones|millones|mill[oó]n|mil|billones|bill[oó]n|trillones|trill[oó]n|cuatrillones|cuatrill[oó]n|quintillones|quintill[oó]n|sextillones|sextill[oó]n|septillones|septill[oó]n)'


### PR DESCRIPTION
### Description
This PR ports the changes made on PR# 1936 for .NET to Python.
### Changes Made
**BaseMergedDateTimeExtractor**

- `try_merge_modifier_token` (logic changes) [# 1936]
- `assign_mod_metadata` (to static method)
- `_filter_item` (to static method)
- `has_token_index` (to static method) and remove old duplicated version

**MergedExtractorConfiguration (and sublcasses)**
- `@property check_both_before_after` (new property)