### PR TITLE
[Java] Add Recognizers dependencies in README

### DIFF
--- a/Java/README.md
+++ b/Java/README.md
@@ -18,6 +18,52 @@ Open a terminal and run the following commands:
     cd Java
     mvn clean install
 
+### Installation
+Install Recognizer's by adding the following dependencies in your `pom.xml`:
+- Get core Recognizer's features:
+    ````xml
+    <dependency>
+        <groupId>com.microsoft.recognizers.text</groupId>
+        <artifactId>recognizers-text</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </dependency>
+    ````
+- Get numbers Recognizer's features:
+    ````xml
+    <dependency>
+        <groupId>com.microsoft.recognizers.text.number</groupId>
+        <artifactId>recognizers-text-number</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </dependency>
+    ````
+
+- Get numbers with units Recognizer's features:
+    ````xml
+    <dependency>
+        <groupId>com.microsoft.recognizers.text.numberwithunit</groupId>
+        <artifactId>recognizers-text-number-with-unit</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </dependency>
+    ````
+
+- Get datetime Recognizer's features:
+    ````xml
+    <dependency>
+        <groupId>com.microsoft.recognizers.text.datetime</groupId>
+        <artifactId>recognizers-text-date-time</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </dependency>
+    ````
+
+- Get choice Recognizer's features:
+    ````xml
+    <dependency>
+        <groupId>com.microsoft.recognizers.text.choice</groupId>
+        <artifactId>recognizers-text-choice</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </dependency>
+    ````
+
 ## API Documentation
 
 Once the proper modules are installed, you'll need to import the modules:


### PR DESCRIPTION
Related to XXXX

## Description
The Java's README doesn't contain the content to install the Recognizers.

## Specific Changes
- Add `Installation` sub-bullet in the README
- Define how to install core Recognizer's features
- Define how to install numbers Recognizer's features
- Define how to install numbers with units Recognizer's features
- Define how to install datetime Recognizer's features
- Define how to install choice Recognizer's features

## Testing
We validated the changes rendering the document manually and comparing it with the C# [README](https://github.com/microsoft/Recognizers-Text/blob/master/.NET/README.md).

_Before vs After_
![image](https://user-images.githubusercontent.com/11904023/106478276-cdbcd800-6487-11eb-9eb4-e7e212fb9e49.png)

_List of the current Recognizers_
![image](https://user-images.githubusercontent.com/11904023/106478282-d01f3200-6487-11eb-898c-633a7739137f.png)
