### PR TITLE
[Python] Port the changes on BaseDatePeriodParser

### DIFF
--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/base_dateperiod.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/base_dateperiod.py
@@ -1624,7 +1624,7 @@ class BaseDatePeriodParser(DateTimeParser):
         if past_end < past_begin:
             past_end = future_end
 
-        if not future_end and not future_begin:
+        if not DateUtils.is_default_value(future_end) and not DateUtils.is_default_value(future_begin):
             result.timex = f'({parse_result1.timex_str},{parse_result2.timex_str},P{(future_end - future_begin).days}D)'
         else:
             result.timex = f'({parse_result1.timex_str},{parse_result2.timex_str})'
@@ -1969,21 +1969,24 @@ class BaseDatePeriodParser(DateTimeParser):
             duration_unit = self.config.unit_map[duration_str]
 
             if duration_unit == Constants.TIMEX_WEEK:
-                diff = Constants.WEEK_DAY_COUNT - (Constants.WEEK_DAY_COUNT if begin_date.weekday() == 0 else
-                                                   int(begin_date.weekday()))
+                begin_date_wd = begin_date.isoweekday()
+                diff = Constants.WEEK_DAY_COUNT - (Constants.WEEK_DAY_COUNT if begin_date.isoweekday() == 0 else
+                                                   int(begin_date.isoweekday()))
                 end_date = begin_date + timedelta(days=diff)
-                duration_timex = "P" + diff + Constants.TIMEX_DAY
+                duration_timex = "P" + str(diff) + Constants.TIMEX_DAY
 
                 if diff == 0:
                     rest_now_sunday = True
-            elif Constants.TIMEX_MONTH_FULL:
+            elif duration_unit == Constants.TIMEX_MONTH_FULL:
                 end_date = DateUtils.safe_create_from_min_value(begin_date.year, begin_date.month, 1)
-                end_date = end_date.replace(month=end_date.month + 1) + timedelta(days=-1)
+                end_date = end_date + timedelta(days=-1)
+                end_date = end_date.replace(month=end_date.month + 1)
                 diff = end_date.day - begin_date.day + 1
                 duration_timex = "P" + str(diff) + Constants.TIMEX_DAY
-            elif Constants.TIMEX_YEAR:
+            elif duration_unit == Constants.TIMEX_YEAR:
                 end_date = DateUtils.safe_create_from_min_value(begin_date.year, 12, 1)
-                end_date = end_date.replace(month=end_date.month + 1) + timedelta(days=-1)
+                end_date = end_date + timedelta(days=-1)
+                end_date = end_date.replace(month=end_date.month + 1)
                 diff = DateUtils.day_of_year(end_date) - DateUtils.day_of_year(begin_date) + 1
                 duration_timex = "P" + str(diff) + Constants.TIMEX_DAY
 

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/base_dateperiod.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/base_dateperiod.py
@@ -1969,7 +1969,6 @@ class BaseDatePeriodParser(DateTimeParser):
             duration_unit = self.config.unit_map[duration_str]
 
             if duration_unit == Constants.TIMEX_WEEK:
-                begin_date_wd = begin_date.isoweekday()
                 diff = Constants.WEEK_DAY_COUNT - (Constants.WEEK_DAY_COUNT if begin_date.isoweekday() == 0 else
                                                    int(begin_date.isoweekday()))
                 end_date = begin_date + timedelta(days=diff)
@@ -1979,14 +1978,20 @@ class BaseDatePeriodParser(DateTimeParser):
                     rest_now_sunday = True
             elif duration_unit == Constants.TIMEX_MONTH_FULL:
                 end_date = DateUtils.safe_create_from_min_value(begin_date.year, begin_date.month, 1)
+                end_date = end_date.replace(month=end_date.month + 1) if end_date.month != 12 else\
+                    end_date.replace(month=1)
+                end_date = end_date.replace(year=end_date.year + 1) if end_date.month == end_date.day == 1 else \
+                    end_date.replace(year=end_date.year)
                 end_date = end_date + timedelta(days=-1)
-                end_date = end_date.replace(month=end_date.month + 1)
                 diff = end_date.day - begin_date.day + 1
                 duration_timex = "P" + str(diff) + Constants.TIMEX_DAY
             elif duration_unit == Constants.TIMEX_YEAR:
                 end_date = DateUtils.safe_create_from_min_value(begin_date.year, 12, 1)
+                end_date = end_date.replace(month=end_date.month + 1) if end_date.month != 12 else\
+                    end_date.replace(month=1)
+                end_date = end_date.replace(year=end_date.year + 1) if end_date.month == end_date.day == 1 else\
+                    end_date.replace(year=end_date.year)
                 end_date = end_date + timedelta(days=-1)
-                end_date = end_date.replace(month=end_date.month + 1)
                 diff = DateUtils.day_of_year(end_date) - DateUtils.day_of_year(begin_date) + 1
                 duration_timex = "P" + str(diff) + Constants.TIMEX_DAY
 

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/base_dateperiod.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/base_dateperiod.py
@@ -1888,7 +1888,7 @@ class BaseDatePeriodParser(DateTimeParser):
                         and DurationParsingUtil.is_date_duration(duration_result.timex) and not after_str:
                     mod_and_date_result = self._get_mod_and_date(begin_date, end_date, reference,
                                                                  duration_result.timex, True)
-                    
+
                     # In _get_mod_and_date, this "future" resolution will add one day to begin_date/end_date,
                     # but for the "within" case it should start from the current day
                     begin_date = mod_and_date_result.begin_date + timedelta(days=-1)
@@ -1902,13 +1902,13 @@ class BaseDatePeriodParser(DateTimeParser):
 
                         mod_and_date_result = self._get_mod_and_date(begin_date, end_date, reference,
                                                                      duration_result.timex, True)
-                        
+
                         # In _get_mod_and_date, this "future" resolution will add one day to begin_date/end_date
                         # but for the "within" case it should start from the current day
                         begin_date = mod_and_date_result.begin_date + timedelta(days=-1)
                         end_date = mod_and_date_result.end_date + timedelta(days=-1)
                         before_str = ''
-                
+
                 if RegExpUtility.is_exact_match(self.config.future_regex, before_str, True):
                     mod_and_date_result = self._get_mod_and_date(begin_date, end_date, reference, duration_result.timex,
                                                                  True)
@@ -1919,27 +1919,27 @@ class BaseDatePeriodParser(DateTimeParser):
                                                                  True)
                     begin_date = mod_and_date_result.begin_date
                     end_date = mod_and_date_result.end_date
-                
+
                 if self.config.future_suffix_regex.match(after_str):
                     mod_and_date_result = self._get_mod_and_date(begin_date, end_date, reference, duration_result.timex,
                                                                  True)
                     begin_date = mod_and_date_result.begin_date
                     end_date = mod_and_date_result.end_date
-                
+
                 # Handle the "in two weeks" case  which means the second week
                 if RegExpUtility.is_exact_match(self.config.in_connector_regex, before_str, True) \
-                    and DurationParsingUtil.is_multiple_duration(duration_result.timex):
+                        and DurationParsingUtil.is_multiple_duration(duration_result.timex):
                     mod_and_date_result = self._get_mod_and_date(begin_date, end_date, reference,
                                                                  duration_result.timex, True)
 
                     # Change the duration value and the begin_date
                     unit = duration_result.timex[len(duration_result.timex) - 1:]
-                    
+
                     duration_result.timex = "P1" + unit
                     begin_date = DurationParsingUtil.shift_date_time(self, duration_result.timex,
                                                                      mod_and_date_result.end_date, False)
                     end_date = mod_and_date_result.end_date
-                
+
                 if mod_and_date_result.mod:
                     duration_parse_result.value.mod = mod_and_date_result.mod
 
@@ -1982,7 +1982,7 @@ class BaseDatePeriodParser(DateTimeParser):
             result.success = True
 
         return result
-            
+
     def _get_mod_and_date(self, begin_date: datetime, end_date: datetime, reference: datetime, timex: str, future: bool):
         begin_date_result = begin_date
         end_date_result = end_date

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/chinese/dateperiod_parser_config.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/chinese/dateperiod_parser_config.py
@@ -14,6 +14,10 @@ from .date_parser import ChineseDateParser
 
 class ChineseDatePeriodParserConfiguration(DatePeriodParserConfiguration):
     @property
+    def future_suffix_regex(self) -> Pattern:
+        return self._future_suffix_regex
+
+    @property
     def less_than_regex(self) -> Pattern:
         return self._check_both_before_after
 
@@ -206,8 +210,6 @@ class ChineseDatePeriodParserConfiguration(DatePeriodParserConfiguration):
         return self._relative_decade_regex
 
     def __init__(self):
-        self._complex_dateperiod_regex = None
-        self._relative_decade_regex = None
         self._relative_regex = RegExpUtility.get_safe_reg_exp(
             ChineseDateTime.RelativeRegex)
         self._date_extractor = ChineseDateExtractor()
@@ -251,6 +253,9 @@ class ChineseDatePeriodParserConfiguration(DatePeriodParserConfiguration):
         self._decade_with_century_regex = None
         self._later_regex = None
         self._ago_regex = None
+        self._future_suffix_regex = None
+        self._complex_dateperiod_regex = None
+        self._relative_decade_regex = None
 
     def get_swift_day_or_month(self, source: str) -> int:
         source = source.strip().lower()

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/chinese/dateperiod_parser_config.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/chinese/dateperiod_parser_config.py
@@ -222,8 +222,8 @@ class ChineseDatePeriodParserConfiguration(DatePeriodParserConfiguration):
     def relative_decade_regex(self) -> Pattern:
         return self._relative_decade_regex
 
-    def __init__(self, config: BaseDateParserConfiguration):
-        self._cardinal_extractor = config.cardinal_extractor
+    def __init__(self):
+        self._cardinal_extractor = None
         self._relative_regex = RegExpUtility.get_safe_reg_exp(
             ChineseDateTime.RelativeRegex)
         self._date_extractor = ChineseDateExtractor()

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/chinese/dateperiod_parser_config.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/chinese/dateperiod_parser_config.py
@@ -7,12 +7,25 @@ from ...resources.chinese_date_time import ChineseDateTime
 from ..extractors import DateTimeExtractor
 from ..parsers import DateTimeParser
 from ..base_dateperiod import DatePeriodParserConfiguration
+from ..base_configs import BaseDateParserConfiguration
 from .duration_extractor import ChineseDurationExtractor
 from .date_extractor import ChineseDateExtractor
 from .date_parser import ChineseDateParser
 
 
 class ChineseDatePeriodParserConfiguration(DatePeriodParserConfiguration):
+    @property
+    def cardinal_extractor(self):
+        return self._cardinal_extractor
+
+    @property
+    def within_next_prefix_regex(self):
+        return self._within_next_prefix_regex
+
+    @property
+    def more_than_regex(self):
+        return self._more_than_regex
+
     @property
     def future_suffix_regex(self) -> Pattern:
         return self._future_suffix_regex
@@ -209,7 +222,8 @@ class ChineseDatePeriodParserConfiguration(DatePeriodParserConfiguration):
     def relative_decade_regex(self) -> Pattern:
         return self._relative_decade_regex
 
-    def __init__(self):
+    def __init__(self, config: BaseDateParserConfiguration):
+        self._cardinal_extractor = config.cardinal_extractor
         self._relative_regex = RegExpUtility.get_safe_reg_exp(
             ChineseDateTime.RelativeRegex)
         self._date_extractor = ChineseDateExtractor()
@@ -255,6 +269,8 @@ class ChineseDatePeriodParserConfiguration(DatePeriodParserConfiguration):
         self._ago_regex = None
         self._future_suffix_regex = None
         self._complex_dateperiod_regex = None
+        self._more_than_regex = None
+        self._within_next_prefix_regex = None
         self._relative_decade_regex = None
 
     def get_swift_day_or_month(self, source: str) -> int:

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/constants.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/constants.py
@@ -36,6 +36,7 @@ class Constants:
 
     SEMESTER_MONTH_COUNT: int = 6
     TRIMESTER_MONTH_COUNT: int = 3
+    WEEK_DAY_COUNT = 7
     QUARTER_COUNT: int = 4
     FOUR_DIGITS_YEAR_LENGTH: int = 4
     MIN_MONTH: int = 1
@@ -187,6 +188,8 @@ class Constants:
 
     AGO_LABEL = "ago"
     LATER_LABEL = "later"
+    TODAY_LABEL = "today"
+    NOW_LABEL = "now"
 
 
 class TimeTypeConstants:

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/english/dateperiod_parser_config.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/english/dateperiod_parser_config.py
@@ -10,6 +10,10 @@ from ..base_dateperiod import DatePeriodParserConfiguration
 
 class EnglishDatePeriodParserConfiguration(DatePeriodParserConfiguration):
     @property
+    def future_suffix_regex(self) -> Pattern:
+        return self._future_suffix_regex
+
+    @property
     def less_than_regex(self) -> Pattern:
         return self._less_than_regex
 
@@ -198,6 +202,7 @@ class EnglishDatePeriodParserConfiguration(DatePeriodParserConfiguration):
         return self._check_both_before_after
 
     def __init__(self, config: BaseDateParserConfiguration):
+        self._future_suffix_regex = RegExpUtility.get_safe_reg_exp(EnglishDateTime.FutureSuffixRegex)
         self._check_both_before_after = EnglishDateTime.CheckBothBeforeAfter
         self._later_regex = RegExpUtility.get_safe_reg_exp(
             EnglishDateTime.LaterRegex)

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/english/dateperiod_parser_config.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/english/dateperiod_parser_config.py
@@ -10,6 +10,18 @@ from ..base_dateperiod import DatePeriodParserConfiguration
 
 class EnglishDatePeriodParserConfiguration(DatePeriodParserConfiguration):
     @property
+    def cardinal_extractor(self):
+        return self._cardinal_extractor
+
+    @property
+    def within_next_prefix_regex(self):
+        return self._within_next_prefix_regex
+
+    @property
+    def more_than_regex(self):
+        return self._more_than_regex
+
+    @property
     def future_suffix_regex(self) -> Pattern:
         return self._future_suffix_regex
 
@@ -202,6 +214,9 @@ class EnglishDatePeriodParserConfiguration(DatePeriodParserConfiguration):
         return self._check_both_before_after
 
     def __init__(self, config: BaseDateParserConfiguration):
+        self._more_than_regex = RegExpUtility.get_safe_reg_exp(EnglishDateTime.MoreThanRegex)
+        self._within_next_prefix_regex = RegExpUtility.get_safe_reg_exp(EnglishDateTime.WithinNextPrefixRegex)
+        self._cardinal_extractor = config.cardinal_extractor
         self._future_suffix_regex = RegExpUtility.get_safe_reg_exp(EnglishDateTime.FutureSuffixRegex)
         self._check_both_before_after = EnglishDateTime.CheckBothBeforeAfter
         self._later_regex = RegExpUtility.get_safe_reg_exp(

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/french/dateperiod_parser_config.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/french/dateperiod_parser_config.py
@@ -10,6 +10,10 @@ from ..base_dateperiod import DatePeriodParserConfiguration
 
 class FrenchDatePeriodParserConfiguration(DatePeriodParserConfiguration):
     @property
+    def future_suffix_regex(self) -> Pattern:
+        return self._future_suffix_regex
+
+    @property
     def less_than_regex(self) -> Pattern:
         return self._less_than_regex
 
@@ -198,6 +202,7 @@ class FrenchDatePeriodParserConfiguration(DatePeriodParserConfiguration):
         return self._relative_decade_regex
 
     def __init__(self, config: BaseDateParserConfiguration):
+        self._future_suffix_regex = RegExpUtility.get_safe_reg_exp(FrenchDateTime.FutureSuffixRegex)
         self._relative_regex = RegExpUtility.get_safe_reg_exp(
             FrenchDateTime.RelativeRegex)
         self._later_regex = FrenchDateTime.LaterRegex

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/french/dateperiod_parser_config.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/french/dateperiod_parser_config.py
@@ -10,6 +10,18 @@ from ..base_dateperiod import DatePeriodParserConfiguration
 
 class FrenchDatePeriodParserConfiguration(DatePeriodParserConfiguration):
     @property
+    def cardinal_extractor(self):
+        return self._cardinal_extractor
+
+    @property
+    def within_next_prefix_regex(self):
+        return self._within_next_prefix_regex
+
+    @property
+    def more_than_regex(self):
+        return self._more_than_regex
+
+    @property
     def future_suffix_regex(self) -> Pattern:
         return self._future_suffix_regex
 
@@ -202,13 +214,15 @@ class FrenchDatePeriodParserConfiguration(DatePeriodParserConfiguration):
         return self._relative_decade_regex
 
     def __init__(self, config: BaseDateParserConfiguration):
+        self._more_than_regex = RegExpUtility.get_safe_reg_exp(FrenchDateTime.MoreThanRegex)
+        self._within_next_prefix_regex = RegExpUtility.get_safe_reg_exp(FrenchDateTime.WithinNextPrefixRegex)
         self._future_suffix_regex = RegExpUtility.get_safe_reg_exp(FrenchDateTime.FutureSuffixRegex)
         self._relative_regex = RegExpUtility.get_safe_reg_exp(
             FrenchDateTime.RelativeRegex)
         self._later_regex = FrenchDateTime.LaterRegex
         self._ago_regex = FrenchDateTime.AgoRegex
         self._token_before_date = FrenchDateTime.TokenBeforeDate
-        self.cardinal_extractor = config.cardinal_extractor
+        self._cardinal_extractor = config.cardinal_extractor
         self.number_parser = config.number_parser
         self._duration_extractor = config.duration_extractor
         self._date_extractor = config.date_extractor

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/spanish/dateperiod_parser_config.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/spanish/dateperiod_parser_config.py
@@ -10,6 +10,18 @@ from ..base_dateperiod import DatePeriodParserConfiguration
 
 class SpanishDatePeriodParserConfiguration(DatePeriodParserConfiguration):
     @property
+    def cardinal_extractor(self):
+        return self._cardinal_extractor
+
+    @property
+    def within_next_prefix_regex(self):
+        return self._within_next_prefix_regex
+
+    @property
+    def more_than_regex(self):
+        return self._more_than_regex
+
+    @property
     def future_suffix_regex(self) -> Pattern:
         return self._future_suffix_regex
 
@@ -202,6 +214,9 @@ class SpanishDatePeriodParserConfiguration(DatePeriodParserConfiguration):
         return self._relative_decade_regex
 
     def __init__(self, config: BaseDateParserConfiguration):
+        self._more_than_regex = RegExpUtility.get_safe_reg_exp(SpanishDateTime.MoreThanRegex)
+        self._within_next_prefix_regex = RegExpUtility.get_safe_reg_exp(SpanishDateTime.WithinNextPrefixRegex)
+        self._cardinal_extractor = config.cardinal_extractor
         self._future_suffix_regex = RegExpUtility.get_safe_reg_exp(SpanishDateTime.FutureSuffixRegex)
         self._relative_regex = RegExpUtility.get_safe_reg_exp(
             SpanishDateTime.RelativeRegex)

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/spanish/dateperiod_parser_config.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/spanish/dateperiod_parser_config.py
@@ -10,6 +10,10 @@ from ..base_dateperiod import DatePeriodParserConfiguration
 
 class SpanishDatePeriodParserConfiguration(DatePeriodParserConfiguration):
     @property
+    def future_suffix_regex(self) -> Pattern:
+        return self._future_suffix_regex
+
+    @property
     def less_than_regex(self) -> Pattern:
         return self._less_than_regex
 
@@ -198,6 +202,7 @@ class SpanishDatePeriodParserConfiguration(DatePeriodParserConfiguration):
         return self._relative_decade_regex
 
     def __init__(self, config: BaseDateParserConfiguration):
+        self._future_suffix_regex = RegExpUtility.get_safe_reg_exp(SpanishDateTime.FutureSuffixRegex)
         self._relative_regex = RegExpUtility.get_safe_reg_exp(
             SpanishDateTime.RelativeRegex)
         self._later_regex = RegExpUtility.get_safe_reg_exp(

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/utilities.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/utilities.py
@@ -137,24 +137,24 @@ class DurationParsingUtil:
 
         return date
 
-    def get_nth_business_day(self, start_date: datetime, n: int, is_future: bool):
+    @staticmethod
+    def get_nth_business_day(start_date: datetime, n: int, is_future: bool):
         date = start_date
         date_list = [date]
 
-        i = 0
-        if i < n:
-            date = self.get_next_business_day(date, is_future)
+        for i in range(0, n):
+            date = DurationParsingUtil.get_next_business_day(date, is_future)
             date_list.append(date)
-            i += 1
 
         if not is_future:
             date_list.reverse()
 
         return date, date_list
 
-    def shift_date_time(self, timex: str, reference: datetime, future: bool):
-        timex_unit_map = self.resolve_duration_timex(timex)
-        result = self.get_shift_result(timex_unit_map, reference, future)
+    @staticmethod
+    def shift_date_time(timex: str, reference: datetime, future: bool):
+        timex_unit_map = DurationParsingUtil.resolve_duration_timex(timex)
+        result = DurationParsingUtil.get_shift_result(timex_unit_map, reference, future)
 
         return result
 
@@ -196,7 +196,8 @@ class DurationParsingUtil:
 
         return result
 
-    def get_shift_result(self, timex_unit_map: Dict[str, float], reference: datetime, future: bool):
+    @staticmethod
+    def get_shift_result(timex_unit_map, reference: datetime, future: bool):
         result = reference
         future_or_past = 1 if future else -1
         for unit_str, number in timex_unit_map:
@@ -215,15 +216,36 @@ class DurationParsingUtil:
             elif unit_str == Constants.TIMEX_YEAR:
                 result = result.replace(year=reference.year + int(number) * future_or_past)
             elif unit_str == Constants.TIMEX_BUSINESS_DAY:
-                result, date_list = self.get_nth_business_day(result, int(number), future)
+                result, date_list = DurationParsingUtil.get_nth_business_day(result, int(number), future)
             else:
                 return result
 
         return result
 
     @staticmethod
-    def is_multiple_duration(cls, timex):
-        pass
+    def is_time_duration(unit_str: str) -> bool:
+        if unit_str == 'H':
+            result = True
+        elif unit_str == 'M':
+            result = True
+        elif unit_str == 'S':
+            result = True
+        else:
+            result = False
+
+        return result
+
+    @staticmethod
+    def is_multiple_duration(timex: str):
+        date_dict = DurationParsingUtil.resolve_duration_timex(timex)
+
+        return len(date_dict) > 1
+
+    @staticmethod
+    def is_date_duration(timex: str):
+        date_dict = DurationParsingUtil.resolve_duration_timex(timex)
+
+        return all(not DurationParsingUtil.is_time_duration_unit(unit) for unit in date_dict.keys())
 
 
 class Token:

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/utilities.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/utilities.py
@@ -175,18 +175,17 @@ class DurationParsingUtil:
 
             return result
 
-        index = 0
-        if index < len(duration_str):
-            if not duration_str[index].isalpha():
+        for index in range(0, len(duration_str)):
+            if duration_str[index].isalpha():
                 if duration_str[index] == 'T':
                     is_time = True
                 else:
                     num_str = duration_str[number_start: index - number_start]
                     number = float(num_str)
-                    if number:
+                    if not number:
                         return {}
 
-                    source_timex_unit = duration_str[index: 1]
+                    source_timex_unit = duration_str[index: index + 1]
                     if not is_time and source_timex_unit == Constants.TIMEX_MONTH:
                         source_timex_unit = Constants.TIMEX_MONTH_FULL
 
@@ -200,7 +199,7 @@ class DurationParsingUtil:
     def get_shift_result(timex_unit_map, reference: datetime, future: bool):
         result = reference
         future_or_past = 1 if future else -1
-        for unit_str, number in timex_unit_map:
+        for unit_str, number in timex_unit_map.items():
             if unit_str == 'H':
                 result = result + timedelta(hours=number * future_or_past)
             elif unit_str == 'M':
@@ -452,6 +451,7 @@ class DayOfWeek(IntEnum):
 
 class DateUtils:
     min_value = datetime(1, 1, 1, 0, 0, 0, 0)
+    default_datetime = datetime(1, 1, 1, 0, 0, 0, 0)
 
     @staticmethod
     def int_try_parse(value):
@@ -490,6 +490,10 @@ class DateUtils:
     @staticmethod
     def is_valid_time(hour: int, minute: int, second: int) -> bool:
         return 0 <= hour < 24 and 0 <= minute < 60 and second >= 0 and minute < 60
+
+    @staticmethod
+    def is_default_value(date: datetime):
+        return date == DateUtils.default_datetime
 
     @staticmethod
     def this(from_date: datetime, day_of_week: DayOfWeek) -> datetime:

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/utilities.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/utilities.py
@@ -130,10 +130,10 @@ class DurationParsingUtil:
     @staticmethod
     def get_next_business_day(start_date: datetime, is_future: bool = True):
         date_increment = 1 if is_future else -1
-        date = start_date + timedelta(days= date_increment)
+        date = start_date + timedelta(days=date_increment)
 
         while date.weekday() == DayOfWeek.SATURDAY or date.weekday() == DayOfWeek.SUNDAY:
-            date = date + timedelta(days = date_increment)
+            date = date + timedelta(days=date_increment)
 
         return date
 

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/utilities.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/utilities.py
@@ -211,7 +211,22 @@ class DurationParsingUtil:
             elif unit_str == Constants.TIMEX_WEEK:
                 result = result + timedelta(days=7 * number * future_or_past)
             elif unit_str == Constants.TIMEX_MONTH_FULL:
-                result = result.replace(month=reference.month + int(number) * future_or_past)
+                if future_or_past == 1 and 12 - result.month > int(number) * future_or_past:
+                    result = result.replace(month=result.month + int(number) * future_or_past)
+                else:
+                    for index in range(0, int(number)):
+                        if future_or_past == 1:
+                            if result.month != 12:
+                                result = result.replace(month=result.month + 1)
+                            else:
+                                result = result.replace(month=1)
+                                result = result.replace(year=result.year + 1)
+                        else:
+                            if result.month != 1:
+                                result = result.replace(month=result.month - 1)
+                            else:
+                                result = result.replace(month=12)
+                                result.replace(year=result.year - 1)
             elif unit_str == Constants.TIMEX_YEAR:
                 result = result.replace(year=reference.year + int(number) * future_or_past)
             elif unit_str == Constants.TIMEX_BUSINESS_DAY:


### PR DESCRIPTION
### Description
This PR ports the changes made on PR# 1884 for .NET to Python.
### Changes Made
#### DatePeriodParserConfiguration (and subclasses)
- `@property cardinal_extractor` (new property)
- `@property within_next_prefix_regex` (new property)
- `@property more_than_regex` (new property)
- `@property future_suffix_regex` (new property)
- `match_with_next_prefix` (moved to BaseDatePeriodParser class)

#### BaseDatePeriodParser
- `merge_two_time_points` (logic changes) [# 1884]
- `parse_duration` (logic changes) [# 1884]
- `parse_date_point_with_ago_and_later` (logic changes) [# 1884]
- `get_mod_and_date` (new method)

#### DurationParsingUtil
- `get_next_business_day` (new method)
- `get_nth_business_day` (new method)
- `shift_date_time` (new method)
- `resolve_duration_timex` (new method)
- `get_shift_result` (new method)
- `is_time_duration` (new method)
- `is_multiple_duration` (new method)
- `is_date_duration` (new method)

#### DateUtils
- `is_default_value` (new method)

#### ModAndDateResult (new Class)
- `@property begin_date` (new property)
- `@property end_date` new property)
- `@property mod` (new property)
- `@property date_list` (new property)

#### Constants
- `WEEK_DAY_COUNT` (new Constant)
- `TODAY_LABEL` (new Constant)
- `NOW_LABEL `(new Constant)