### PR TITLE
[Java][Number] Decrease end property of ModelResult by 1

### DIFF
--- a/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/models/AbstractNumberModel.java
+++ b/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/models/AbstractNumberModel.java
@@ -54,7 +54,7 @@ public abstract class AbstractNumberModel implements IModel {
             return new ModelResult(
                     o.getText(),
                     o.getStart(),
-                o.getStart() + o.getLength(),
+                o.getStart() + o.getLength() - 1,
                 getModelTypeName(),
                 sortedMap
             );                

--- a/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/models/AbstractNumberModel.java
+++ b/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/models/AbstractNumberModel.java
@@ -51,6 +51,7 @@ public abstract class AbstractNumberModel implements IModel {
             SortedMap<String, Object> sortedMap = new TreeMap<String, Object>();
             sortedMap.put(ResolutionKey.Value, o.getResolutionStr());
 
+            // We decreased the end property by 1 in order to keep parity with other platforms (C#/JS).
             return new ModelResult(
                     o.getText(),
                     o.getStart(),

--- a/Java/tests/src/test/java/com/microsoft/recognizers/text/tests/number/NumberTest.java
+++ b/Java/tests/src/test/java/com/microsoft/recognizers/text/tests/number/NumberTest.java
@@ -1,5 +1,6 @@
 package com.microsoft.recognizers.text.tests.number;
 
+import com.microsoft.recognizers.text.ExtendedModelResult;
 import com.microsoft.recognizers.text.ModelResult;
 import com.microsoft.recognizers.text.number.NumberOptions;
 import com.microsoft.recognizers.text.number.NumberRecognizer;
@@ -7,11 +8,14 @@ import com.microsoft.recognizers.text.tests.AbstractTest;
 import com.microsoft.recognizers.text.tests.DependencyConstants;
 import com.microsoft.recognizers.text.tests.NotSupportedException;
 import com.microsoft.recognizers.text.tests.TestCase;
+import org.javatuples.Pair;
+import org.junit.Assert;
 import org.junit.AssumptionViolatedException;
 import org.junit.runners.Parameterized;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.stream.IntStream;
 
 public class NumberTest extends AbstractTest {
 
@@ -23,6 +27,36 @@ public class NumberTest extends AbstractTest {
 
     public NumberTest(TestCase currentCase) {
         super(currentCase);
+    }
+
+    @Override
+    protected void recognizeAndAssert(TestCase currentCase) {
+
+        // parse
+        List<ModelResult> results = recognize(currentCase);
+
+        // assert
+        assertResultsNumber(currentCase, results);
+    }
+
+    public static <T extends ModelResult> void assertResultsNumber(TestCase currentCase, List<T> results) {
+
+        List<ExtendedModelResult> expectedResults = readExpectedResults(ExtendedModelResult.class, currentCase.results);
+        Assert.assertEquals(getMessage(currentCase, "\"Result Count\""), expectedResults.size(), results.size());
+
+        IntStream.range(0, expectedResults.size())
+                .mapToObj(i -> Pair.with(expectedResults.get(i), results.get(i)))
+                .forEach(t -> {
+                    ExtendedModelResult expected = t.getValue0();
+                    T actual = t.getValue1();
+
+                    Assert.assertEquals(getMessage(currentCase, "typeName"), expected.typeName, actual.typeName);
+                    Assert.assertEquals(getMessage(currentCase, "text"), expected.text, actual.text);
+
+                    // Number and NumberWithUnit are supported currently.
+                    Assert.assertEquals(getMessage(currentCase, "start"), expected.start, actual.start);
+                    Assert.assertEquals(getMessage(currentCase, "end"), expected.end, actual.end);
+                });
     }
 
     @Override

--- a/Java/tests/src/test/java/com/microsoft/recognizers/text/tests/number/NumberTest.java
+++ b/Java/tests/src/test/java/com/microsoft/recognizers/text/tests/number/NumberTest.java
@@ -13,7 +13,9 @@ import org.junit.Assert;
 import org.junit.AssumptionViolatedException;
 import org.junit.runners.Parameterized;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.IntStream;
 
@@ -36,10 +38,10 @@ public class NumberTest extends AbstractTest {
         List<ModelResult> results = recognize(currentCase);
 
         // assert
-        assertResultsNumber(currentCase, results);
+        assertResultsNumber(currentCase, results, new ArrayList() {{ add("value");}});
     }
 
-    public static <T extends ModelResult> void assertResultsNumber(TestCase currentCase, List<T> results) {
+    public static <T extends ModelResult> void assertResultsNumber(TestCase currentCase, List<T> results, List<String> testResolutionKeys) {
 
         List<ExtendedModelResult> expectedResults = readExpectedResults(ExtendedModelResult.class, currentCase.results);
         Assert.assertEquals(getMessage(currentCase, "\"Result Count\""), expectedResults.size(), results.size());
@@ -56,6 +58,10 @@ public class NumberTest extends AbstractTest {
                     // Number and NumberWithUnit are supported currently.
                     Assert.assertEquals(getMessage(currentCase, "start"), expected.start, actual.start);
                     Assert.assertEquals(getMessage(currentCase, "end"), expected.end, actual.end);
+
+                    for (String key : testResolutionKeys) {
+                        Assert.assertEquals(getMessage(currentCase, key), expected.resolution.get(key), actual.resolution.get(key));
+                    }
                 });
     }
 


### PR DESCRIPTION
Fixes 2254

## Description
There is a disparity on the generation of the `ModelResult`, specifically the `end` property, which needs to be decreased by 1. See [C#](https://github.com/microsoft/Recognizers-Text/blob/master/.NET/Microsoft.Recognizers.Text.Number/Models/AbstractNumberModel.cs#L79) and [Java](https://github.com/microsoft/Recognizers-Text/blob/master/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/models/AbstractNumberModel.java#L57). Also, [JavaScript](https://github.com/microsoft/Recognizers-Text/blob/e56e3a7fc82aeeb3979ce2c3c61d20a25f4261d3/JavaScript/packages/recognizers-number/src/number/models.ts#L94) follows the behavior of C#.

## Specific Changes
- Decrease the `end` property of `ModelResult` by 1

## Testing
These changes were validated using the PR 2439.

_Parity of ModelResult_
![image](https://user-images.githubusercontent.com/11904023/106523605-20b28180-64c0-11eb-9b96-1c48a5472625.png)

_Test passing correctly using Java 8/11/15_
![image](https://user-images.githubusercontent.com/11904023/106523657-30ca6100-64c0-11eb-8a38-b8dc06ef637d.png)